### PR TITLE
Add documentation for AUTH_LDAP_SEARCH_FILTER

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -71,6 +71,14 @@ Use config.py to configure the following parameters. By default it will use SQLL
 |                                   |                                            |           |
 |                                   | AUTH_LDAP_SEARCH = "ou=people,dc=example"  |           |
 +-----------------------------------+--------------------------------------------+-----------+
+| AUTH_LDAP_SEARCH_FILTER           | Filter or limit allowable users from       |   No      |
+|                                   | the LDAP server, e.g., only the people     |           |
+|                                   | on your team.                              |           |
+|                                   |                                            |           |
+|                                   | AUTH_LDAP_SEARCH_FILTER =                  |           |
+|                                   | "(memberOf=cn=group name,OU=type,dc=ex     |           |
+|                                   | ,cn=com)"                                  |           |
++-----------------------------------+--------------------------------------------+-----------+
 | AUTH_LDAP_UID_FIELD               | if doing an indirect bind to ldap, this    |   No      |
 |                                   | is the field that matches the username     |           |
 |                                   | when searching for the account to bind     |           | 
@@ -191,10 +199,10 @@ Use config.py to configure the following parameters. By default it will use SQLL
 Using config.py
 ---------------
  
-My favorite way, and the one i advise if you are building a medium to large size application
+My favorite way, and the one I advise if you are building a medium to large size application
 is to place all your configuration keys on a config.py file
  
-next you only have to import them to the Flask app object, like this
+Next you only have to import them to the Flask app object, like this
 ::
 
     app = Flask(__name__)


### PR DESCRIPTION
This just adds a description to the documentation for the optional LDAP configuration field `AUTH_LDAP_SEARCH_FILTER`. I noticed in the code this was available but not mentioned in the documentation.

This is my first pull request on an open-source repo, so apologies if I haven't followed protocol -- I appreciate any help or suggestions.