### PR TITLE
[cosmetics] making row button (show/edit/delete) not primary

### DIFF
--- a/flask_appbuilder/static/appbuilder/css/ab.css
+++ b/flask_appbuilder/static/appbuilder/css/ab.css
@@ -46,4 +46,3 @@ th.action_checkboxes {
 .fa-black {
     color: black;
 }
-

--- a/flask_appbuilder/templates/appbuilder/general/lib.html
+++ b/flask_appbuilder/templates/appbuilder/general/lib.html
@@ -306,7 +306,7 @@
 {% endmacro %}
 
 {% macro lnk_back() %}
-    <a href="{{url_for('UtilView' + '.back')}}" class="btn btn-sm btn-primary" data-toggle="tooltip" rel="tooltip"
+    <a href="{{url_for('UtilView' + '.back')}}" class="btn btn-sm btn-default" data-toggle="tooltip" rel="tooltip"
        title="{{_('Back')}}">
         <i class="fa fa-arrow-left"></i>
     </a>
@@ -321,21 +321,21 @@
 {% endmacro %}
 
 {% macro lnk_edit(my_href) %}
-    <a href="{{my_href}}" class="btn btn-sm btn-primary" data-toggle="tooltip" rel="tooltip"
+    <a href="{{my_href}}" class="btn btn-sm btn-default" data-toggle="tooltip" rel="tooltip"
        title="{{_('Edit record')}}">
         <i class="fa fa-edit"></i>
     </a>
 {% endmacro %}
 
 {% macro lnk_show(my_href) %}
-    <a href="{{my_href}}" class="btn btn-sm btn-primary" data-toggle="tooltip" rel="tooltip"
+    <a href="{{my_href}}" class="btn btn-sm btn-default" data-toggle="tooltip" rel="tooltip"
        title="{{_('Show record')}}">
         <i class="fa fa-search"></i>
     </a>
 {% endmacro %}
 
 {% macro lnk_delete(my_href) %}
-    <a data-text="{{ _('You sure you want to delete this item?') }}" data-href="{{my_href}}" class="btn btn-sm btn-primary confirm" rel="tooltip"
+    <a data-text="{{ _('You sure you want to delete this item?') }}" data-href="{{my_href}}" class="btn btn-sm btn-default confirm" rel="tooltip"
         title="{{_('Delete record')}}" data-toggle="modal" data-target="#modal-confirm" href="#">
         <i class="fa fa-eraser"></i>
     </a>


### PR DESCRIPTION
I thought this make a lot of primary buttons on one page, making them
default allows to better highlight the [+] button

## before
<img width="366" alt="screen shot 2017-06-14 at 8 25 05 pm" src="https://user-images.githubusercontent.com/487433/27163970-ae393b2c-513f-11e7-9db6-b8ac34209ea7.png">

## after
<img width="334" alt="screen shot 2017-06-14 at 8 24 36 pm" src="https://user-images.githubusercontent.com/487433/27163969-ae3917d2-513f-11e7-9330-fdc155623479.png">

Feel free to pass on this PR if you prefer the current settings