### PR TITLE
support for Enum type (sqla only)

### DIFF
--- a/flask_appbuilder/models/base.py
+++ b/flask_appbuilder/models/base.py
@@ -4,6 +4,12 @@ from functools import reduce
 from flask_babel import lazy_gettext
 from .filters import Filters
 
+try:
+    import enum
+    _has_enum = True
+except ImportError:
+    _has_enum = False
+
 log = logging.getLogger(__name__)
 
 
@@ -44,7 +50,12 @@ class BaseInterface(object):
             return getattr(item, col)()
         else:
             # its an attribute
-            return getattr(item, col)
+            value = getattr(item, col)
+            # if value is an Enum instance than list and show widgets should display
+            # its .value rather than its .name:
+            if _has_enum and isinstance(value, enum.Enum):
+                return value.value
+            return value
 
     def get_filters(self, search_columns=None):
         search_columns = search_columns or []
@@ -151,6 +162,9 @@ class BaseInterface(object):
         return False
 
     def is_datetime(self, col_name):
+        return False
+
+    def is_enum(self, col_name):
         return False
 
     def is_relation(self, prop):

--- a/flask_appbuilder/models/generic/filters.py
+++ b/flask_appbuilder/models/generic/filters.py
@@ -63,7 +63,9 @@ class GenericFilterConverter(BaseFilterConverter):
         specific for SQLAlchemy.
 
     """
-    conversion_table = (('is_text', [FilterContains,
+    conversion_table = (('is_enum', [FilterEqual,
+                                     FilterNotEqual]),
+                        ('is_text', [FilterContains,
                                      FilterIContains,
                                      FilterNotContains,
                                      FilterEqual,

--- a/flask_appbuilder/models/sqla/filters.py
+++ b/flask_appbuilder/models/sqla/filters.py
@@ -183,6 +183,8 @@ class SQLAFilterConverter(BaseFilterConverter):
                         FilterRelationOneToManyNotEqual]),
                         ('is_relation_many_to_many', [FilterRelationManyToManyEqual]),
                         ('is_relation_one_to_many', [FilterRelationManyToManyEqual]),
+                        ('is_enum', [FilterEqual,
+                                     FilterNotEqual]),
                         ('is_text', [FilterStartsWith,
                                      FilterEndsWith,
                                      FilterContains,

--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -201,6 +201,12 @@ class SQLAInterface(BaseInterface):
         except:
             return False
 
+    def is_enum(self, col_name):
+        try:
+            return isinstance(self.list_columns[col_name].type, sa.types.Enum)
+        except:
+            return False
+
     def is_relation(self, col_name):
         try:
             return isinstance(self.list_properties[col_name], sa.orm.properties.RelationshipProperty)
@@ -264,6 +270,8 @@ class SQLAInterface(BaseInterface):
 
     def get_max_length(self, col_name):
         try:
+            if self.is_enum(col_name):
+                return -1
             col = self.list_columns[col_name]
             if col.type.length:
                 return col.type.length


### PR DESCRIPTION
This is an attempt to support Sqlalchemy Enum types. I don't use Mongo so I'm not sure if there is an equivalent type there. Should resolve #408, I guess.

I also used destructuring-bind for a loop over conversion_table to increase readability.

(tested with Python 3.4)