### PR TITLE
added a number of new filters for the generic interface, plus a fix to the 'like' and 'equal' operators

### DIFF
--- a/flask_appbuilder/models/generic/__init__.py
+++ b/flask_appbuilder/models/generic/__init__.py
@@ -176,12 +176,85 @@ class GenericSession(object):
     #           FUNCTIONS for FILTERS
     #-----------------------------------------
 
+    def starts_with(self, col_name, value):
+        self._filters_cmd.append((self._starts_with, col_name, value))
+        return self
+
+    def _starts_with(self, item, col_name, value):
+        lw_col = getattr(item, col_name)
+        try:
+            lw_col = lw_col.lower()
+        except:
+            return None
+        lw_value = value.lower()
+        lw_value_list = lw_value.split(' ')
+
+        for lw_item in lw_value_list:
+            if not lw_col.startswith(lw_item):
+                return None
+
+        return col_name
+
+    def greater(self, col_name, value):
+        self._filters_cmd.append((self._greater, col_name, value))
+        return self
+
+    def _greater(self, item, col_name, value):
+        if getattr(item, col_name) == None:
+            return False
+        else:
+            try:
+                right_val = float(value)
+                return getattr(item, col_name) > right_val
+            except:
+                return False
+
+    def smaller(self, col_name, value):
+        self._filters_cmd.append((self._smaller, col_name, value))
+        return self
+
+    def _smaller(self, item, col_name, value):
+        if getattr(item, col_name) == None:
+            return False
+        else:
+            try:
+                right_val = float(value)
+                return getattr(item, col_name) < right_val
+            except:
+                return False
+
+    def ilike(self, col_name, value):
+        self._filters_cmd.append((self._ilike, col_name, value))
+        return self
+
+    def _ilike(self, item, col_name, value):
+        lw_col = getattr(item, col_name)
+        try:
+            lw_col = lw_col.lower()
+        except:
+            return None
+        lw_value = value.lower()
+        lw_value_list = lw_value.split(' ')
+
+        for lw_item in lw_value_list:
+            if not lw_item in lw_col:
+                return None
+
+        return col_name
+
     def like(self, col_name, value):
         self._filters_cmd.append((self._like, col_name, value))
         return self
 
     def _like(self, item, col_name, value):
-        return value in getattr(item, col_name)
+        lw_col = getattr(item, col_name)
+        lw_value_list = value.split(' ')
+
+        for lw_item in lw_value_list:
+            if not lw_item in lw_col:
+                return None
+
+        return col_name
 
     def not_like(self, col_name, value):
         self._filters_cmd.append((self._not_like, col_name, value))
@@ -196,7 +269,10 @@ class GenericSession(object):
 
     def _equal(self, item, col_name, value):
         source_value = getattr(item, col_name)
-        return source_value == type(source_value)(value)
+        try:
+            return source_value == type(source_value)(value)
+        except:
+            return 0.0
 
     def not_equal(self, col_name, value):
         self._filters_cmd.append((self._not_equal, col_name, value))

--- a/flask_appbuilder/models/generic/filters.py
+++ b/flask_appbuilder/models/generic/filters.py
@@ -2,7 +2,8 @@ from flask.ext.babelpkg import lazy_gettext
 from ..filters import BaseFilter, FilterRelation, BaseFilterConverter
 
 
-__all__ = ['GenericFilterConverter', 'FilterNotContains', 'FilterEqual', 'FilterContains', 'FilterNotEqual']
+__all__ = ['GenericFilterConverter', 'FilterNotContains', 'FilterEqual', 'FilterContains', 'FilterIContains',
+           'FilterNotEqual', 'FilterGreater', 'FilterSmaller', 'FilterStartsWith']
 
 
 class FilterContains(BaseFilter):
@@ -11,6 +12,14 @@ class FilterContains(BaseFilter):
     def apply(self, query, value):
         return query.like(self.column_name, value)
 
+class FilterIContains(BaseFilter):
+    '''
+    case insensitive like
+    '''
+    name = lazy_gettext('Contains')
+
+    def apply(self, query, value):
+        return query.ilike(self.column_name, value)
 
 class FilterNotContains(BaseFilter):
     name = lazy_gettext('Not Contains')
@@ -18,13 +27,11 @@ class FilterNotContains(BaseFilter):
     def apply(self, query, value):
         return query.not_like(self.column_name, value)
 
-
 class FilterEqual(BaseFilter):
     name = lazy_gettext('Equal to')
 
     def apply(self, query, value):
         return query.equal(self.column_name, value)
-
 
 class FilterNotEqual(BaseFilter):
     name = lazy_gettext('Not Equal to')
@@ -32,6 +39,23 @@ class FilterNotEqual(BaseFilter):
     def apply(self, query, value):
         return query.not_equal(self.column_name, value)
 
+class FilterGreater(BaseFilter):
+    name = lazy_gettext('Greater than')
+
+    def apply(self, query, value):
+        return query.greater(self.column_name, value)
+
+class FilterSmaller(BaseFilter):
+    name = lazy_gettext('Smaller than')
+
+    def apply(self, query, value):
+        return query.smaller(self.column_name, value)
+
+class FilterStartsWith(BaseFilter):
+    name = lazy_gettext('Start with')
+
+    def apply(self, query, value):
+        return query.starts_with(self.column_name, value)
 
 class GenericFilterConverter(BaseFilterConverter):
     """
@@ -42,13 +66,16 @@ class GenericFilterConverter(BaseFilterConverter):
     conversion_table = (('is_text', [FilterContains,
                                      FilterNotContains,
                                      FilterEqual,
-                                     FilterNotEqual]
+                                     FilterNotEqual,
+                                     FilterStartsWith]
                                      ),
                         ('is_string', [FilterContains,
                                        FilterNotContains,
                                        FilterEqual,
-                                       FilterNotEqual]),
+                                       FilterNotEqual,
+                                       FilterStartWith]),
                         ('is_integer', [FilterEqual,
-                                        FilterNotEqual]),
+                                        FilterNotEqual,
+                                        FilterGreater,
+                                        FilterSmaller]),
                         )
-

--- a/flask_appbuilder/models/generic/filters.py
+++ b/flask_appbuilder/models/generic/filters.py
@@ -64,16 +64,18 @@ class GenericFilterConverter(BaseFilterConverter):
 
     """
     conversion_table = (('is_text', [FilterContains,
+                                     FilterIContains,
                                      FilterNotContains,
                                      FilterEqual,
                                      FilterNotEqual,
                                      FilterStartsWith]
                                      ),
                         ('is_string', [FilterContains,
+                                       FilterIContains,
                                        FilterNotContains,
                                        FilterEqual,
                                        FilterNotEqual,
-                                       FilterStartWith]),
+                                       FilterStartsWith]),
                         ('is_integer', [FilterEqual,
                                         FilterNotEqual,
                                         FilterGreater,


### PR DESCRIPTION
hi,

due to my needs I've derived a series of generic* classes into my project and I've implemented additional filters for the generic interface. I don't know if this can help the project in anyway.

The expected behaviour is to have out-of-the-box filters for equal, greater, smaller, like, insensitive like, starts with and so on...

In order to make pull request a bit more streamlined, I've merged the contents of my custom classes into the FAB's base classes I've derived from.

The merged code needs *a lot* of debugging as I've merged it very fast in order to avoid to put a lot of crap into my custom classes making future merges impossible.

hope this helps.

bye,
MN