### PR TITLE
Support AUTH_USER_REGISTRATION with AUTH_REMOTE_USER

### DIFF
--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -691,7 +691,6 @@ class BaseSecurityManager(AbstractSecurityManager):
 
         # User does not exist, create one if auto user registration.
         if user is None and self.auth_user_registration:
-            log.info(LOGMSG_WAR_SEC_LOGIN_FAILED.format(username))
             user = self.add_user(
                 # All we have is REMOTE_USER, so we set
                 # the other fields to blank.


### PR DESCRIPTION
I'm using AUTH_REMOTE_USER with LDAP auth done by an HTTP reverse proxy.  The [docs say](http://flask-appbuilder.readthedocs.io/en/latest/security.html#authentication-methods):

> Finally you can allow users to self register...These settings can apply to all the authentication methods

which is not true.  This patch makes it true for AUTH_REMOTE_USER.

