### PR TITLE
Fix: Only one end of the one-to-one relation returned the right result

### DIFF
--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -223,6 +223,8 @@ class SQLAInterface(BaseInterface):
     def is_relation(self, col_name):
         try:
             return isinstance(self.list_properties[col_name], sa.orm.properties.RelationshipProperty)
+        except KeyError:
+            return False
         except Exception as e:
             log.warning("An error occured when determining the relation")
             log.exception(e)
@@ -241,6 +243,8 @@ class SQLAInterface(BaseInterface):
                     rem_interf.obj,
                     rem_fk).property.uselist
                 return direction == 'MANYTOONE' and rem_uselist is True
+        except KeyError:
+            return False
         except Exception as e:
             log.warning("An error occured when determining the relation")
             log.exception(e)
@@ -252,6 +256,8 @@ class SQLAInterface(BaseInterface):
                 prop = self.list_properties[col_name]
                 direction = prop.direction.name
                 return direction == 'MANYTOMANY'
+        except KeyError:
+            return False
         except Exception as e:
             log.warning("An error occured when determining the relation")
             log.exception(e)
@@ -272,6 +278,8 @@ class SQLAInterface(BaseInterface):
                     rem_fk).property.uselist
                 return ((direction == 'ONETOMANY' and prop.uselist is False) or
                         (direction == 'MANYTOONE' and rem_uselist is False))
+        except KeyError:
+            return False
         except Exception as e:
             log.warning("An error occured when determining the relation")
             log.exception(e)

--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -231,14 +231,16 @@ class SQLAInterface(BaseInterface):
             if self.is_relation(col_name):
                 prop = self.list_properties[col_name]
                 direction = prop.direction.name
-                return direction == 'MANYTOONE'
+                return direction == 'MANYTOONE' and prop.uselist is True
         except:
             return False
 
     def is_relation_many_to_many(self, col_name):
         try:
             if self.is_relation(col_name):
-                return self.list_properties[col_name].direction.name == 'MANYTOMANY'
+                prop = self.list_properties[col_name]
+                direction = prop.direction.name
+                return direction == 'MANYTOMANY' and prop.uselist is True
         except:
             return False
 

--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -223,7 +223,9 @@ class SQLAInterface(BaseInterface):
     def is_relation(self, col_name):
         try:
             return isinstance(self.list_properties[col_name], sa.orm.properties.RelationshipProperty)
-        except:
+        except Exception as e:
+            log.warning("An error occured when determining the relation")
+            log.exception(e)
             return False
 
     def is_relation_many_to_one(self, col_name):

--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -247,7 +247,8 @@ class SQLAInterface(BaseInterface):
             if self.is_relation(col_name):
                 prop = self.list_properties[col_name]
                 direction = prop.direction.name
-                return direction == 'ONETOMANY' and prop.uselist is False
+                return ((direction == 'ONETOMANY' and prop.uselist is False) or
+                        (direction == 'MANYTOONE' and prop.uselist is False))
         except:
             return False
 

--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -291,6 +291,8 @@ class SQLAInterface(BaseInterface):
                 prop = self.list_properties[col_name]
                 direction = prop.direction.name
                 return direction == 'ONETOMANY' and prop.uselist is True
+        except KeyError:
+            return False
         except Exception as e:
             log.warning("An error occured when determining the relation")
             log.exception(e)

--- a/flask_appbuilder/tests/test_sqlalchemy.py
+++ b/flask_appbuilder/tests/test_sqlalchemy.py
@@ -75,11 +75,13 @@ class FlaskTestCase(unittest.TestCase):
 
     def test_is_many_to_many(self):
         interf = SQLAInterface(Parent)
+        eq_(True, interf.is_relation('neighbours'))
         eq_(False, interf.is_relation_one_to_many('neighbours'))
         eq_(False, interf.is_relation_one_to_one('neighbours'))
         eq_(False, interf.is_relation_many_to_one('neighbours'))
         eq_(True, interf.is_relation_many_to_many('neighbours'))
         interf = SQLAInterface(Neighbour)
+        eq_(True, interf.is_relation('parents'))
         eq_(False, interf.is_relation_one_to_many('parents'))
         eq_(False, interf.is_relation_one_to_one('parents'))
         eq_(False, interf.is_relation_many_to_one('parents'))
@@ -87,6 +89,7 @@ class FlaskTestCase(unittest.TestCase):
 
     def test_is_many_to_one_no_backref(self):
         interf = SQLAInterface(Headache)
+        eq_(True, interf.is_relation('parent'))
         eq_(False, interf.is_relation_one_to_many('parent'))
         eq_(False, interf.is_relation_one_to_one('parent'))
         eq_(True, interf.is_relation_many_to_one('parent'))
@@ -94,6 +97,7 @@ class FlaskTestCase(unittest.TestCase):
 
     def test_is_one_to_many(self):
         interf = SQLAInterface(Parent)
+        eq_(True, interf.is_relation('children'))
         eq_(True, interf.is_relation_one_to_many('children'))
         eq_(False, interf.is_relation_one_to_one('children'))
         eq_(False, interf.is_relation_many_to_one('children'))
@@ -101,6 +105,7 @@ class FlaskTestCase(unittest.TestCase):
 
     def test_is_many_to_one(self):
         interf = SQLAInterface(Child)
+        eq_(True, interf.is_relation('parent'))
         eq_(False, interf.is_relation_one_to_many('parent'))
         eq_(False, interf.is_relation_one_to_one('parent'))
         eq_(True, interf.is_relation_many_to_one('parent'))

--- a/flask_appbuilder/tests/test_sqlalchemy.py
+++ b/flask_appbuilder/tests/test_sqlalchemy.py
@@ -1,11 +1,18 @@
 from nose.tools import eq_
 import unittest
 import sqlalchemy as sa
+import sqlalchemy.ext.declarative
 from flask_appbuilder.models.sqla.interface import _is_sqla_type
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 
-Base = sa.ext.declarative.declarative_base()
+Base = sqlalchemy.ext.declarative.declarative_base()
 
+
+rel_table = sa.Table('association', Base.metadata,
+                     sa.Column('parent_id', sa.Integer,
+                               sa.ForeignKey('parent.id'), nullable=False),
+                     sa.Column('neighbour_id', sa.Integer,
+                               sa.ForeignKey('neighbour.id'), nullable=False))
 
 class Parent(Base):
     __tablename__ = 'parent'
@@ -13,6 +20,7 @@ class Parent(Base):
     favorite_child = sa.orm.relation('FavoriteChild', back_populates='parent',
                                      uselist=False)
     children = sa.orm.relation('Child', back_populates='parent')
+    neighbours = sa.orm.relation('Neighbour', secondary=rel_table)
 
 
 class FavoriteChild(Base):
@@ -28,6 +36,18 @@ class Child(Base):
     parent_id = sa.Column(sa.Integer, sa.ForeignKey('parent.id'))
     parent = sa.orm.relation(Parent, back_populates='children')
 
+class Neighbour(Base):
+    __tablename__ = 'neighbour'
+    id = sa.Column(sa.Integer, primary_key=True)
+    parents = sa.orm.relation('Parent', secondary=rel_table)
+
+class Headache(Base):
+    """Relation without backref or back_populates"""
+    __tablename__ = "headache"
+    id = sa.Column(sa.Integer, primary_key=True)
+    parent_id = sa.Column(sa.Integer, sa.ForeignKey('parent.id'))
+    parent = sa.orm.relation(Parent)
+
 
 class CustomSqlaType(sa.types.TypeDecorator):
     impl = sa.types.DateTime(timezone=True)
@@ -41,18 +61,50 @@ class NotSqlaType():
 class FlaskTestCase(unittest.TestCase):
     def test_is_one_to_one(self):
         interf = SQLAInterface(Parent)
+        eq_(True, interf.is_relation('favorite_child'))
         eq_(True, interf.is_relation_one_to_one('favorite_child'))
         eq_(False, interf.is_relation_one_to_many('favorite_child'))
+        eq_(False, interf.is_relation_many_to_many('favorite_child'))
         eq_(False, interf.is_relation_many_to_one('favorite_child'))
         interf = SQLAInterface(FavoriteChild)
+        eq_(True, interf.is_relation('parent'))
         eq_(True, interf.is_relation_one_to_one('parent'))
         eq_(False, interf.is_relation_one_to_many('parent'))
+        eq_(False, interf.is_relation_many_to_many('parent'))
         eq_(False, interf.is_relation_many_to_one('parent'))
+
+    def test_is_many_to_many(self):
+        interf = SQLAInterface(Parent)
+        eq_(False, interf.is_relation_one_to_many('neighbours'))
+        eq_(False, interf.is_relation_one_to_one('neighbours'))
+        eq_(False, interf.is_relation_many_to_one('neighbours'))
+        eq_(True, interf.is_relation_many_to_many('neighbours'))
+        interf = SQLAInterface(Neighbour)
+        eq_(False, interf.is_relation_one_to_many('parents'))
+        eq_(False, interf.is_relation_one_to_one('parents'))
+        eq_(False, interf.is_relation_many_to_one('parents'))
+        eq_(True, interf.is_relation_many_to_many('parents'))
+
+    def test_is_many_to_one_no_backref(self):
+        interf = SQLAInterface(Headache)
+        eq_(False, interf.is_relation_one_to_many('parent'))
+        eq_(False, interf.is_relation_one_to_one('parent'))
+        eq_(True, interf.is_relation_many_to_one('parent'))
+        eq_(False, interf.is_relation_many_to_many('parent'))
 
     def test_is_one_to_many(self):
         interf = SQLAInterface(Parent)
         eq_(True, interf.is_relation_one_to_many('children'))
         eq_(False, interf.is_relation_one_to_one('children'))
+        eq_(False, interf.is_relation_many_to_one('children'))
+        eq_(False, interf.is_relation_many_to_many('children'))
+
+    def test_is_many_to_one(self):
+        interf = SQLAInterface(Child)
+        eq_(False, interf.is_relation_one_to_many('parent'))
+        eq_(False, interf.is_relation_one_to_one('parent'))
+        eq_(True, interf.is_relation_many_to_one('parent'))
+        eq_(False, interf.is_relation_many_to_many('parent'))
 
     def test_is_sqla_type(self):
         t1 = sa.types.DateTime(timezone=True)

--- a/flask_appbuilder/tests/test_sqlalchemy.py
+++ b/flask_appbuilder/tests/test_sqlalchemy.py
@@ -41,13 +41,15 @@ class NotSqlaType():
 class FlaskTestCase(unittest.TestCase):
     def test_is_one_to_one(self):
         interf = SQLAInterface(Parent)
-        eq_(True,  interf.is_relation_one_to_one('favorite_child'))
-        eq_(False,  interf.is_relation_one_to_many('favorite_child'))
+        eq_(True, interf.is_relation_one_to_one('favorite_child'))
+        eq_(False, interf.is_relation_one_to_many('favorite_child'))
+        interf = SQLAInterface(FavoriteChild)
+        eq_(True, interf.is_relation_one_to_one('parent'))
 
     def test_is_one_to_many(self):
         interf = SQLAInterface(Parent)
-        eq_(True,  interf.is_relation_one_to_many('children'))
-        eq_(False,  interf.is_relation_one_to_one('children'))
+        eq_(True, interf.is_relation_one_to_many('children'))
+        eq_(False, interf.is_relation_one_to_one('children'))
 
     def test_is_sqla_type(self):
         t1 = sa.types.DateTime(timezone=True)

--- a/flask_appbuilder/tests/test_sqlalchemy.py
+++ b/flask_appbuilder/tests/test_sqlalchemy.py
@@ -43,8 +43,11 @@ class FlaskTestCase(unittest.TestCase):
         interf = SQLAInterface(Parent)
         eq_(True, interf.is_relation_one_to_one('favorite_child'))
         eq_(False, interf.is_relation_one_to_many('favorite_child'))
+        eq_(False, interf.is_relation_many_to_one('favorite_child'))
         interf = SQLAInterface(FavoriteChild)
         eq_(True, interf.is_relation_one_to_one('parent'))
+        eq_(False, interf.is_relation_one_to_many('parent'))
+        eq_(False, interf.is_relation_many_to_one('parent'))
 
     def test_is_one_to_many(self):
         interf = SQLAInterface(Parent)


### PR DESCRIPTION
The SQLAInterface.is_relation_one_to_one only returned true for one end of a one-to-one relation, not for the other end. This is because sqlalchemy reports the relation with direction=ONETOMANY or direction=MANYTOONE (depending on the side of the relation). The previous code only checked the ONETOMANY side, not the MANYTOONE. This is now fixed (including a test).