### PR TITLE
Fixed bug with back button url not working when using uwsgi under sub-do...

### DIFF
--- a/flask_appbuilder/templates/appbuilder/general/lib.html
+++ b/flask_appbuilder/templates/appbuilder/general/lib.html
@@ -277,7 +277,7 @@
     {% endmacro %}
 
     {% macro lnk_back() %}
-    <a href="/back" class="btn btn-sm btn-primary" data-toggle="tooltip" rel="tooltip"
+    <a href="{{url_for('IndexView' + '.back')}}" class="btn btn-sm btn-primary" data-toggle="tooltip" rel="tooltip"
        title="{{_('Back')}}">
         <i class="fa fa-arrow-left"></i>
     </a>


### PR DESCRIPTION
The back button in FAB is hard-coded to be "/back" but if you are running FAB with UWSGI in a subdirectory (www.example.com/fab/) then you need the link to be to www.example.com/fab/back 

This patch uses url_for to generate the right link, so it detects if it is a subdirectory, etc, just like most other urls generated. 
