### PR TITLE
Pinning Flask-Login to 0.2.11 since 0.3.0 breaks the common interface

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'click>=3.0',
         'Flask>=0.10',
         'Flask-BabelPkg>=0.9.4',
-        'Flask-Login>=0.2.0',
+        'Flask-Login==0.2.11',
         'Flask-OpenID>=1.1.0',
         'Flask-SQLAlchemy>=0.16',
         'Flask-WTF>=0.9.1',


### PR DESCRIPTION
Here's the commit that changes the `current_user.is_authenticated` and pretty much all `is_.*` calls...
https://github.com/maxcountryman/flask-login/commit/7b2583c45ac383029605adf4f9f4a7f23161f782#commitcomment-13199701

This was apparent to me when users aren't logged in in flask appbuilder and AnonymousUserMixin is the generic user used at that moment.