### PR TITLE
fix user not being created when logging in through an OAuth provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ app.db
 env
 venv
 *.sublime*
+*.egg-info/

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -681,7 +681,17 @@ class BaseSecurityManager(AbstractSecurityManager):
         else:
             log.error('User info does not have username or email {0}'.format(userinfo))
             return None
-        if user is None or (not user.is_active()):
+
+        if user is None:
+            user = self.add_user(
+                userinfo['username'],
+                userinfo['first_name'],
+                userinfo['last_name'],
+                userinfo['email'],
+                self.find_role(self.auth_user_registration_role)
+            )
+
+        if not user or (not user.is_active()):
             log.info(LOGMSG_WAR_SEC_LOGIN_FAILED.format(userinfo))
             return None
         else:
@@ -1016,4 +1026,3 @@ class BaseSecurityManager(AbstractSecurityManager):
     @staticmethod
     def before_request():
         g.user = current_user
-


### PR DESCRIPTION
When using an OAuth provider, no user is created after a successful provider authentication. The user is ejected right away and the login fails. This PR changes that so that a new user is created, just like with other providers.
