### PR TITLE
Accept SQLAlchemy custom types defined by TypeDecorator

### DIFF
--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -25,6 +25,10 @@ def _include_filters(obj):
         if not hasattr(obj, key):
             setattr(obj, key, getattr(filters, key))
 
+def _is_sqla_type(obj, sa_type):
+    return isinstance(obj, sa_type) or \
+        isinstance(obj, sa.types.TypeDecorator) and isinstance(obj.impl, sa_type)
+
 
 class SQLAInterface(BaseInterface):
     """
@@ -158,61 +162,61 @@ class SQLAInterface(BaseInterface):
 
     def is_string(self, col_name):
         try:
-            return isinstance(self.list_columns[col_name].type, sa.types.String)
+            return _is_sqla_type(self.list_columns[col_name].type, sa.types.String)
         except:
             return False
 
     def is_text(self, col_name):
         try:
-            return isinstance(self.list_columns[col_name].type, sa.types.Text)
+            return _is_sqla_type(self.list_columns[col_name].type, sa.types.Text)
         except:
             return False
 
     def is_binary(self, col_name):
         try:
-            return isinstance(self.list_columns[col_name].type, sa.types.LargeBinary)
+            return _is_sqla_type(self.list_columns[col_name].type, sa.types.LargeBinary)
         except:
             return False
 
     def is_integer(self, col_name):
         try:
-            return isinstance(self.list_columns[col_name].type, sa.types.Integer)
+            return _is_sqla_type(self.list_columns[col_name].type, sa.types.Integer)
         except:
             return False
 
     def is_numeric(self, col_name):
         try:
-            return isinstance(self.list_columns[col_name].type, sa.types.Numeric)
+            return _is_sqla_type(self.list_columns[col_name].type, sa.types.Numeric)
         except:
             return False
 
     def is_float(self, col_name):
         try:
-            return isinstance(self.list_columns[col_name].type, sa.types.Float)
+            return _is_sqla_type(self.list_columns[col_name].type, sa.types.Float)
         except:
             return False
 
     def is_boolean(self, col_name):
         try:
-            return isinstance(self.list_columns[col_name].type, sa.types.Boolean)
+            return _is_sqla_type(self.list_columns[col_name].type, sa.types.Boolean)
         except:
             return False
 
     def is_date(self, col_name):
         try:
-            return isinstance(self.list_columns[col_name].type, sa.types.Date)
+            return _is_sqla_type(self.list_columns[col_name].type, sa.types.Date)
         except:
             return False
 
     def is_datetime(self, col_name):
         try:
-            return isinstance(self.list_columns[col_name].type, sa.types.DateTime)
+            return _is_sqla_type(self.list_columns[col_name].type, sa.types.DateTime)
         except:
             return False
 
     def is_enum(self, col_name):
         try:
-            return isinstance(self.list_columns[col_name].type, sa.types.Enum)
+            return _is_sqla_type(self.list_columns[col_name].type, sa.types.Enum)
         except:
             return False
 

--- a/flask_appbuilder/tests/test_sqlalchemy.py
+++ b/flask_appbuilder/tests/test_sqlalchemy.py
@@ -1,0 +1,23 @@
+from nose.tools import eq_
+import unittest
+import sqlalchemy as sa
+from flask_appbuilder.models.sqla.interface import _is_sqla_type
+
+
+class CustomSqlaType(sa.types.TypeDecorator):
+    impl = sa.types.DateTime(timezone=True)
+
+
+class NotSqlaType():
+    def __init__(self):
+        self.impl = sa.types.DateTime(timezone=True)
+
+
+class FlaskTestCase(unittest.TestCase):
+    def test_is_sqla_type(self):
+        t1 = sa.types.DateTime(timezone=True)
+        t2 = CustomSqlaType()
+        t3 = NotSqlaType()
+        eq_(True, _is_sqla_type(t1, sa.types.DateTime))
+        eq_(True, _is_sqla_type(t2, sa.types.DateTime))
+        eq_(False, _is_sqla_type(t3, sa.types.DateTime))


### PR DESCRIPTION
This will allow any [custom sa types](http://docs.sqlalchemy.org/en/latest/core/custom_types.html) (e.g. UtcDateTime in Airflow) inherited from TypeDecorator class. 

cc @mistercrunch 