### PR TITLE
Feature: redirect after login/register with OAuth

### DIFF
--- a/flask_appbuilder/security/decorators.py
+++ b/flask_appbuilder/security/decorators.py
@@ -1,7 +1,7 @@
 import logging
 import functools
 
-from flask import flash, redirect, url_for, make_response, jsonify
+from flask import flash, redirect, url_for, make_response, jsonify, request
 from .._compat import as_unicode
 from ..const import LOGMSG_ERR_SEC_ACCESS_DENIED, FLAMSG_ERR_SEC_ACCESS_DENIED, PERMISSION_PREFIX
 
@@ -27,7 +27,7 @@ def has_access(f):
         else:
             log.warning(LOGMSG_ERR_SEC_ACCESS_DENIED.format(permission_str, self.__class__.__name__))
             flash(as_unicode(FLAMSG_ERR_SEC_ACCESS_DENIED), "danger")
-        return redirect(url_for(self.appbuilder.sm.auth_view.__class__.__name__ + ".login"))
+        return redirect(url_for(self.appbuilder.sm.auth_view.__class__.__name__ + ".login", next=request.url))
     f._permission_name = permission_str
     return functools.update_wrapper(wraps, f)
 
@@ -56,7 +56,7 @@ def has_access_api(f):
                                               'severity': 'danger'}), 401)
             response.headers['Content-Type'] = "application/json"
             return response
-        return redirect(url_for(self.appbuilder.sm.auth_view.__class__.__name__ + ".login"))
+        return redirect(url_for(self.appbuilder.sm.auth_view.__class__.__name__ + ".login", next=request.url))
     f._permission_name = permission_str
     return functools.update_wrapper(wraps, f)
 

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -839,9 +839,9 @@ class BaseSecurityManager(AbstractSecurityManager):
         if not user:
             user = self.add_user(
                     username=userinfo['username'],
-                    first_name=userinfo['first_name'],
-                    last_name=userinfo['last_name'],
-                    email=userinfo['email'],
+                    first_name=userinfo.get('first_name', ''),
+                    last_name=userinfo.get('last_name', ''),
+                    email=userinfo.get('email', ''),
                     role=self.find_role(self.auth_user_registration_role)
                 )
             if not user:

--- a/flask_appbuilder/security/views.py
+++ b/flask_appbuilder/security/views.py
@@ -512,10 +512,15 @@ class AuthOAuthView(AuthView):
                 if register:
                     log.debug('Login to Register')
                     session['register'] = True
-                return self.appbuilder.sm.oauth_remotes[provider].authorize(
-                    callback=url_for
-                        ('.oauth_authorized', provider=provider, _external=True),
-                        state=state)
+                if provider == 'twitter':
+                    return self.appbuilder.sm.oauth_remotes[provider].authorize(
+                        callback=url_for
+                            ('.oauth_authorized', provider=provider, _external=True, state=state))
+                else:
+                    return self.appbuilder.sm.oauth_remotes[provider].authorize(
+                        callback=url_for
+                            ('.oauth_authorized', provider=provider, _external=True),
+                            state=state)
             except Exception as e:
                 log.error("Error on OAuth authorize: {0}".format(e))
                 flash(as_unicode(self.invalid_login_message), 'warning')

--- a/flask_appbuilder/templates/appbuilder/general/security/login_oauth.html
+++ b/flask_appbuilder/templates/appbuilder/general/security/login_oauth.html
@@ -7,7 +7,7 @@
 
 var baseLoginUrl = "{{url_for('AuthOAuthView.login')}}";
 var baseRegisterUrl = "{{url_for('AuthOAuthView.login')}}";
-var next = "?next={{request.args.get('next')}}"
+var next = "?next={{request.args.get('next', '')}}"
 
 var currentSelection = "";
 

--- a/flask_appbuilder/templates/appbuilder/general/security/login_oauth.html
+++ b/flask_appbuilder/templates/appbuilder/general/security/login_oauth.html
@@ -5,8 +5,9 @@
 
 <script type="text/javascript">
 
-var baseLoginUrl = {{url_for('AuthOAuthView.login')}};
-var baseRegisterUrl = {{url_for('AuthOAuthView.login')}};
+var baseLoginUrl = "{{url_for('AuthOAuthView.login')}}";
+var baseRegisterUrl = "{{url_for('AuthOAuthView.login')}}";
+var next = "?next={{request.args.get('next')}}"
 
 var currentSelection = "";
 
@@ -20,13 +21,13 @@ function set_openid(url, pr)
 
 function signin() {
     if (currentSelection != "") {
-        window.location.href = baseLoginUrl + currentSelection;
+        window.location.href = baseLoginUrl + currentSelection + next;
     }
 }
 
 function register() {
     if (currentSelection != "") {
-        window.location.href = baseRegisterUrl + currentSelection + '/register';
+        window.location.href = baseRegisterUrl + currentSelection + '/register' + next;
     }
 }
 

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -8,3 +8,4 @@ Flask-Login>=0.3,<0.5
 Flask-OpenID>=1.2.5,<2
 Flask-SQLAlchemy>=2.3,<3
 Flask-WTF>=0.14.2,<1
+PyJWT>=1.7.1

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'Flask-SQLAlchemy>=2.3,<3',
         'Flask-WTF>=0.14.2,<1',
         'python-dateutil>=2.3,<3',
+        'PyJWT>=1.7.1',
     ],
     tests_require=[
         'nose>=1.0',


### PR DESCRIPTION
Currently, after a user goes through the authentication flow they are sent to the index page, instead of the page they tried to visit initially.

I improved the flow by storing the initial URL in a `state` parameter, that is signed and sent to the OAuth provider [[see docs](https://auth0.com/docs/protocols/oauth2/oauth-state)]. One the user has been authenticated, the `state` parameter received back from the provider is used to redirect them to the initial URL.

Note that the `state` is signed, to avoid a malicious provider of redirecting the user to a URL they control.

I tested the workflow with Superset, and it works as expected. I only tested with Google OAuth.