### PR TITLE
update the requirements txt to allow higher versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'colorama==0.3.9',
         'click==6.7',
         'Flask>=0.10.0,<0.12.99',
-        'Flask-Babel>=0.11.1',  # known issues with 0.11.2
+        'Flask-Babel==0.11.1',  # known issues with 0.11.2
         'Flask-Login>=0.3,<0.5',
         'Flask-OpenID>=1.2.5',
         'Flask-SQLAlchemy>=2.1',

--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,11 @@ setup(
         'colorama==0.3.9',
         'click==6.7',
         'Flask>=0.10.0,<0.12.99',
-        'Flask-Babel==0.11.1',  # known issues with 0.11.2
+        'Flask-Babel>=0.11.1',  # known issues with 0.11.2
         'Flask-Login>=0.3,<0.5',
-        'Flask-OpenID==1.2.5',
-        'Flask-SQLAlchemy==2.1',
-        'Flask-WTF==0.14.2',
+        'Flask-OpenID>=1.2.5',
+        'Flask-SQLAlchemy>=2.1',
+        'Flask-WTF>=0.14.2',
         'python-dateutil>=2.3, <3',
     ],
     tests_require=[


### PR DESCRIPTION
Currently, many packages in the setup.py are hardcoded to a specific version. Unless there is a breaking issue with higher version, we should let users install any of the minor versions of the package. This would prevent issues with piptools pinning of python library versions