### PR TITLE
added datetime.date objects to generic models

### DIFF
--- a/flask_appbuilder/models/generic/__init__.py
+++ b/flask_appbuilder/models/generic/__init__.py
@@ -3,7 +3,7 @@ __author__ = 'dpgaspar'
 import operator
 import os
 from ..._compat import with_metaclass
-from datetime import date
+from datetime import date, datetime
 
 #--------------------------------------
 #        Exceptions
@@ -296,8 +296,7 @@ class GenericSession(object):
 
             #date has special constructor, tested only on sqlite
             elif isinstance(source_value, date):
-                parts = value.split('-')
-                value = date(int(parts[0]), int(parts[1]), int(parts[2]))
+                value = datetime.strptime(value, "%Y-%m-%d").date()
 
             #fallback to native python types
             else:            

--- a/flask_appbuilder/models/generic/__init__.py
+++ b/flask_appbuilder/models/generic/__init__.py
@@ -3,6 +3,7 @@ __author__ = 'dpgaspar'
 import operator
 import os
 from ..._compat import with_metaclass
+from datetime import date
 
 #--------------------------------------
 #        Exceptions
@@ -287,9 +288,24 @@ class GenericSession(object):
 
     def _equal(self, item, col_name, value):
         source_value = getattr(item, col_name)
+
         try:
-            return source_value == type(source_value)(value)
+            #whatever we have to copare it will never match
+            if source_value == None:
+                return 0.0
+
+            #date has special constructor, tested only on sqlite
+            elif isinstance(source_value, date):
+                parts = value.split('-')
+                value = date(int(parts[0]), int(parts[1]), int(parts[2]))
+
+            #fallback to native python types
+            else:            
+                value = type(source_value)(value)
+
+            return source_value == value
         except:
+            #when everything fails silently report False
             return 0.0
 
     def not_equal(self, col_name, value):

--- a/flask_appbuilder/models/generic/__init__.py
+++ b/flask_appbuilder/models/generic/__init__.py
@@ -219,28 +219,50 @@ class GenericSession(object):
         return self
 
     def _greater(self, item, col_name, value):
-        if getattr(item, col_name) == None:
-            return False
-        else:
-            try:
-                right_val = float(value)
-                return getattr(item, col_name) > right_val
-            except:
+        source_value = getattr(item, col_name)
+
+        try:
+            #whatever we have to copare it will never match
+            if source_value == None:
                 return False
+
+            #date has special constructor, tested only on sqlite
+            elif isinstance(source_value, date):
+                value = datetime.strptime(value, "%Y-%m-%d").date()
+
+            #fallback to native python types
+            else:            
+                value = type(source_value)(value)
+
+            return source_value > value
+        except:
+            #when everything fails silently report False
+            return False
 
     def smaller(self, col_name, value):
         self._filters_cmd.append((self._smaller, col_name, value))
         return self
 
     def _smaller(self, item, col_name, value):
-        if getattr(item, col_name) == None:
-            return False
-        else:
-            try:
-                right_val = float(value)
-                return getattr(item, col_name) < right_val
-            except:
+        source_value = getattr(item, col_name)
+
+        try:
+            #whatever we have to copare it will never match
+            if source_value == None:
                 return False
+
+            #date has special constructor, tested only on sqlite
+            elif isinstance(source_value, date):
+                value = datetime.strptime(value, "%Y-%m-%d").date()
+
+            #fallback to native python types
+            else:            
+                value = type(source_value)(value)
+
+            return source_value < value
+        except:
+            #when everything fails silently report False
+            return False
 
     def ilike(self, col_name, value):
         self._filters_cmd.append((self._ilike, col_name, value))
@@ -292,7 +314,7 @@ class GenericSession(object):
         try:
             #whatever we have to copare it will never match
             if source_value == None:
-                return 0.0
+                return False
 
             #date has special constructor, tested only on sqlite
             elif isinstance(source_value, date):
@@ -305,15 +327,14 @@ class GenericSession(object):
             return source_value == value
         except:
             #when everything fails silently report False
-            return 0.0
+            return False
 
     def not_equal(self, col_name, value):
         self._filters_cmd.append((self._not_equal, col_name, value))
         return self
 
     def _not_equal(self, item, col_name, value):
-        source_value = getattr(item, col_name)
-        return source_value != type(source_value)(value)
+        return not self._equal(item, col_name, value)
 
     def offset(self, offset=0):
         self._offset = offset

--- a/flask_appbuilder/models/generic/filters.py
+++ b/flask_appbuilder/models/generic/filters.py
@@ -80,4 +80,8 @@ class GenericFilterConverter(BaseFilterConverter):
                                         FilterNotEqual,
                                         FilterGreater,
                                         FilterSmaller]),
+                        ('is_date', [FilterEqual,
+                                        FilterNotEqual,
+                                        FilterGreater,
+                                        FilterSmaller]),
                         )


### PR DESCRIPTION
now the generic model/session is able to cope with datetime.date objects. While the _equal operator has only been tested filling generic models with dates coming from a sqlite db, it seems that SQLAlchemy makes a good effort in standardiziing the format of the date objects output, so generic models should be OK with other backends.

*ANYWAY* proper test with other db is suggested. feel free to drop this pull if you can't trust it: In the end I've not figured out how to test unit the thing!