### PR TITLE
Revert "Fixing the blank space at the top of forms"

### DIFF
--- a/flask_appbuilder/templates/appbuilder/general/widgets/form.html
+++ b/flask_appbuilder/templates/appbuilder/general/widgets/form.html
@@ -24,7 +24,7 @@
                 <table class="table table-bordered">
                 {% for item in fieldset_item[1].get('fields') %}
                         {% if item not in exclude_cols %}
-                          <tr><td>{{ lib.render_field(form[item], begin_sep_label, end_sep_label, begin_sep_field, end_sep_field) }}</td></tr>
+                            <tr>{{ lib.render_field(form[item], begin_sep_label, end_sep_label, begin_sep_field, end_sep_field) }}</tr>
                         {% endif %}
                 {% endfor %}
                 </table></div>
@@ -37,8 +37,8 @@
             {% for col in include_cols %}
                 {% set field = form[col] %}
                     {% if field.name not in exclude_cols %}
-                      <tr><td>{{ lib.render_field(field, begin_sep_label, end_sep_label, begin_sep_field, end_sep_field) }}</td></tr>
-                    {% endif %}
+                            <tr>{{ lib.render_field(field, begin_sep_label, end_sep_label, begin_sep_field, end_sep_field) }}</tr>
+                        {% endif %}
                 {% endfor %}
             </table>
     </div>


### PR DESCRIPTION
Reverts dpgaspar/Flask-AppBuilder#324

Nop, the problem is on lib.render_field it will render the div for each field. I'll fix it.

Thanks for reporting this one.