### PR TITLE
Fix: Oauth security search is not sufficiently comprehensive

### DIFF
--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -821,13 +821,17 @@ class BaseSecurityManager(AbstractSecurityManager):
             :userinfo: dict with user information the keys have the same name
             as User model columns.
         """
-        if 'username' in userinfo:
-            user = self.find_user(username=userinfo['username'])
-        elif 'email' in userinfo:
-            user = self.find_user(email=userinfo['email'])
-        else:
+        user = None
+
+        if 'username' not in userinfo and 'email' not in userinfo:
             log.error('User info does not have username or email {0}'.format(userinfo))
             return None
+
+        if 'username' in userinfo:
+            user = self.find_user(username=userinfo['username'])
+        if not user and 'email' in userinfo:
+            user = self.find_user(email=userinfo['email'])
+
         # User is disabled
         if user and not user.is_active:
             log.info(LOGMSG_WAR_SEC_LOGIN_FAILED.format(userinfo))


### PR DESCRIPTION
As described in #818, in the case where Google Oauth is used (and I think generally in Oauth all around), the current logic is to search for a username if the `username` key exists in the userinfo dictionary, and only if the `username` key does not exist is a search done with email. 

This fix searches for a user by username, and if the result of find_user from that search returns a false-y value, it then proceeds to search by email.
