### PR TITLE
fix: dont overwrite csrf_token on form fill

### DIFF
--- a/flask_appbuilder/security/views.py
+++ b/flask_appbuilder/security/views.py
@@ -98,6 +98,7 @@ class UserInfoEditView(SimpleFormView):
         item = self.appbuilder.sm.get_user_by_id(g.user.id)
         # fills the form generic solution
         for key, value in  form.data.items():
+            if key == 'csrf_token': continue
             form_field = getattr(form, key)
             form_field.data = getattr(item, key)
 


### PR DESCRIPTION
When CSRF_ENABLED (WTF_CSRF_ENABLED), there is error with User object don't have csrf_token.

This fixes https://github.com/airbnb/superset/issues/2232 for me, 
because csrf_token is overwritten to None.

Also, there is some deprecation warnings that already fixed on master, can we get minor version bump soon?
