### PR TITLE
support instantiation of the modelview class

### DIFF
--- a/flask_appbuilder/base.py
+++ b/flask_appbuilder/base.py
@@ -349,14 +349,14 @@ class AppBuilder(object):
             appbuilder.add_link("google", href="www.google.com", icon = "fa-google-plus")
         """
         baseview = self._check_and_init(baseview)
-        log.info(LOGMSG_INF_FAB_ADD_VIEW.format(baseview.__class__.__name__, name))
+        log.info(LOGMSG_INF_FAB_ADD_VIEW.format(baseview.endpoint, name))
 
         if not self._view_exists(baseview):
             baseview.appbuilder = self
             self.baseviews.append(baseview)
             self._process_inner_views()
             if self.app:
-                self.register_blueprint(baseview)
+                self.register_blueprint(baseview, baseview.endpoint)
                 self._add_permission(baseview)
         self.add_link(name=name, href=href, icon=icon, label=label,
                       category=category, category_icon=category_icon,
@@ -415,7 +415,7 @@ class AppBuilder(object):
 
         """
         baseview = self._check_and_init(baseview)
-        log.info(LOGMSG_INF_FAB_ADD_VIEW.format(baseview.__class__.__name__, ""))
+        log.info(LOGMSG_INF_FAB_ADD_VIEW.format(baseview.endpoint, ""))
 
         if not self._view_exists(baseview):
             baseview.appbuilder = self
@@ -426,7 +426,7 @@ class AppBuilder(object):
                      endpoint=endpoint, static_folder=static_folder)
                 self._add_permission(baseview)
         else:
-            log.warning(LOGMSG_WAR_FAB_VIEW_EXISTS.format(baseview.__class__.__name__))
+            log.warning(LOGMSG_WAR_FAB_VIEW_EXISTS.format(baseview.endpoint))
         return baseview
 
     def security_cleanup(self):
@@ -466,7 +466,7 @@ class AppBuilder(object):
     def _add_permission(self, baseview):
         if self.update_perms:
             try:
-                self.sm.add_permissions_view(baseview.base_permissions, baseview.__class__.__name__)
+                self.sm.add_permissions_view(baseview.base_permissions, baseview.endpoint)
             except Exception as e:
                 log.exception(e)
                 log.error(LOGMSG_ERR_FAB_ADD_PERMISSION_VIEW.format(str(e)))
@@ -476,7 +476,7 @@ class AppBuilder(object):
 
     def _view_exists(self, view):
         for baseview in self.baseviews:
-            if baseview.__class__ == view.__class__:
+            if baseview.endpoint == view.endpoint:
                 return True
         return False
 

--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -119,9 +119,8 @@ class BaseView(object):
 
         # If endpoint name is not provided, get it from the class name
         self.endpoint = endpoint or self.__class__.__name__
-
         if self.route_base is None:
-            self.route_base = '/' + self.__class__.__name__.lower()
+            self.route_base = '/' + self.endpoint.lower()
 
         self.static_folder = static_folder
         if not static_folder:
@@ -756,15 +755,15 @@ class BaseCRUDView(BaseModelView):
         widgets = widgets or {}
         widgets['related_views'] = []
         for view in self._related_views:
-            if orders.get(view.__class__.__name__):
-                order_column, order_direction = orders.get(view.__class__.__name__)
+            if orders.get(view.endpoint):
+                order_column, order_direction = orders.get(view.endpoint)
             else:
                 order_column, order_direction = '', ''
             widgets['related_views'].append(self._get_related_view_widget(item, view,
                                                                           order_column, order_direction,
-                                                                          page=pages.get(view.__class__.__name__),
+                                                                          page=pages.get(view.endpoint),
                                                                           page_size=page_sizes.get(
-                                                                              view.__class__.__name__)))
+                                                                              view.endpoint)))
         return widgets
 
     def _get_view_widget(self, **kwargs):
@@ -807,7 +806,7 @@ class BaseCRUDView(BaseModelView):
                                            pks=pks,
                                            actions=actions,
                                            filters=filters,
-                                           modelview_name=self.__class__.__name__)
+                                           modelview_name=self.endpoint)
         return widgets
 
     def _get_show_widget(self, pk, item, widgets=None, actions=None, show_fieldsets=None):
@@ -821,7 +820,7 @@ class BaseCRUDView(BaseModelView):
                                            formatters_columns=self.formatters_columns,
                                            actions=actions,
                                            fieldsets=show_fieldsets,
-                                           modelview_name=self.__class__.__name__
+                                           modelview_name=self.endpoint
         )
         return widgets
 
@@ -869,12 +868,12 @@ class BaseCRUDView(BaseModelView):
             list function logic, override to implement different logic
             returns list and search widget
         """
-        if get_order_args().get(self.__class__.__name__):
-            order_column, order_direction = get_order_args().get(self.__class__.__name__)
+        if get_order_args().get(self.endpoint):
+            order_column, order_direction = get_order_args().get(self.endpoint)
         else:
             order_column, order_direction = '', ''
-        page = get_page_args().get(self.__class__.__name__)
-        page_size = get_page_size_args().get(self.__class__.__name__)
+        page = get_page_args().get(self.endpoint)
+        page_size = get_page_size_args().get(self.endpoint)
         get_filter_args(self._filters)
         widgets = self._get_list_widget(filters=self._filters,
                                         order_column=order_column,

--- a/flask_appbuilder/console.py
+++ b/flask_appbuilder/console.py
@@ -168,7 +168,7 @@ def list_users(app, appbuilder):
     _appbuilder = import_application(app, appbuilder)
     echo_header('List of registered views')
     for view in _appbuilder.baseviews:
-        click.echo('View:{0} | Route:{1} | Perms:{2}'.format(view.__class__.__name__, view.route_base, view.base_permissions))
+        click.echo('View:{0} | Route:{1} | Perms:{2}'.format(view.endpoint, view.route_base, view.base_permissions))
 
 
 @cli_app.command("list-users")

--- a/flask_appbuilder/security/decorators.py
+++ b/flask_appbuilder/security/decorators.py
@@ -22,10 +22,10 @@ def has_access(f):
 
     def wraps(self, *args, **kwargs):
         permission_str = PERMISSION_PREFIX + f._permission_name
-        if self.appbuilder.sm.has_access(permission_str, self.__class__.__name__):
+        if self.appbuilder.sm.has_access(permission_str, self.endpoint or self.__class__.__name__):
             return f(self, *args, **kwargs)
         else:
-            log.warning(LOGMSG_ERR_SEC_ACCESS_DENIED.format(permission_str, self.__class__.__name__))
+            log.warning(LOGMSG_ERR_SEC_ACCESS_DENIED.format(permission_str, self.endpoint or self.__class__.__name__))
             flash(as_unicode(FLAMSG_ERR_SEC_ACCESS_DENIED), "danger")
         return redirect(url_for(self.appbuilder.sm.auth_view.__class__.__name__ + ".login"))
     f._permission_name = permission_str
@@ -48,10 +48,10 @@ def has_access_api(f):
 
     def wraps(self, *args, **kwargs):
         permission_str = PERMISSION_PREFIX + f._permission_name
-        if self.appbuilder.sm.has_access(permission_str, self.__class__.__name__):
+        if self.appbuilder.sm.has_access(permission_str, self.endpoint or self.__class__.__name__):
             return f(self, *args, **kwargs)
         else:
-            log.warning(LOGMSG_ERR_SEC_ACCESS_DENIED.format(permission_str, self.__class__.__name__))
+            log.warning(LOGMSG_ERR_SEC_ACCESS_DENIED.format(permission_str, self.endpoint or self.__class__.__name__))
             response = make_response(jsonify({'message': str(FLAMSG_ERR_SEC_ACCESS_DENIED),
                                               'severity': 'danger'}), 401)
             response.headers['Content-Type'] = "application/json"

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -854,7 +854,7 @@ class BaseSecurityManager(AbstractSecurityManager):
         for viewmenu in viewsmenus:
             found = False
             for baseview in baseviews:
-                if viewmenu.name == baseview.__class__.__name__:
+                if viewmenu.name == baseview.endpoint:
                     found = True
                     break
             if menus.find(viewmenu.name):

--- a/flask_appbuilder/views.py
+++ b/flask_appbuilder/views.py
@@ -143,7 +143,7 @@ class RestCRUDView(BaseCRUDView):
         :param api_urls: A dict with the urls {'<FUNCTION>':'<URL>',...}
         :return: A dict with the CRUD urls of the base API.
         """
-        view_name = self.__class__.__name__
+        view_name = self.endpoint
         api_urls = api_urls or {}
         api_urls['read'] = url_for(view_name + ".api_read")
         api_urls['delete'] = url_for(view_name + ".api_delete", pk="")
@@ -152,7 +152,7 @@ class RestCRUDView(BaseCRUDView):
         return api_urls
 
     def _get_modelview_urls(self, modelview_urls=None):
-        view_name = self.__class__.__name__
+        view_name = self.endpoint
         modelview_urls = modelview_urls or {}
         modelview_urls['show'] = url_for(view_name + ".show", pk="")
         modelview_urls['add'] = url_for(view_name + ".add")
@@ -164,7 +164,7 @@ class RestCRUDView(BaseCRUDView):
     @has_access_api
     @permission_name('list')
     def api(self):
-        view_name = self.__class__.__name__
+        view_name = self.endpoint
         api_urls = self._get_api_urls()
         modelview_urls = self._get_modelview_urls()
         #
@@ -207,12 +207,12 @@ class RestCRUDView(BaseCRUDView):
         """
         """
         # Get arguments for ordering
-        if get_order_args().get(self.__class__.__name__):
-            order_column, order_direction = get_order_args().get(self.__class__.__name__)
+        if get_order_args().get(self.endpoint):
+            order_column, order_direction = get_order_args().get(self.endpoint)
         else:
             order_column, order_direction = '', ''
-        page = get_page_args().get(self.__class__.__name__)
-        page_size = get_page_size_args().get(self.__class__.__name__)
+        page = get_page_args().get(self.endpoint)
+        page_size = get_page_size_args().get(self.endpoint)
         get_filter_args(self._filters)
         joined_filters = self._filters.get_joined_filters(self._base_filters)
         count, lst = self.datamodel.query(joined_filters, order_column, order_direction, page=page, page_size=page_size)
@@ -224,7 +224,7 @@ class RestCRUDView(BaseCRUDView):
                            page=page,
                            page_size=page_size,
                            count=count,
-                           modelview_name=self.__class__.__name__,
+                           modelview_name=self.endpoint,
                            pks=pks,
                            result=result)
         response = make_response(ret_json, 200)
@@ -254,7 +254,7 @@ class RestCRUDView(BaseCRUDView):
         ret_json = jsonify(pk=pk,
                            label_columns=self._label_columns_json(),
                            include_columns=self.show_columns,
-                           modelview_name=self.__class__.__name__,
+                           modelview_name=self.endpoint,
                            result=self.show_item_dict(item))
         response = make_response(ret_json, 200)
         response.headers['Content-Type'] = "application/json"
@@ -417,8 +417,8 @@ class RestCRUDView(BaseCRUDView):
         """
         """
         # Get arguments for ordering
-        if get_order_args().get(self.__class__.__name__):
-            order_column, order_direction = get_order_args().get(self.__class__.__name__)
+        if get_order_args().get(self.endpoint):
+            order_column, order_direction = get_order_args().get(self.endpoint)
         else:
             order_column, order_direction = '', ''
         get_filter_args(self._filters)
@@ -557,7 +557,7 @@ class ModelView(RestCRUDView):
             Action method to handle actions from a show view
         """
         pk = self._deserialize_pk_if_composite(pk)
-        if self.appbuilder.sm.has_access(name, self.__class__.__name__):
+        if self.appbuilder.sm.has_access(name, self.endpoint):
             action = self.actions.get(name)
             return action.func(self.datamodel.get(pk))
         else:
@@ -572,7 +572,7 @@ class ModelView(RestCRUDView):
         """
         name = request.form['action']
         pks = request.form.getlist('rowid')
-        if self.appbuilder.sm.has_access(name, self.__class__.__name__):
+        if self.appbuilder.sm.has_access(name, self.endpoint):
             action = self.actions.get(name)
             items = [self.datamodel.get(self._deserialize_pk_if_composite(pk)) for pk in pks]
             return action.func(items)
@@ -665,12 +665,12 @@ class MultipleView(BaseView):
         orders = get_order_args()
         views_widgets = list()
         for view in self._views:
-            if orders.get(view.__class__.__name__):
-                order_column, order_direction = orders.get(view.__class__.__name__)
+            if orders.get(view.endpoint):
+                order_column, order_direction = orders.get(view.endpoint)
             else:
                 order_column, order_direction = '', ''
-            page = pages.get(view.__class__.__name__)
-            page_size = page_sizes.get(view.__class__.__name__)
+            page = pages.get(view.endpoint)
+            page_size = page_sizes.get(view.endpoint)
             views_widgets.append(view._get_view_widget(filters=view._base_filters,
                                                        order_column=order_column,
                                                        order_direction=order_direction,


### PR DESCRIPTION
When trying to create several views in a for loop, everything halts because it is looking at the class name.  I don't want to create 20+ class names with the only difference in them being the name of the class and 1 string value.

With these changes, all I have to do in the for loop is:

- instantiate class
- set instance.endpoint
- set instance.blueprint = Class.create_blueprint(instance, appbuilder, endpoint)
- instantiate generic model
- set genericmodel_instance.string_value
- set instance.datamodel = genericmodel_instance
- appbuilder.add_view(instance, 'Name')