### PR TITLE
Support jinja2 StrictUndefined.

### DIFF
--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -455,7 +455,6 @@ class BaseModelView(BaseView):
         return ret
 
 
-
 class BaseCRUDView(BaseModelView):
     """
         The base class for ModelView, all properties are inherited

--- a/flask_appbuilder/templates/appbuilder/general/model/edit.html
+++ b/flask_appbuilder/templates/appbuilder/general/model/edit.html
@@ -4,7 +4,7 @@
 {% block content %}
 {{ lib.panel_begin(title) }}
 
-{% if related_views %}
+{% if related_views is defined %}
     <ul class="nav nav-tabs">
     <li class="active"><a href="#Home" data-toggle="tab">{{ _("Detail") }}</a> </li>
         {% for view in related_views %}
@@ -27,7 +27,7 @@
 
 {% endblock %}
 
-    {% if related_views %} </div> {% endif %}
+    {% if related_views is defined %} </div> {% endif %}
 
 {{ lib.panel_end() }}
 {% endblock %}

--- a/flask_appbuilder/templates/appbuilder/general/model/edit_cascade.html
+++ b/flask_appbuilder/templates/appbuilder/general/model/edit_cascade.html
@@ -10,7 +10,7 @@
 {% endblock edit_form %}
 
 {% block related_views %}
-    {% if related_views %}
+    {% if related_views is defined %}
         {% for view in related_views %}
             {% call lib.accordion_tag(view.__class__.__name__,view.title, False) %}
                 {{ widgets.get('related_views')[loop.index - 1](pk = pk)|safe }}

--- a/flask_appbuilder/templates/appbuilder/general/model/show.html
+++ b/flask_appbuilder/templates/appbuilder/general/model/show.html
@@ -4,7 +4,7 @@
 {% block content %}
 {{ lib.panel_begin(title) }}
 
-{% if related_views %}
+{% if related_views is defined %}
     <ul class="nav nav-tabs">
     <li class="active"><a href="#Home" data-toggle="tab">{{ _("Detail") }}</a> </li>
         {% for view in related_views %}
@@ -28,7 +28,7 @@
     </div>
 {% endblock show_form %}
 
-{% if related_views %}</div>{% endif %}
+{% if related_views is defined %}</div>{% endif %}
 {{ lib.panel_end() }}
 
 {% endblock content %}

--- a/flask_appbuilder/templates/appbuilder/general/model/show_cascade.html
+++ b/flask_appbuilder/templates/appbuilder/general/model/show_cascade.html
@@ -9,7 +9,7 @@
 {% endblock show_form %}
 
 {% block related_views %}
-    {% if related_views %}
+    {% if related_views is defined %}
         {% for view in related_views %}
             {% call lib.accordion_tag(view.__class__.__name__,view.title, False) %}
                 {{ widgets.get('related_views')[loop.index - 1](pk = pk)|safe }}

--- a/flask_appbuilder/templates/appbuilder/general/security/login_db.html
+++ b/flask_appbuilder/templates/appbuilder/general/security/login_db.html
@@ -16,7 +16,7 @@
                 <form class="form" action="" method="post" name="login">
                     {{form.hidden_tag()}}
                     <div class="help-block">{{_("Enter your login and password below")}}:</div>
-                    <div class="control-group{% if form.errors.openid %} error{% endif %}">
+                    <div class="control-group{% if form.errors.openid is defined %} error{% endif %}">
                         <label class="control-label" for="openid">{{_("Username")}}:</label>
 
                         <div class="controls">
@@ -24,7 +24,7 @@
                                 <span class="input-group-addon"><i class="fa fa-user"></i></span>
                                 {{ form.username(size = 80, class = "form-control") }}
                             </div>
-                            {% for error in form.errors.openid %}
+                            {% for error in form.errors.get('openid', []) %}
                             <span class="help-inline">[{{error}}]</span><br>
                             {% endfor %}
                             <label class="control-label" for="openid">{{_("Password")}}:</label>
@@ -33,7 +33,7 @@
                                 <span class="input-group-addon"><i class="fa fa-key"></i></span>
                                 {{ form.password(size = 80, class = "form-control") }}
                             </div>
-                            {% for error in form.errors.openid %}
+                            {% for error in form.errors.get('openid', []) %}
                             <span class="help-inline">[{{error}}]</span><br>
                             {% endfor %}
                         </div>

--- a/flask_appbuilder/templates/appbuilder/general/security/login_ldap.html
+++ b/flask_appbuilder/templates/appbuilder/general/security/login_ldap.html
@@ -14,14 +14,14 @@
     <form class="form" action="" method="post" name="login">
         {{form.hidden_tag()}}
         <div class="help-block">{{_("Enter your login and password below")}}:</div>
-        <div class="control-group{% if form.errors.openid %} error{% endif %}">
+        <div class="control-group{% if form.errors.openid is defined %} error{% endif %}">
             <label class="control-label" for="openid">{{_("Username")}}:</label>
             <div class="controls">
                 <div class="input-group">
                 <span class="input-group-addon"><i class="fa fa-user"></i></span>
                 {{ form.username(size = 80, class = "form-control") }}
                 </div>
-                {% for error in form.errors.openid %}
+                {% for error in form.errors.get('openid', []) %}
                     <span class="help-inline">[{{error}}]</span><br>
                 {% endfor %}
 		<label class="control-label" for="openid">{{_("Password")}}:</label>
@@ -29,7 +29,7 @@
                 <span class="input-group-addon"><i class="fa fa-key"></i></span>
                 {{ form.password(size = 80, class = "form-control") }}
                 </div>
-                {% for error in form.errors.openid %}
+                {% for error in form.errors.get('openid', []) %}
                     <span class="help-inline">[{{error}}]</span><br>
                 {% endfor %}
             </div>

--- a/flask_appbuilder/templates/appbuilder/general/security/login_oid.html
+++ b/flask_appbuilder/templates/appbuilder/general/security/login_oid.html
@@ -97,11 +97,11 @@ function registerUser() {
             {% endfor %}
         </div>
         </center>
-        <div class="control-group{% if form.errors.openid %} error{% endif %}">
+        <div class="control-group{% if form.errors.openid is defined %} error{% endif %}">
             <label class="hidden control-label" id="label-openid" for="openid">{{_("Or enter your OpenID here")}}:</label>
             <div class="controls">
                 {{ form.openid(size = 80, class = "hidden form-control") }}
-                {% for error in form.errors.openid %}
+                {% for error in form.errors.get('openid', []) %}
                     <span class="help-inline">{{_('Please choose a provider')}}</span><br>
                 {% endfor %}
                 <label class="hidden control-label" id="label-username" for="username">{{_("Enter your OpenID Username")}}:</label>

--- a/flask_appbuilder/templates/appbuilder/general/widgets/form.html
+++ b/flask_appbuilder/templates/appbuilder/general/widgets/form.html
@@ -7,7 +7,7 @@
 {% set end_sep_field = '</td>' %}
 
 
-{% if form_action %}
+{% if form_action is defined %}
     <form action="{{form_action}}" method="post" enctype="multipart/form-data">
 {% else %}
     <form id="model_form" action="" method="post" enctype="multipart/form-data">

--- a/flask_appbuilder/templates/appbuilder/general/widgets/form_horizontal.html
+++ b/flask_appbuilder/templates/appbuilder/general/widgets/form_horizontal.html
@@ -2,7 +2,7 @@
 {% import 'appbuilder/general/lib.html' as lib %}
 
 
-{% if form_action %}
+{% if form_action is defined %}
     <form class="form-horizontal" role="form" action="{{form_action}}" method="post" enctype="multipart/form-data">
 {% else %}
     <form class="form-horizontal" role="form" id="model_form" action="" method="post" enctype="multipart/form-data">

--- a/flask_appbuilder/templates/appbuilder/general/widgets/form_inline.html
+++ b/flask_appbuilder/templates/appbuilder/general/widgets/form_inline.html
@@ -1,7 +1,7 @@
 
 {% import 'appbuilder/general/lib.html' as lib %}
 
-{% if form_action %}
+{% if form_action is defined %}
     <form action="{{form_action}}" method="post" enctype="multipart/form-data">
 {% endif %}
 <form class="form-inline" role="form" id="model_form" action="" method="post" enctype="multipart/form-data">

--- a/flask_appbuilder/templates/appbuilder/general/widgets/form_vertical.html
+++ b/flask_appbuilder/templates/appbuilder/general/widgets/form_vertical.html
@@ -1,7 +1,7 @@
 
 {% import 'appbuilder/general/lib.html' as lib %}
 
-{% if form_action %}
+{% if form_action is defined %}
     <form action="{{form_action}}" method="post" enctype="multipart/form-data">
 {% endif %}
 <form class="form-vertical" role="form" id="model_form" action="" method="post" enctype="multipart/form-data">

--- a/flask_appbuilder/tests/test_base.py
+++ b/flask_appbuilder/tests/test_base.py
@@ -16,6 +16,7 @@ from nose.tools import eq_, ok_
 from sqlalchemy import Column, Integer, String, ForeignKey, Date, Float, Enum, DateTime
 from sqlalchemy.orm import relationship
 from flask import redirect, request, session
+import jinja2
 
 from flask_appbuilder import Model, SQLA
 from flask_appbuilder.models.sqla.filters import FilterStartsWith, FilterEqual
@@ -107,6 +108,7 @@ class FlaskTestCase(unittest.TestCase):
         from flask_appbuilder.views import ModelView
 
         self.app = Flask(__name__)
+        self.app.jinja_env.undefined = jinja2.StrictUndefined
         self.basedir = os.path.abspath(os.path.dirname(__file__))
         self.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///'
         self.app.config['CSRF_ENABLED'] = False
@@ -206,6 +208,7 @@ class FlaskTestCase(unittest.TestCase):
         class Model2DirectByChartView(DirectByChartView):
             datamodel = SQLAInterface(Model2)
             chart_title = 'Test Model1 Chart'
+            list_title = ''
 
             definitions = [
                 {

--- a/flask_appbuilder/tests/test_ldapsearch.py
+++ b/flask_appbuilder/tests/test_ldapsearch.py
@@ -5,6 +5,7 @@ import logging
 from flask import Flask
 from flask_appbuilder import AppBuilder, SQLA
 from mockldap import MockLdap
+import jinja2
 
 from flask_appbuilder.const import AUTH_LDAP
 
@@ -39,6 +40,7 @@ class LDAPSearchTestCase(unittest.TestCase):
 		self.ldapobj = self.mockldap['ldap://localhost/']
 
 		self.app = Flask(__name__)
+		self.app.jinja_env.undefined = jinja2.StrictUndefined
 		self.db = SQLA(self.app)
 
 		self.app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False

--- a/flask_appbuilder/tests/test_mongoengine.py
+++ b/flask_appbuilder/tests/test_mongoengine.py
@@ -4,6 +4,7 @@ import os
 import string
 import random
 import datetime
+import jinja2
 from flask_mongoengine import MongoEngine
 from mongoengine import Document
 from mongoengine import IntField, FloatField, DateTimeField, StringField, ReferenceField, ListField, FileField, ImageField
@@ -75,6 +76,7 @@ class FlaskTestCase(unittest.TestCase):
         from flask_appbuilder.security.mongoengine.manager import SecurityManager
 
         self.app = Flask(__name__)
+        self.app.jinja_env.undefined = jinja2.StrictUndefined
         self.basedir = os.path.abspath(os.path.dirname(__file__))
         self.app.config['MONGODB_SETTINGS'] = {'DB': 'test'}
         self.app.config['CSRF_ENABLED'] = False


### PR DESCRIPTION
So that apps using appbuilder can configure jinja to error on undefined variables, explicitly test whether template variable are defined rather than treating undefined as falsy.