### PR TITLE
check whether `session_form_edit_pk` still exist in db

### DIFF
--- a/flask_appbuilder/views.py
+++ b/flask_appbuilder/views.py
@@ -716,7 +716,7 @@ class CompactCRUDMixin(BaseCRUDView):
             form_widget = self._add().get('add')
         elif session_form_widget == 'edit':
             pk = self.get_key('session_form_edit_pk')
-            if pk:
+            if pk and self.datamodel.get(int(pk)):
                 form_widget = self._edit(int(pk)).get('edit')
         return {
             'list': GroupFormListWidget(


### PR DESCRIPTION
It will raise "AttributeError: 'NoneType' object has no attribute 'id' ", when session_form_edit_pk doesn't exist in database.

<img width="1117" alt="2017-07-13 09 55 47" src="https://user-images.githubusercontent.com/7597155/28147273-d3c53b1a-67b1-11e7-8766-4abb66841c21.png">
