### PR TITLE
Fix OAuth authentication when the OAuth provider returns an empty username

### DIFF
--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -674,7 +674,7 @@ class BaseSecurityManager(AbstractSecurityManager):
             :userinfo: dict with user information the keys have the same name
             as User model columns.
         """
-        if 'username' in userinfo:
+        if 'username' in userinfo and userinfo['username']:
             user = self.find_user(username=userinfo['username'])
         elif 'email' in userinfo:
             user = self.find_user(email=userinfo['email'])


### PR DESCRIPTION
Useful for Google Auth that returns an empty username when the user hasn't signed up on Google Plus
