### PR TITLE
[cosmetic] left-align the text in filter dropdown

### DIFF
--- a/flask_appbuilder/static/appbuilder/css/ab.css
+++ b/flask_appbuilder/static/appbuilder/css/ab.css
@@ -46,4 +46,6 @@ th.action_checkboxes {
 .fa-black {
     color: black;
 }
-
+.btn.filter {
+    text-align: left;
+}


### PR DESCRIPTION
before
<img width="236" alt="screen shot 2017-06-14 at 8 28 22 pm" src="https://user-images.githubusercontent.com/487433/27164061-39ebf006-5140-11e7-9715-0c74bae61a00.png">

after
<img width="217" alt="screen shot 2017-06-14 at 8 28 37 pm" src="https://user-images.githubusercontent.com/487433/27164067-3cc2b652-5140-11e7-8537-e641317616b4.png">
