### PR TITLE
Remove double-instantiation of declarative base

### DIFF
--- a/flask_appbuilder/models/sqla/__init__.py
+++ b/flask_appbuilder/models/sqla/__init__.py
@@ -32,9 +32,7 @@ class SQLA(SQLAlchemy):
     """
     def make_declarative_base(self, metadata=None):
         """Creates the declarative base."""
-        base = declarative_base(cls=Model, name='Model',
-                                metadata=metadata,
-                                metaclass=ModelDeclarativeMeta)
+        base = Model
         base.query = _QueryProperty(self)
         return base
 
@@ -84,7 +82,7 @@ class Model(object):
             result[key] = col
         return result
 
-    
+
 
 """
     This is for retro compatibility


### PR DESCRIPTION
The Model is already decorated with @as_declarative, so when SQLA wraps that again in a call to declarative_base(), it's creating yet another instance of declarative_base. This is causing flask_migrate (which uses SQLA.Model.metadata) to not recognize all the tables I've declared when I subclass from Model (since the metadata instances are different).