### PR TITLE
Fix, Console: Use appbuilder variable instead of literal.

### DIFF
--- a/flask_appbuilder/console.py
+++ b/flask_appbuilder/console.py
@@ -32,7 +32,7 @@ def import_application(app_package, appbuilder):
     except Exception as e:
         click.echo(click.style('Was unable to import {0} Error: {1}'.format(app_package, e), fg='red'))
         exit(3)
-    if hasattr(_app, 'appbuilder'):
+    if hasattr(_app, appbuilder):
         return getattr(_app, appbuilder)
     else:
         click.echo(click.style('There in no appbuilder var on your package, you can use appbuilder parameter to config', fg='red'))


### PR DESCRIPTION
The problem is that when appbuilder is in a different module,  one needs to use `fabmanager --appbuilder` to specify the variable,  however the import_application code does not use the appbuilder variable.  Instead it uses the string literal "appbuilder".  I believe this is a typo.

fixes  #861
