### PR TITLE
APP_NAME with accents

### DIFF
--- a/flask_appbuilder/models/mongoengine/filters.py
+++ b/flask_appbuilder/models/mongoengine/filters.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import logging
 from flask_babel import lazy_gettext
 from ..filters import BaseFilter, FilterRelation, BaseFilterConverter

--- a/flask_appbuilder/models/mongoengine/interface.py
+++ b/flask_appbuilder/models/mongoengine/interface.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import logging, sys
 from flask import flash
 from . import filters

--- a/flask_appbuilder/models/sqla/filters.py
+++ b/flask_appbuilder/models/sqla/filters.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import logging
 from flask_babel import lazy_gettext
 from ..filters import BaseFilter, FilterRelation, BaseFilterConverter


### PR DESCRIPTION
Added # -_\- coding: utf-8 -_\- to fix app names with accents. 

e.g. APP_NAME = u’éèàôïù’
