### PR TITLE
Adding column_formatters to ModelView

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "2.7"
   - "2.6"
 install:
+  - "pip install pip --upgrade"
   - "pip install -r requirements.txt"
   - "pip install coveralls"
   - "pip install pymongo==2.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
   - "2.7"
   - "2.6"
 install:
-  - "pip install pip --upgrade"
   - "pip install -r requirements.txt"
   - "pip install coveralls"
   - "pip install pymongo==2.8"

--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -553,7 +553,11 @@ class BaseCRUDView(BaseModelView):
     """
     validators_columns = None
     """ Dictionary to add your own validators for forms """
+    formatters_columns = None
+    """ Dictionary of formatter used to format the display of columns
 
+        formatters_columns = {'some_date_col': lambda x: x.isoformat() }
+    """
     add_form_extra_fields = None
     """
         A dictionary containing column names and a WTForm
@@ -678,6 +682,7 @@ class BaseCRUDView(BaseModelView):
         self._related_views = self._related_views or []
         self.description_columns = self.description_columns or {}
         self.validators_columns = self.validators_columns or {}
+        self.formatters_columns = self.formatters_columns or {}
         self.add_form_extra_fields = self.add_form_extra_fields or {}
         self.edit_form_extra_fields = self.edit_form_extra_fields or {}
         self.show_exclude_columns = self.show_exclude_columns or []
@@ -789,6 +794,7 @@ class BaseCRUDView(BaseModelView):
                                            include_columns=self.list_columns,
                                            value_columns=self.datamodel.get_values(lst, self.list_columns),
                                            order_columns=self.order_columns,
+                                           formatters_columns=self.formatters_columns,
                                            page=page,
                                            page_size=page_size,
                                            count=count,
@@ -806,6 +812,7 @@ class BaseCRUDView(BaseModelView):
                                            label_columns=self.label_columns,
                                            include_columns=self.show_columns,
                                            value_columns=self.datamodel.get_values_item(item, self.show_columns),
+                                           formatters_columns=self.formatters_columns,
                                            actions=actions,
                                            fieldsets=show_fieldsets,
                                            modelview_name=self.__class__.__name__
@@ -875,7 +882,7 @@ class BaseCRUDView(BaseModelView):
 
     def _show(self, pk):
         """
-            show function logic, override to implement diferent logic
+            show function logic, override to implement different logic
             returns show and related list widget
         """
         pages = get_page_args()
@@ -892,7 +899,7 @@ class BaseCRUDView(BaseModelView):
 
     def _add(self):
         """
-            Add function logic, override to implement diferent logic
+            Add function logic, override to implement different logic
             returns add widget or None
         """
         is_valid_form = True

--- a/flask_appbuilder/templates/appbuilder/general/model/list.html
+++ b/flask_appbuilder/templates/appbuilder/general/model/list.html
@@ -18,5 +18,3 @@
 {{ lib.panel_end() }}
 
 {% endblock %}
-
-

--- a/flask_appbuilder/templates/appbuilder/general/widgets/list.html
+++ b/flask_appbuilder/templates/appbuilder/general/widgets/list.html
@@ -56,7 +56,12 @@
                     </center></td>
                 {% endif %}
                 {% for value in include_columns %}
-                    <td>{{ item[value]|safe }}</td>
+                    {% set formatter = formatters_columns.get(value) %}
+                    {% if formatter %}
+                        <td>{{ formatter(item[value]) }}</td>
+                    {% else %}
+                        <td>{{ item[value]|safe }}</td>
+                    {% endif %}
                 {% endfor %}
             </tr>
         {% endfor %}

--- a/flask_appbuilder/templates/appbuilder/general/widgets/show.html
+++ b/flask_appbuilder/templates/appbuilder/general/widgets/show.html
@@ -29,8 +29,12 @@
 
     {% for item in include_columns %}
         <tr>
-        <th class="col-lg-2 col-md-2 col-sm-2">{{label_columns.get(item)}}</th>
-        <td><span style="white-space: pre-line">{{value_columns[loop.index-1]}}</span></td>
+            <th class="col-lg-2 col-md-2 col-sm-2">{{label_columns.get(item)}}</th>
+            <td>
+                {% set formatter = formatters_columns.get(item) %}
+                {% set v = value_columns[loop.index-1]%}
+                <span style="white-space: pre-line">{{formatter(v) if formatter else v}}</span>
+            </td>
         </tr>
     {% endfor %}
     </table></div>

--- a/flask_appbuilder/tests/test_base.py
+++ b/flask_appbuilder/tests/test_base.py
@@ -271,7 +271,7 @@ class FlaskTestCase(unittest.TestCase):
         """
             Test views creation and registration
         """
-        eq_(len(self.appbuilder.baseviews), 27)  # current minimal views are 12
+        eq_(len(self.appbuilder.baseviews), 28)  # current minimal views are 12
 
     def test_back(self):
         """

--- a/flask_appbuilder/tests/test_base.py
+++ b/flask_appbuilder/tests/test_base.py
@@ -116,7 +116,6 @@ class FlaskTestCase(unittest.TestCase):
             related_views = [Model2View]
             list_columns = ['field_string','field_file']
 
-
         class Model1CompactView(CompactCRUDMixin, ModelView):
             datamodel = SQLAInterface(Model1)
 
@@ -185,6 +184,14 @@ class FlaskTestCase(unittest.TestCase):
             datamodel = SQLAInterface(Model1)
             related_views = [Model2DirectByChartView]
 
+        class Model1FormattedView(ModelView):
+            datamodel = SQLAInterface(Model1)
+            list_columns = ['field_string']
+            show_columns = ['field_string']
+            formatters_columns = {
+                'field_string': lambda x: 'FORMATTED_STRING',
+            }
+
 
         self.appbuilder.add_view(Model1View, "Model1", category='Model1')
         self.appbuilder.add_view(Model1CompactView, "Model1Compact", category='Model1')
@@ -192,6 +199,7 @@ class FlaskTestCase(unittest.TestCase):
         self.appbuilder.add_view(Model1MasterChartView, "Model1MasterChart", category='Model1')
         self.appbuilder.add_view(Model1Filtered1View, "Model1Filtered1", category='Model1')
         self.appbuilder.add_view(Model1Filtered2View, "Model1Filtered2", category='Model1')
+        self.appbuilder.add_view(Model1FormattedView, "Model1FormattedView", category='Model1FormattedView')
 
         self.appbuilder.add_view(Model2View, "Model2")
         self.appbuilder.add_view(Model22View, "Model22")
@@ -407,6 +415,21 @@ class FlaskTestCase(unittest.TestCase):
         eq_(rv.status_code, 200)
         model = self.db.session.query(Model1).first()
         eq_(model, None)
+
+    def test_excluded_cols(self):
+        """
+            Test formatters_columns
+        """
+        client = self.app.test_client()
+        rv = self.login(client, DEFAULT_ADMIN_USER, DEFAULT_ADMIN_PASSWORD)
+        rv = client.get('/model1formattedview/list')
+        eq_(rv.status_code, 200)
+        data = rv.data.decode('utf-8')
+        ok_('FORMATTED_STRING' in data)
+        rv = client.get('/model1formattedview/show/1')
+        eq_(rv.status_code, 200)
+        data = rv.data.decode('utf-8')
+        ok_('FORMATTED_STRING' in data)
 
     def test_excluded_cols(self):
         """

--- a/flask_appbuilder/tests/test_base.py
+++ b/flask_appbuilder/tests/test_base.py
@@ -416,13 +416,14 @@ class FlaskTestCase(unittest.TestCase):
         model = self.db.session.query(Model1).first()
         eq_(model, None)
 
-    def test_excluded_cols(self):
+    def test_formatted_cols(self):
         """
-            Test formatters_columns
+            Test ModelView's formatters_columns
         """
         client = self.app.test_client()
         rv = self.login(client, DEFAULT_ADMIN_USER, DEFAULT_ADMIN_PASSWORD)
-        rv = client.get('/model1formattedview/list')
+        self.insert_data()
+        rv = client.get('/model1formattedview/list/')
         eq_(rv.status_code, 200)
         data = rv.data.decode('utf-8')
         ok_('FORMATTED_STRING' in data)


### PR DESCRIPTION
Dictionary of formatter callables used to format columns in list and show widgets. This allows user to apply whatever formatting they want to their data. Similar to:
http://flask-admin.readthedocs.io/en/latest/api/mod_model/#flask_admin.model.BaseModelView.column_formatters

For context, I'm currently attempting to port the [Apache Airflow](https://github.com/apache/incubator-airflow) UI from `Flask-Admin` to FAB and may need to match some of the functionality there. The incentive is getting auth, and REST for all of our model from FAB while having a easy-ish port from Flask/ Flask-Admin