### PR TITLE
Fixes #273 by not registering a view that will not exist for LDAP

### DIFF
--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -388,7 +388,8 @@ class BaseSecurityManager(AbstractSecurityManager):
                 self.registeruser_view = self.registeruseroidview()
             elif self.auth_type == AUTH_OAUTH:
                 self.registeruser_view = self.registeruseroauthview()
-            self.appbuilder.add_view_no_menu(self.registeruser_view)
+            if self.registeruser_view:
+                self.appbuilder.add_view_no_menu(self.registeruser_view)
 
         self.appbuilder.add_view_no_menu(self.resetpasswordview())
         self.appbuilder.add_view_no_menu(self.resetmypasswordview())


### PR DESCRIPTION
Without `AUTH_USER_REGISTRATION` set to `False`, ldap users logging in for the first time are bound successfully, but an account is never made for them (See #314).

Enabling `AUTH_USER_REGISTRATION`, however sees the `SecurityManager` attempting to load a view that will never come. This change loads the view only when there is one to be had.