### PR TITLE
Fix list and form widget rendering html InLine

### DIFF
--- a/flask_appbuilder/templates/appbuilder/general/widgets/base_list.html
+++ b/flask_appbuilder/templates/appbuilder/general/widgets/base_list.html
@@ -26,7 +26,7 @@
     {% block end_content scoped %}
     {% endblock %}
 
-    {{ lib.action_form(actions,modelview_name) }}
+    {{ lib.action_form(actions, modelview_name) }}
 
     <script language="javascript">
         var modelActions = new AdminActions();

--- a/flask_appbuilder/templates/appbuilder/general/widgets/group_form_list.html
+++ b/flask_appbuilder/templates/appbuilder/general/widgets/group_form_list.html
@@ -2,7 +2,7 @@
 
 {% if form_widget %}
         {{ lib.panel_begin(form_title) }}
-            {{ form_widget(form_action = form_action) }}
+            {{ form_widget(form_action = form_action) | safe }}
         {{ lib.panel_end() }}
 {% endif %}
-{{ list_widget() }}
+{{ list_widget() | safe }}


### PR DESCRIPTION
It appears that since
https://github.com/dpgaspar/Flask-AppBuilder/pull/797 , there have been
issues rendering inlines that show as HTML.

This quick fix addresses it, and a quick test shows that <script> tags
get rendered as strings so things are still secure following this fix.

<img width="1272" alt="bildschirmfoto 2018-10-16 um 15 45 54" src="https://user-images.githubusercontent.com/44201975/47021149-2ce16c00-d15b-11e8-9871-393a1fd193fc.png">