### PR TITLE
flask_wtf.Form has been renamed to FlaskForm

### DIFF
--- a/flask_appbuilder/forms.py
+++ b/flask_appbuilder/forms.py
@@ -1,5 +1,5 @@
 import logging
-from flask_wtf import Form
+from flask_wtf import FlaskForm
 from wtforms import (BooleanField, StringField,
                      TextAreaField, IntegerField, FloatField,
                       DateField, DateTimeField, DecimalField)
@@ -235,7 +235,7 @@ class GeneralModelConverter(object):
         return type('DynamicForm', (DynamicForm,), form_props)
 
 
-class DynamicForm(Form):
+class DynamicForm(FlaskForm):
     """
         Refresh method will force select field to refresh
     """

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'Flask-Login==0.2.11',
         'Flask-OpenID>=1.1.0',
         'Flask-SQLAlchemy>=2.0',
-        'Flask-WTF>=0.9.1',
+        'Flask-WTF>=0.12',
     ],
     tests_require=[
         'nose>=1.0',


### PR DESCRIPTION
I've been seeing the message: 

```
FlaskWTFDeprecationWarning:
"flask_wtf.Form" has been renamed to "FlaskForm" and will be removed in
1.0.
```
in my builds and this should tackle it. Also bumping the setup.py to
`>0.12` as I'm running that version without any issues.

Message can be observed in this build:
https://travis-ci.org/airbnb/caravel/jobs/172202030