### PR TITLE
Redirects on invalid list view page number

### DIFF
--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -789,6 +789,13 @@ class BaseCRUDView(BaseModelView):
             order_column, order_direction = self.base_order
         joined_filters = filters.get_joined_filters(self._base_filters)
         count, lst = self.datamodel.query(joined_filters, order_column, order_direction, page=page, page_size=page_size)
+
+        if page:
+            page_number = count // page_size
+            if page > page_number:
+                page_qp = 'page_' + self.__class__.__name__
+                args = {k: page_number if k == page_qp else v for k,v in request.args.items()}
+                raise ValueError(url_for(request.endpoint, **args))
         pks = self.datamodel.get_keys(lst)
         widgets['list'] = self.list_widget(label_columns=self.label_columns,
                                            include_columns=self.list_columns,

--- a/flask_appbuilder/tests/test_base.py
+++ b/flask_appbuilder/tests/test_base.py
@@ -536,6 +536,27 @@ class FlaskTestCase(unittest.TestCase):
         eq_(rv.status_code, 200)
         ok_('Test Redirects' in data)
 
+    def test_invalid_pagination(self):
+        """
+            Test redirect on invalid page number
+        """
+        client = self.app.test_client()
+        rv = self.login(client, DEFAULT_ADMIN_USER, DEFAULT_ADMIN_PASSWORD)
+
+        model1 = Model1(field_string='Test Pagination')
+        self.db.session.add(model1)
+        model1.id = REDIRECT_OBJ_ID
+        self.db.session.flush()
+
+        rv = client.get('/model1view/list/?page_Model1View=0')
+        eq_(rv.status_code, 200)
+
+        rv = client.get('/model1view/list/?page_Model1View=1')
+        eq_(rv.status_code, 302)
+        print("DBG asdaskjdlaksjdlaksjdlkjasldkajsld")
+        print(rv.data)
+
+
     def test_excluded_cols(self):
         """
             Test add_exclude_columns, edit_exclude_columns, show_exclude_columns

--- a/flask_appbuilder/views.py
+++ b/flask_appbuilder/views.py
@@ -472,7 +472,11 @@ class ModelView(RestCRUDView):
     @has_access
     def list(self):
 
-        widgets = self._list()
+        try:
+            widgets = self._list()
+        except ValueError as e:
+            return redirect(str(e))
+
         return self.render_template(self.list_template,
                                     title=self.list_title,
                                     widgets=widgets)
@@ -609,7 +613,11 @@ class MasterDetailView(BaseCRUDView):
         page_sizes = get_page_size_args()
         orders = get_order_args()
 
-        widgets = self._list()
+        try:
+            widgets = self._list()
+        except ValueError as e:
+            return redirect(str(e))
+
         if pk:
             item = self.datamodel.get(pk)
             widgets = self._get_related_views_widgets(item, orders=orders,
@@ -730,7 +738,11 @@ class CompactCRUDMixin(BaseCRUDView):
     @expose('/list/', methods=['GET', 'POST'])
     @has_access
     def list(self):
-        list_widgets = self._list()
+        try:
+            list_widgets = self._list()
+        except ValueError as e:
+            return redirect(str(e))
+
         return self.render_template(self.list_template,
                                     title=self.list_title,
                                     widgets=list_widgets)


### PR DESCRIPTION
Instead of returning an empty set redirect to the last valid page
given the provided pagination parameters.

Fixes #637