### PR TITLE
Update baseviews.py

### DIFF
--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -126,11 +126,11 @@ class BaseView(object):
         self.static_folder = static_folder
         if not static_folder:
             # Create blueprint and register rules
-            self.blueprint = Blueprint(self.endpoint, __name__,
+            self.blueprint = Blueprint(self.endpoint, self.__module__,
                                        url_prefix=self.route_base,
                                        template_folder=self.template_folder)
         else:
-            self.blueprint = Blueprint(self.endpoint, __name__,
+            self.blueprint = Blueprint(self.endpoint, self.__module__,
                                        url_prefix=self.route_base,
                                        template_folder=self.template_folder,
                                        static_folder=static_folder)


### PR DESCRIPTION
Fix a bug when blueprint did not pass a root_path, it will use the import_name as the root_path to search the template.  But the __name__ is the parent class BaseView's import_name, so for the sub-classes which will not get its correct root path when searching the template file in the template path. So change it to the __module__ which can identify its correct root path for the blueprint template path.