### PR TITLE
Fix issue 838: Views has no attribute name error raised in log statement

### DIFF
--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -738,7 +738,7 @@ class BaseCRUDView(BaseModelView):
             filters.add_filter_related_view(fk, self.datamodel.FilterRelationManyToManyEqual,
                                         self.datamodel.get_pk_value(item))
         else:
-            log.error("Can't find relation on related view {0}".format(related_view.name))
+            log.error("Can't find relation on related view {0}".format(related_view.__class__.__name__))
             return None
         return related_view._get_view_widget(filters=filters,
                                              order_column=order_column,

--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -1,3 +1,4 @@
+from inspect import isclass
 import json
 import logging
 from datetime import datetime, date
@@ -738,7 +739,11 @@ class BaseCRUDView(BaseModelView):
             filters.add_filter_related_view(fk, self.datamodel.FilterRelationManyToManyEqual,
                                         self.datamodel.get_pk_value(item))
         else:
-            log.error("Can't find relation on related view {0}".format(related_view.__class__.__name__))
+            if isclass(related_view) and issubclass(related_view, BaseView):
+                name = related_view.__name__
+            else:
+                name = related_view.__class__.__name__
+            log.error("Can't find relation on related view {0}".format(name))
             return None
         return related_view._get_view_widget(filters=filters,
                                              order_column=order_column,


### PR DESCRIPTION
Fixes issue #838. Change the log statement to get the actual name of the view through getting the class `.__name__`  attribute instead of `.name`