### PR TITLE
Use `dateutil.parser.parse` method instead of `strptime` 

### DIFF
--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -1039,13 +1039,12 @@ class BaseCRUDView(BaseModelView):
         def date_deserializer(obj):
             if '_type' not in obj:
                 return obj
-            type = obj['_type']
-            if type == 'datetime' and '.' in obj['value']:
-                return datetime.strptime(obj['value'], "%Y-%m-%dT%H:%M:%S.%f")
-            elif type == 'datetime':
-                return datetime.strptime(obj['value'], "%Y-%m-%dT%H:%M:%S")
-            elif type == 'date':
-                return  datetime.strptime(obj['value'], "%Y-%m-%d").date()
+
+            from dateutil import parser
+            if obj['_type'] == 'datetime':
+                return parser.parse(obj['value'])
+            elif obj['_type'] == 'date':
+                return parser.parse(obj['value']).date()
             return obj
 
         if self.datamodel.is_pk_composite():

--- a/flask_appbuilder/models/sqla/filters.py
+++ b/flask_appbuilder/models/sqla/filters.py
@@ -1,4 +1,6 @@
 import logging
+import datetime
+from dateutil import parser
 from flask_babel import lazy_gettext
 from ..filters import BaseFilter, FilterRelation, BaseFilterConverter
 
@@ -41,6 +43,16 @@ def set_value_to_type(datamodel, column_name, value):
     elif datamodel.is_boolean(column_name):
             if value == 'y':
                 return True
+    elif datamodel.is_date(column_name) and not isinstance(value, datetime.date):
+        try:
+            return parser.parse(value).date()
+        except Exception as e:
+            return None
+    elif datamodel.is_datetime(column_name) and not isinstance(value, datetime.datetime):
+        try:
+            return parser.parse(value)
+        except Exception as e:
+            return None
     return value
 
 

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'Flask-OpenID==1.2.5',
         'Flask-SQLAlchemy==2.1',
         'Flask-WTF==0.14.2',
+        'python-dateutil>=2.3, <3',
     ],
     tests_require=[
         'nose>=1.0',


### PR DESCRIPTION
datetime.strptime doesn't handle the parsing of timezone-aware dates very well; plus this is easier to read.