### PR TITLE
added default autosizing to app image (if any)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "2.7"
   - "2.6"
 install:
-  - "pip install -r requirements.txt --use-mirrors"
+  - "pip install -r requirements.txt"
   - "pip install coveralls"
   - "pip install pymongo==2.8"
   - "pip install flask-mongoengine==0.7.1"

--- a/flask_appbuilder/templates/appbuilder/navbar.html
+++ b/flask_appbuilder/templates/appbuilder/navbar.html
@@ -14,7 +14,7 @@
             </button>
             {% if appbuilder.app_icon %}
                 <a class="navbar-brand" href="{{appbuilder.get_url_for_index}}">
-                <img src="{{appbuilder.app_icon}}" >
+                <img src="{{appbuilder.app_icon}}" height="100%" width="auto">
                 </a>
             {% else %}
                 <span class="navbar-brand">


### PR DESCRIPTION
this will prevent images to flood out of navbar estate.

I've recently added an icon for the app and the image has been rendered in its full size, going out of the navbar. this should fix the thing.
While I do not expect that _height="100%" width="auto"_ will be the one-fit-for-all, at least the default is now more sane IMHO.
User can override the template and customize it anyway.
