### PR TITLE
Implement create-user command to fabmanager

### DIFF
--- a/docs/fabmanager.rst
+++ b/docs/fabmanager.rst
@@ -15,6 +15,8 @@ Take a quick look to the current possibilities. The bold ones require to import 
 
   - **create-admin** - Creates an admin user
 
+  - **create-user** - Create user with arbitrary role
+
   - create-app - Create a Skeleton application (SQLAlchemy or MongoEngine).
 
   - create-addon - Create a Skeleton AddOn.

--- a/flask_appbuilder/console.py
+++ b/flask_appbuilder/console.py
@@ -106,6 +106,28 @@ def create_admin(app, appbuilder, username, firstname, lastname, email, password
         click.echo(click.style('No user created an error occured', fg='red'))
 
 
+@cli_app.command("create-user")
+@click.option('--app', default='app', help='Your application init directory (package)')
+@click.option('--appbuilder', default='appbuilder', help='your AppBuilder object')
+@click.option('--role', default='Public', prompt='Role')
+@click.option('--username', prompt='Username')
+@click.option('--firstname', prompt='User first name')
+@click.option('--lastname', prompt='User last name')
+@click.option('--email', prompt='Email')
+@click.password_option()
+def create_user(app, appbuilder, role, username, firstname, lastname, email, password):
+    """
+        Create a user
+    """
+    _appbuilder = import_application(app, appbuilder)
+    role_object = _appbuilder.sm.find_role(role)
+    user = _appbuilder.sm.add_user(username, firstname, lastname, email, role_object, password)
+    if user:
+        click.echo(click.style('User {0} created.'.format(username), fg='green'))
+    else:
+        click.echo(click.style('Error!! No user created', fg='red'))
+
+
 @cli_app.command("run")
 @click.option('--app', default='app', help='Your application init directory (package)')
 @click.option('--appbuilder', default='appbuilder', help='your AppBuilder object')

--- a/flask_appbuilder/tests/test_fabmanager.py
+++ b/flask_appbuilder/tests/test_fabmanager.py
@@ -33,13 +33,14 @@ class FlaskTestCase(unittest.TestCase):
             ok_('Downloaded the skeleton app, good coding!' in result.output)
 
             with open('myapp/__init__.py', 'w') as f:
-                f.write("""
-                    from flask import Flask
-                    from flask_appbuilder import AppBuilder, SQLA
-                    app = Flask(__name__)
-                    db = SQLA(app)
-                    appbuilder = AppBuilder(app, db.session)
-                """)
+                for line in [
+                    'from flask import Flask\n',
+                    'from flask_appbuilder import AppBuilder, SQLA\n',
+                    'app = Flask(__name__)\n',
+                    'db = SQLA(app)\n',
+                    'appbuilder = AppBuilder(app, db.session)\n',
+                ]:
+                    f.write(line)
 
             result = runner.invoke(create_user,[
                 '--app=myapp', '--username=bob', '--role=Public', '--firstname=Bob',

--- a/flask_appbuilder/tests/test_fabmanager.py
+++ b/flask_appbuilder/tests/test_fabmanager.py
@@ -28,26 +28,24 @@ class FlaskTestCase(unittest.TestCase):
             Test create app
         """
         runner = CliRunner()
-        result = runner.invoke(create_app, input='myapp\nSQLAlchemy\n')
-        ok_('Downloaded the skeleton app, good coding!' in result.output)
+        with runner.isolated_filesystem():
+            result = runner.invoke(create_app, input='myapp\nSQLAlchemy\n')
+            ok_('Downloaded the skeleton app, good coding!' in result.output)
 
-        with open('myapp/__init__.py', 'w') as f:
-            f.write("""
-                from flask import Flask
-                from flask_appbuilder import AppBuilder, SQLA
-                app = Flask(__name__)
-                db = SQLA(app)
-                appbuilder = AppBuilder(app, db.session)
-            """)
+            with open('myapp/__init__.py', 'w') as f:
+                f.write("""
+                    from flask import Flask
+                    from flask_appbuilder import AppBuilder, SQLA
+                    app = Flask(__name__)
+                    db = SQLA(app)
+                    appbuilder = AppBuilder(app, db.session)
+                """)
 
-        result = runner.invoke(create_user,[
-            '--app=myapp', '--username=bob', '--role=Public', '--firstname=Bob',
-            '--lastname=Smith', '--email=bob@fab.com', '--password=foo'])
-        ok_('User bob created.' in result.output)
+            result = runner.invoke(create_user,[
+                '--app=myapp', '--username=bob', '--role=Public', '--firstname=Bob',
+                '--lastname=Smith', '--email=bob@fab.com', '--password=foo'])
+            ok_('User bob created.' in result.output)
 
-        shutil.rmtree('myapp')
-        result = runner.invoke(create_app, input='myapp\nMongoEngine\n')
-        ok_('Downloaded the skeleton app, good coding!' in result.output)
-        shutil.rmtree('myapp')
-
-
+        with runner.isolated_filesystem():
+            result = runner.invoke(create_app, input='myapp\nMongoEngine\n')
+            ok_('Downloaded the skeleton app, good coding!' in result.output)

--- a/flask_appbuilder/tests/test_fabmanager.py
+++ b/flask_appbuilder/tests/test_fabmanager.py
@@ -5,7 +5,7 @@ import string
 import random
 import datetime
 import shutil
-from flask_appbuilder.console import create_app, create_admin
+from flask_appbuilder.console import create_app, create_admin, create_user
 from click.testing import CliRunner
 
 import logging

--- a/flask_appbuilder/tests/test_fabmanager.py
+++ b/flask_appbuilder/tests/test_fabmanager.py
@@ -30,6 +30,21 @@ class FlaskTestCase(unittest.TestCase):
         runner = CliRunner()
         result = runner.invoke(create_app, input='myapp\nSQLAlchemy\n')
         ok_('Downloaded the skeleton app, good coding!' in result.output)
+
+        with open('myapp/__init__.py', 'w') as f:
+            f.write("""
+                from flask import Flask
+                from flask_appbuilder import AppBuilder, SQLA
+                app = Flask(__name__)
+                db = SQLA(app)
+                appbuilder = AppBuilder(app, db.session)
+            """)
+
+        result = runner.invoke(create_user,[
+            '--app=myapp', '--username=bob', '--role=Public', '--firstname=Bob',
+            '--lastname=Smith', '--email=bob@fab.com', '--password=foo'])
+        ok_('User bob created.' in result.output)
+
         shutil.rmtree('myapp')
         result = runner.invoke(create_app, input='myapp\nMongoEngine\n')
         ok_('Downloaded the skeleton app, good coding!' in result.output)


### PR DESCRIPTION
It is convenient to have a scriptable method for creating users.  It might be cleaner to merge this with 'create-admin', but I don't see an easy way to do that without either changing the name of 'create-admin', or having usage 'fabmanager create-admin --role=non-admin role', which just seems wrong.