### PR TITLE
Allow ImageManager to keep image in original size

### DIFF
--- a/flask_appbuilder/filemanager.py
+++ b/flask_appbuilder/filemanager.py
@@ -85,6 +85,7 @@ class ImageManager(FileManager):
     """
 
     keep_image_formats = ('PNG',)
+    max_size=None
 
     def __init__(self, base_path=None,
                  relative_path=None,


### PR DESCRIPTION
After this bug fix, Image upload can using original image size without error.

How to config:
in config.py, comment out IMG_SIZE
_#IMG_SIZE = (300, 200, True)_

in models.py, set **size=None**
_photo = Column(ImageColumn(thumbnail_size=(30, 30, True), **size=None**))_
