### PR TITLE
fix babel-extract command

### DIFF
--- a/docs/fabmanager.rst
+++ b/docs/fabmanager.rst
@@ -52,6 +52,15 @@ Command Line uses the excellent click package, so you can have a detailed help f
     --help                          Show this message and exit.
 
 
+**babel-extract** - Babel, Extracts and updates all messages.
+----------------------------------------
+
+Use multi **-k** options separated by space to specify how to locate the strings you want to translate. 
+Default values: **lazy_gettext, gettext, _, __**.
+For example:
+
+    fabmanager babel-extract --target flask_appbuilder/translations/ -k _ -k __
+
 **create-app** - Create new Applications
 ----------------------------------------
 

--- a/flask_appbuilder/console.py
+++ b/flask_appbuilder/console.py
@@ -194,7 +194,7 @@ def babel_extract(config, input, output, target):
         Babel, Extracts and updates all messages marked for translation
     """
     click.echo(click.style('Starting Extractions config:{0} input:{1} output:{2}'.format(config, input, output), fg='green'))
-    os.popen('pybabel extract -F {0} -k lazy_gettext -o {1} {2}'.format(config, output, input))
+    os.popen('pybabel extract -F {0} -k lazy_gettext -k gettext -o {1} {2}'.format(config, output, input))
     click.echo(click.style('Starting Update target:{0}'.format(target), fg='green'))
     os.popen('pybabel update -N -i {0} -d {1}'.format(output, target))
     click.echo(click.style('Finish, you can start your translations', fg='green'))

--- a/flask_appbuilder/console.py
+++ b/flask_appbuilder/console.py
@@ -189,7 +189,7 @@ def list_users(app, appbuilder):
 @click.option('--input', default='.')
 @click.option('--output', default='./babel/messages.pot')
 @click.option('--target', default='app/translations')
-@click.option('--keywords', '-k', multiple=True, default=['lazy_gettext', 'gettext'])
+@click.option('--keywords', '-k', multiple=True, default=['lazy_gettext', 'gettext', '_', '__'])
 def babel_extract(config, input, output, target, keywords):
     """
         Babel, Extracts and updates all messages marked for translation

--- a/flask_appbuilder/console.py
+++ b/flask_appbuilder/console.py
@@ -189,12 +189,14 @@ def list_users(app, appbuilder):
 @click.option('--input', default='.')
 @click.option('--output', default='./babel/messages.pot')
 @click.option('--target', default='app/translations')
-def babel_extract(config, input, output, target):
+@click.option('--keywords', '-k', multiple=True, default=['lazy_gettext', 'gettext'])
+def babel_extract(config, input, output, target, keywords):
     """
         Babel, Extracts and updates all messages marked for translation
     """
-    click.echo(click.style('Starting Extractions config:{0} input:{1} output:{2}'.format(config, input, output), fg='green'))
-    os.popen('pybabel extract -F {0} -k lazy_gettext -k gettext -k __ -k _ -o {1} {2}'.format(config, output, input))
+    click.echo(click.style('Starting Extractions config:{0} input:{1} output:{2} keywords:{3}'.format(config, input, output, keywords), fg='green'))
+    keywords = ' -k '.join(keywords)
+    os.popen('pybabel extract -F {0} -k {1} -o {2} {3}'.format(config, keywords, output, input))
     click.echo(click.style('Starting Update target:{0}'.format(target), fg='green'))
     os.popen('pybabel update -N -i {0} -d {1}'.format(output, target))
     click.echo(click.style('Finish, you can start your translations', fg='green'))

--- a/flask_appbuilder/console.py
+++ b/flask_appbuilder/console.py
@@ -194,7 +194,7 @@ def babel_extract(config, input, output, target):
         Babel, Extracts and updates all messages marked for translation
     """
     click.echo(click.style('Starting Extractions config:{0} input:{1} output:{2}'.format(config, input, output), fg='green'))
-    os.popen('pybabel extract -F {0} -k lazy_gettext -k gettext -o {1} {2}'.format(config, output, input))
+    os.popen('pybabel extract -F {0} -k lazy_gettext -k gettext -k __ -k _ -o {1} {2}'.format(config, output, input))
     click.echo(click.style('Starting Update target:{0}'.format(target), fg='green'))
     os.popen('pybabel update -N -i {0} -d {1}'.format(output, target))
     click.echo(click.style('Finish, you can start your translations', fg='green'))


### PR DESCRIPTION
support `-k gettext` parameter when extract translatable strings using `fabmanager babel-extract`.