### PR TITLE
Example masterdetail: bugfix

### DIFF
--- a/examples/masterdetail/app/views.py
+++ b/examples/masterdetail/app/views.py
@@ -5,7 +5,7 @@ from flask_appbuilder.charts.views import ChartView, TimeChartView
 from flask_babel import lazy_gettext as _
 
 from app import db, appbuilder
-from models import ContactGroup, Gender, Contact
+from app.models import ContactGroup, Gender, Contact
 
 
 def fill_gender():

--- a/examples/masterdetail/testdata.py
+++ b/examples/masterdetail/testdata.py
@@ -24,7 +24,7 @@ try:
 except:
     db.session.rollback()
 
-f = open('NAMES.DIC', "rb")
+f = open('NAMES.DIC', "r")
 names_list = [x.strip() for x in f.readlines()]
 
 f.close()


### PR DESCRIPTION
Hi!
I was not able to run masterdetail example on python 3.4 due to error:
`Was unable to import app Error: No module named 'models' `
so I changed import statement in views.py.

I also was unable to seed database with testdata.py due to error:
`TypeError: sequence item 0: expected str instance, bytes found`

I made quick small fixes, and hope they will be helpful.