### PR TITLE
Fixing 'Mixed Content' message when behind an https reverse proxy

### DIFF
--- a/flask_appbuilder/views.py
+++ b/flask_appbuilder/views.py
@@ -599,7 +599,7 @@ class CompactCRUDMixin(BaseCRUDView):
             return redirect(request.referrer)
         else:
             self._session_form_widget = widgets.get('add')
-            self._session_form_action = request.url
+            self._session_form_action = request.full_path
             self._session_form_title = self.add_title
             return redirect(self.get_redirect())
 
@@ -615,7 +615,7 @@ class CompactCRUDMixin(BaseCRUDView):
             return redirect(self.get_redirect())
         else:
             self._session_form_widget = widgets.get('edit')
-            self._session_form_action = request.url
+            self._session_form_action = request.full_path
             self._session_form_title = self.edit_title
             return redirect(self.get_redirect())
 


### PR DESCRIPTION
We have somewhat of an unusual setup in our intranet where we use a reverse proxy that provides SSL and LDAP authentication and routes the request to application while adding headers we use to authenticate.

I was getting the message bellow in Chrome, and the inline CRUD widgets didn't work properly behind the proxy, so I tracked it down to these 2 lines of code, and found an easy alternative in the Flask request object in the form of `full_path`.

For reference here's the difference between `url` and `full_path`
```
>>> request.url
https://github.com/dpgaspar/Flask-AppBuilder
>>> request.full_path
/github.com/dpgaspar/Flask-AppBuilder
```
Chrome message:
```
Mixed Content: The page at 'https://panoramix.d.musta.ch/datasourcemodelview/edit/50' was loaded over a secure connection, but contains a form which targets an insecure endpoint 'http://panoramix.d.musta.ch/columninlineview/edit/461?_flt_0_datasource=24'. This endpoint should be made available over a secure connection.
```