### PR TITLE
minor fix to display proper chart title.

### DIFF
--- a/flask_appbuilder/templates/appbuilder/general/widgets/direct_chart.html
+++ b/flask_appbuilder/templates/appbuilder/general/widgets/direct_chart.html
@@ -54,7 +54,7 @@
                 //instantiate our chart object
                 var chart = new google.visualization.{{chart_type}}(document.getElementById('{{ chart_title|replace(' ','_') }}'));
                 //define options for visualization
-                var options = {is3D: {{ chart_3d }}, title: '{{ chart_title|replace(' ','_') }}' };
+                var options = {is3D: {{ chart_3d }}, title: '{{ chart_title }}' };
 
 		attachRedrawForTab(chart, dataTable, options);
 		attachRedrawForAccord(chart, dataTable, options);


### PR DESCRIPTION
previous bugfix was a bit aggressive in substituting spaces with underscores.
this commit restores a properly rendered chart title on screen, respecting
original spaces.