### PR TITLE
[Fix] SQLAlchemy enabling the pre-ping feature

### DIFF
--- a/flask_appbuilder/models/sqla/__init__.py
+++ b/flask_appbuilder/models/sqla/__init__.py
@@ -44,6 +44,11 @@ class SQLA(SQLAlchemy):
                 result.append(tables[key])
         return result
 
+    def apply_pool_defaults(self, app, options):
+        """Apply the connection pool defaults enabling the 'pre-ping' feature."""
+        super(SQLA, self).apply_pool_defaults(app, options)
+        options['pool_pre_ping'] = True
+
 
 class ModelDeclarativeMeta(DefaultMeta):
     """
@@ -87,4 +92,3 @@ class Model(object):
     This is for retro compatibility
 """
 Base = Model
-


### PR DESCRIPTION
This PR attempts to resolve the "MySQL server has gone away" which is caused by an idle timeout. This was raised in Fixes https://github.com/dpgaspar/Flask-AppBuilder/issues/672 and we've also noticed it in our Superset deployment which uses Flask-AppBuilder. 

The solution is based on enabling the SQLAlchemy "pre-ping" feature which was suggested [here](https://stackoverflow.com/a/45078959) and uses the pattern [here](https://github.com/mitsuhiko/flask-sqlalchemy/issues/589) for extending the Flask SQLAlchemy class. Note we've seen this issue with other Flask applications and this proposed fix seems to remedy the problem.

Fixes https://github.com/dpgaspar/Flask-AppBuilder/issues/672

to: @dpgaspar @mistercrunch 