### PR TITLE
Fix two instances of urls being generated wrongly when running under a prefix.

### DIFF
--- a/flask_appbuilder/security/views.py
+++ b/flask_appbuilder/security/views.py
@@ -372,7 +372,7 @@ class AuthDBView(AuthView):
     @expose('/login/', methods=['GET', 'POST'])
     def login(self):
         if g.user is not None and g.user.is_authenticated():
-            return redirect('/')
+            return redirect(self.appbuilder.get_url_for_index)
         form = LoginForm_db()
         if form.validate_on_submit():
             user = self.appbuilder.sm.auth_user_db(form.username.data, form.password.data)

--- a/flask_appbuilder/tests/test_base.py
+++ b/flask_appbuilder/tests/test_base.py
@@ -656,6 +656,31 @@ class FlaskTestCase(unittest.TestCase):
         rv = client.get('/model1compactview/list/')
         eq_(rv.status_code, 200)
 
+    def test_edit_add_form_action_prefix_for_compactCRUDMixin(self):
+        """
+            Test form_action in add, form_action in edit (CompactCRUDMixin)
+        """
+        client = self.app.test_client()
+        self.login(client, DEFAULT_ADMIN_USER, DEFAULT_ADMIN_PASSWORD)
+
+        # Make sure we have something to edit.
+        self.insert_data()
+
+        prefix = '/some-prefix'
+        base_url = 'http://localhost' + prefix
+        session_form_action_key = 'Model1CompactView__session_form_action'
+
+        with client as c:
+            expected_form_action = prefix + '/model1compactview/add/?'
+
+            c.get('/model1compactview/add/', base_url=base_url)
+            ok_(session[session_form_action_key] == expected_form_action)
+
+            expected_form_action = prefix + '/model1compactview/edit/1?'
+            c.get('/model1compactview/edit/1', base_url=base_url)
+
+            ok_(session[session_form_action_key] == expected_form_action)
+
     def test_charts_view(self):
         """
             Test Various Chart views

--- a/flask_appbuilder/views.py
+++ b/flask_appbuilder/views.py
@@ -739,7 +739,10 @@ class CompactCRUDMixin(BaseCRUDView):
             return redirect(request.referrer)
         else:
             self.set_key('session_form_widget', 'add')
-            self.set_key('session_form_action', request.full_path)
+            self.set_key(
+                'session_form_action',
+                request.script_root + request.full_path
+            )
             self.set_key('session_form_title', self.add_title)
             return redirect(self.get_redirect())
 
@@ -754,7 +757,10 @@ class CompactCRUDMixin(BaseCRUDView):
             return redirect(self.get_redirect())
         else:
             self.set_key('session_form_widget', 'edit')
-            self.set_key('session_form_action', request.full_path)
+            self.set_key(
+                'session_form_action',
+                request.script_root + request.full_path
+            )
             self.set_key('session_form_title', self.add_title)
             self.set_key('session_form_edit_pk', pk)
             return redirect(self.get_redirect())


### PR DESCRIPTION
This PR fixes two parts of flask-appbuilder that doesn't work when running a site under a prefix.

The most important one is in the CompactCRUDMixin used for inline add/edit views for a ModelView. The session parameter that is used to set the form action only used `request.full_path`. This will not work when the wsgi `SCRIPT_NAME` is different than `''`. Adding in the `request.script_root` solves this problem.

The second one is that the DBAuthView redirects to `/` rather than `self.appbuilder.get_url_for_index`. This will also break on a flask app build that uses a different url for it's index page than `/`