### PR TITLE
Realign deprecated references to `flask.ext`

### DIFF
--- a/flask_appbuilder/babel/manager.py
+++ b/flask_appbuilder/babel/manager.py
@@ -1,5 +1,5 @@
 from flask import session
-from flask.ext.babelpkg import Babel
+from flask_babelpkg import Babel
 from ..basemanager import BaseManager
 from .. import translations
 from .views import LocaleView

--- a/flask_appbuilder/babel/views.py
+++ b/flask_appbuilder/babel/views.py
@@ -1,5 +1,5 @@
 from flask import redirect, session
-from flask.ext.babelpkg import refresh
+from flask_babelpkg import refresh
 from ..baseviews import BaseView, expose
 
 

--- a/flask_appbuilder/base.py
+++ b/flask_appbuilder/base.py
@@ -45,7 +45,7 @@ class AppBuilder(object):
         initialize your application like this for SQLAlchemy::
 
             from flask import Flask
-            from flask.ext.appbuilder import SQLA, AppBuilder
+            from flask_appbuilder import SQLA, AppBuilder
 
             app = Flask(__name__)
             app.config.from_object('config')

--- a/flask_appbuilder/charts/views.py
+++ b/flask_appbuilder/charts/views.py
@@ -1,5 +1,5 @@
 import logging
-from flask.ext.babelpkg import lazy_gettext
+from flask_babelpkg import lazy_gettext
 from .widgets import ChartWidget, DirectChartWidget
 from .jsontools import dict_to_json
 from ..widgets import SearchWidget

--- a/flask_appbuilder/charts/widgets.py
+++ b/flask_appbuilder/charts/widgets.py
@@ -1,4 +1,4 @@
-from flask.ext.appbuilder.widgets import RenderTemplateWidget
+from flask_appbuilder.widgets import RenderTemplateWidget
 
 
 class ChartWidget(RenderTemplateWidget):

--- a/flask_appbuilder/fieldwidgets.py
+++ b/flask_appbuilder/fieldwidgets.py
@@ -1,5 +1,4 @@
 from wtforms.widgets import HTMLString, html_params
-#from flask.ext.wtf import fields, widgets, TextField
 from wtforms import fields, widgets, TextField
 
 class DatePickerWidget(object):

--- a/flask_appbuilder/messages.py
+++ b/flask_appbuilder/messages.py
@@ -1,4 +1,4 @@
-from flask.ext.babelpkg import lazy_gettext as _
+from flask_babelpkg import lazy_gettext as _
 
 """
 This Module is not used.

--- a/flask_appbuilder/security/registerviews.py
+++ b/flask_appbuilder/security/registerviews.py
@@ -35,7 +35,7 @@ class BaseRegisterUser(PublicFormView):
         your authentication method.
         then override SecurityManager property that defines the class to use::
 
-            from flask.ext.appbuilder.security.registerviews import RegisterUserDBView
+            from flask_appbuilder.security.registerviews import RegisterUserDBView
 
             class MyRegisterUserDBView(BaseRegisterUser):
                 email_template = 'register_mail.html'
@@ -138,7 +138,7 @@ class BaseRegisterUser(PublicFormView):
 
     def add_form_unique_validations(self, form):
         datamodel_user = self.appbuilder.sm.get_user_datamodel
-        datamodel_register_user = self.appbuilder.sm.get_register_user_datamodel        
+        datamodel_register_user = self.appbuilder.sm.get_register_user_datamodel
         if len(form.username.validators) == 1:
             form.username.validators.append(Unique(datamodel_user, 'username'))
             form.username.validators.append(Unique(datamodel_register_user, 'username'))
@@ -243,7 +243,7 @@ class RegisterUserOAuthView(BaseRegisterUser):
         View for Registering a new user, auth OID mode
     """
     form = RegisterUserOIDForm
-    
+
     def form_get(self, form):
         self.add_form_unique_validations(form)
         # fills the register form with the collected data from OAuth
@@ -251,12 +251,12 @@ class RegisterUserOAuthView(BaseRegisterUser):
         form.first_name.data = request.args.get('first_name', '')
         form.last_name.data = request.args.get('last_name', '')
         form.email.data = request.args.get('email', '')
-    
+
     def form_post(self, form):
         log.debug('Adding Registration')
         self.add_registration(username=form.username.data,
                                               first_name=form.first_name.data,
                                               last_name=form.last_name.data,
                                               email=form.email.data)
-    
-        
+
+

--- a/flask_appbuilder/tests/test_base.py
+++ b/flask_appbuilder/tests/test_base.py
@@ -7,7 +7,7 @@ import datetime
 from sqlalchemy import Column, Integer, String, ForeignKey, Date, Float
 from sqlalchemy.orm import relationship
 from flask import request, session
-from flask.ext.appbuilder import Model, SQLA
+from flask_appbuilder import Model, SQLA
 from flask_appbuilder.models.sqla.filters import FilterStartsWith, FilterEqual
 from flask_appbuilder.models.mixins import FileColumn, ImageColumn
 from flask_appbuilder.views import MasterDetailView, CompactCRUDMixin
@@ -16,7 +16,7 @@ from flask_appbuilder.charts.views import (ChartView, TimeChartView,
                                            DirectByChartView)
 from flask_appbuilder.models.group import aggregate_avg, aggregate_count, aggregate_sum
 
-from flask.ext.appbuilder.models.generic import PSSession
+from flask_appbuilder.models.generic import PSSession
 from flask_appbuilder.models.generic.interface import GenericInterface
 from flask_appbuilder.models.generic import PSModel
 
@@ -68,15 +68,15 @@ class Model2(Model):
         return str(self.field_string)
 
     def field_method(self):
-       return "field_method_value"                                               
+       return "field_method_value"
 
 
 class FlaskTestCase(unittest.TestCase):
     def setUp(self):
         from flask import Flask
-        from flask.ext.appbuilder import AppBuilder
-        from flask.ext.appbuilder.models.sqla.interface import SQLAInterface
-        from flask.ext.appbuilder.views import ModelView
+        from flask_appbuilder import AppBuilder
+        from flask_appbuilder.models.sqla.interface import SQLAInterface
+        from flask_appbuilder.views import ModelView
 
         self.app = Flask(__name__)
         self.basedir = os.path.abspath(os.path.dirname(__file__))
@@ -102,7 +102,7 @@ class FlaskTestCase(unittest.TestCase):
             list_columns = ['field_integer', 'field_float', 'field_string', 'field_method', 'group.field_string']
             edit_form_query_rel_fields = {'group':[['field_string', FilterEqual, 'G2']]}
             add_form_query_rel_fields = {'group':[['field_string', FilterEqual, 'G1']]}
-            
+
         class Model22View(ModelView):
             datamodel = SQLAInterface(Model2)
             list_columns = ['field_integer', 'field_float', 'field_string', 'field_method', 'group.field_string']
@@ -155,7 +155,7 @@ class FlaskTestCase(unittest.TestCase):
                             ]
                 }
             ]
-            
+
         class Model2DirectByChartView(DirectByChartView):
             datamodel = SQLAInterface(Model2)
             chart_title = 'Test Model1 Chart'
@@ -255,7 +255,7 @@ class FlaskTestCase(unittest.TestCase):
                     self.db.session.add(model)
                     self.db.session.commit()
             except Exception as e:
-                print("ERROR {0}".format(str(e)))                                                      
+                print("ERROR {0}".format(str(e)))
                 self.db.session.rollback()
 
 
@@ -264,7 +264,7 @@ class FlaskTestCase(unittest.TestCase):
             Test views creation and registration
         """
         eq_(len(self.appbuilder.baseviews), 27)  # current minimal views are 12
-        
+
     def test_back(self):
         """
             Test Back functionality
@@ -362,10 +362,10 @@ class FlaskTestCase(unittest.TestCase):
         data = rv.data.decode('utf-8')
         ok_("Reset Password Form" in data)
         rv = client.post('/resetmypassword/form',
-                         data=dict(password=DEFAULT_ADMIN_PASSWORD, conf_password=DEFAULT_ADMIN_PASSWORD), 
+                         data=dict(password=DEFAULT_ADMIN_PASSWORD, conf_password=DEFAULT_ADMIN_PASSWORD),
                          follow_redirects=True)
         eq_(rv.status_code, 200)
-        
+
 
     def test_generic_interface(self):
         """
@@ -439,7 +439,7 @@ class FlaskTestCase(unittest.TestCase):
         ok_('Field Float' in data)
         ok_('Field Date' in data)
         ok_('Excluded String' not in data)
-        
+
 
     def test_query_rel_fields(self):
         """
@@ -566,7 +566,7 @@ class FlaskTestCase(unittest.TestCase):
         """
         client = self.app.test_client()
         self.login(client, DEFAULT_ADMIN_USER, DEFAULT_ADMIN_PASSWORD)
-        self.insert_data2()                                               
+        self.insert_data2()
         rv = client.get('/model2view/list/')
         eq_(rv.status_code, 200)
         data = rv.data.decode('utf-8')

--- a/flask_appbuilder/upload.py
+++ b/flask_appbuilder/upload.py
@@ -3,7 +3,7 @@ from werkzeug.datastructures import FileStorage
 
 from wtforms import ValidationError, fields
 from wtforms.widgets import HTMLString, html_params
-from flask.ext.babelpkg import gettext
+from flask_babelpkg import gettext
 from .filemanager import ImageManager, FileManager
 
 try:


### PR DESCRIPTION
From: http://flask.pocoo.org/docs/0.11/extensiondev/#extension-import-transition
```
As of Flask 0.11, most Flask extensions have transitioned to the new
naming schema. The flask.ext.foo compatibility alias is still in Flask
0.11 but is now deprecated – you should use flask_foo.
```