### PR TITLE
_bind_ldap: perform search regardless of indirect_user setting

### DIFF
--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -575,13 +575,13 @@ class BaseSecurityManager(AbstractSecurityManager):
                 log.debug("LDAP indirect bind with: {0}".format(indirect_user))
                 con.bind_s(indirect_user, indirect_password)
                 log.debug("LDAP BIND indirect OK")
-                user = self._search_ldap(ldap, con, username)
-                if user:
-                    log.debug("LDAP got User {0}".format(user))
-                    # username = DN from search
-                    username = user[0][0]
-                else:
-                    return False
+            user = self._search_ldap(ldap, con, username)
+            if user:
+                log.debug("LDAP got User {0}".format(user))
+                # username = DN from search
+                username = user[0][0]
+            else:
+                return False
             log.debug("LDAP bind with: {0} {1}".format(username, "XXXXXX"))
             if self.auth_ldap_username_format:
                 username = self.auth_ldap_username_format % username


### PR DESCRIPTION
LDAP binding should be perfomed using the full user DN not just the username. So regardless of whether indirect_user is given or not, search should be done first to acquire the full user DN.