### PR TITLE
Security: Prevent masquerade attacks through oauth providers

### DIFF
--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -378,7 +378,7 @@ class BaseSecurityManager(AbstractSecurityManager):
         if provider == 'google':
             me = self.appbuilder.sm.oauth_remotes[provider].get('people/me')
             log.debug("User info from Google: {0}".format(me.data))
-            return {'username': "google_" + me.data['id'].get('value',''),
+            return {'username': "google_" + me.data['id'],
                 'email': me.data['emails'][0].get('value',''),
                 'first_name': me.data['name'].get('givenName',''),
                 'last_name': me.data['name'].get('familyName','')}

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -360,17 +360,17 @@ class BaseSecurityManager(AbstractSecurityManager):
         if provider == 'github' or provider == 'githublocal':
             me = self.appbuilder.sm.oauth_remotes[provider].get('user')
             log.debug("User info from Github: {0}".format(me.data))
-            return {'username': me.data.get('login')}
+            return {'username': "github_" + me.data.get('login')}
         # for twitter
         if provider == 'twitter':
             me = self.appbuilder.sm.oauth_remotes[provider].get('account/settings.json')
             log.debug("User info from Twitter: {0}".format(me.data))
-            return {'username': me.data.get('screen_name','')}
+            return {'username': "twitter_" + me.data.get('screen_name','')}
         # for linkedin
         if provider == 'linkedin':
             me = self.appbuilder.sm.oauth_remotes[provider].get('people/~:(id,email-address,first-name,last-name)?format=json')
             log.debug("User info from Linkedin: {0}".format(me.data))
-            return {'username': me.data.get('id',''),
+            return {'username': "linkedin_" + me.data.get('id',''),
                 'email': me.data.get('email-address',''),
                 'first_name': me.data.get('firstName',''),
                 'last_name': me.data.get('lastName','')}
@@ -378,7 +378,7 @@ class BaseSecurityManager(AbstractSecurityManager):
         if provider == 'google':
             me = self.appbuilder.sm.oauth_remotes[provider].get('people/me')
             log.debug("User info from Google: {0}".format(me.data))
-            return {'username': me.data['id'].get('value',''),
+            return {'username': "google_" + me.data['id'].get('value',''),
                 'email': me.data['emails'][0].get('value',''),
                 'first_name': me.data['name'].get('givenName',''),
                 'last_name': me.data['name'].get('familyName','')}

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -378,7 +378,7 @@ class BaseSecurityManager(AbstractSecurityManager):
         if provider == 'google':
             me = self.appbuilder.sm.oauth_remotes[provider].get('people/me')
             log.debug("User info from Google: {0}".format(me.data))
-            return {'username': me.data.get('displayName',''),
+            return {'username': me.data['id'].get('value',''),
                 'email': me.data['emails'][0].get('value',''),
                 'first_name': me.data['name'].get('givenName',''),
                 'last_name': me.data['name'].get('familyName','')}


### PR DESCRIPTION
This PR changes the ID that is used to link a google login to an account to an immutable user ID that is provided by google. The previous implementation used the display name, which could easily be changed at any point and used to log in to a different account by an attacker.

This also prefixes all oauth created users with the name of the provider that created it. This prevents someone from creating a colliding account through a different provider to gain access to an application.