### PR TITLE
Flask extension proper import

### DIFF
--- a/bin/hash_db_password.py
+++ b/bin/hash_db_password.py
@@ -11,7 +11,7 @@ try:
 
 except:
     from flask import Flask
-    from flask.ext.sqlalchemy import SQLAlchemy
+    from flask_sqlalchemy import SQLAlchemy
 
     if len(sys.argv) < 2:
         print "Without typical app structure use parameter to config"

--- a/bin/migrate_db_1.3.py
+++ b/bin/migrate_db_1.3.py
@@ -7,7 +7,7 @@ from sqlalchemy import create_engine
 from flask_appbuilder.security.sqla.models import User
 
 sys.path.append(os.getcwd())
-from flask.ext.appbuilder import SQLA
+from flask_appbuilder import SQLA
 
 #from app import app
 #from app import appbuilder, db

--- a/examples/quickhowto/app/views.py
+++ b/examples/quickhowto/app/views.py
@@ -4,7 +4,7 @@ from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.charts.views import GroupByChartView
 from flask_appbuilder.models.group import aggregate_count
 from flask_appbuilder.widgets import FormHorizontalWidget, FormInlineWidget, FormVerticalWidget
-from flask.ext.babel import lazy_gettext as _
+from flask_babel import lazy_gettext as _
 
 
 from app import db, appbuilder

--- a/examples/quickhowto3/app/__init__.py
+++ b/examples/quickhowto3/app/__init__.py
@@ -1,7 +1,7 @@
 import logging
 from flask import Flask
 from flask_appbuilder import AppBuilder
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy
 from flask_appbuilder.models import SQLA
 from sqlalchemy import event
 

--- a/flask_appbuilder/models/sqla/__init__.py
+++ b/flask_appbuilder/models/sqla/__init__.py
@@ -22,13 +22,13 @@ _camelcase_re = re.compile(r'([A-Z]+)(?=[a-z0-9])')
 
 class SQLA(SQLAlchemy):
     """
-        This is a child class of flask.ext.SQLAlchemy
+        This is a child class of flask_SQLAlchemy
         It's purpose is to override the declarative base of the original
         package. So that it is bound to F.A.B. Model class allowing the dev
         to be in the same namespace of the security tables (and others)
         and can use AuditMixin class alike.
 
-        Use it and configure it just like flask.ext.SQLAlchemy
+        Use it and configure it just like flask_SQLAlchemy
     """
     def make_declarative_base(self):
         """Creates the declarative base."""
@@ -64,7 +64,7 @@ class Model(object):
         ::
 
             from sqlalchemy import Table, Column, Integer, String, Boolean, ForeignKey, Date
-            from flask.ext.appbuilder import Model
+            from flask_appbuilder import Model
 
             class MyModel(Model):
                 id = Column(Integer, primary_key=True)

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'Flask-Babel>=0.10.0',
         'Flask-Login==0.2.11',
         'Flask-OpenID>=1.1.0',
-        'Flask-SQLAlchemy>=2.0',
+        'Flask-SQLAlchemy==2.0',
         'Flask-WTF>=0.9.1',
     ],
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'Flask-Babel>=0.10.0',
         'Flask-Login==0.2.11',
         'Flask-OpenID>=1.1.0',
-        'Flask-SQLAlchemy==2.0',
+        'Flask-SQLAlchemy>=2.0',
         'Flask-WTF>=0.9.1',
     ],
     tests_require=[


### PR DESCRIPTION
This replaced all occurencies of flask.ext.something with flask_something to avoid the deprecation warning in Flask 0.11

http://flask.pocoo.org/docs/0.11/extensiondev/#extension-import-transition