### PR TITLE
[api] Fix, M-M fields are always required, now default to not required #947

### DIFF
--- a/flask_appbuilder/api/convert.py
+++ b/flask_appbuilder/api/convert.py
@@ -17,6 +17,7 @@ class Tree:
     """
         Simplistic one level Tree
     """
+
     def __init__(self):
         self.root = TreeNode('+')
 
@@ -132,6 +133,7 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
                 many = False
             elif datamodel.is_relation_many_to_many(column.data):
                 many = True
+                required = False
             else:
                 many = False
             field = fields.Nested(nested_schema, many=many, required=required)
@@ -139,7 +141,14 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
             return field
         # Handle bug on marshmallow-sqlalchemy #163
         elif datamodel.is_relation(column.data):
-            required = not datamodel.is_nullable(column.data)
+            if (datamodel.is_relation_many_to_many(column.data) or
+                    datamodel.is_relation_one_to_many(column.data)):
+                if datamodel.get_info(column.data).get('required', False):
+                    required = True
+                else:
+                    required = False
+            else:
+                required = not datamodel.is_nullable(column.data)
             field = field_for(_model, column.data)
             field.required = required
             field.unique = datamodel.is_unique(column.data)

--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -525,6 +525,10 @@ class SQLAInterface(BaseInterface):
                 if model == self.get_related_model(col_name):
                     return col_name
 
+    def get_info(self, col_name):
+        if col_name in self.list_properties:
+            return self.list_properties[col_name].info
+        return {}
     """
     -------------
      GET METHODS

--- a/flask_appbuilder/tests/sqla/models.py
+++ b/flask_appbuilder/tests/sqla/models.py
@@ -98,6 +98,33 @@ class ModelMMChild(Model):
     id = Column(Integer, primary_key=True)
     field_string = Column(String(50), unique=True, nullable=False)
 
+
+assoc_parent_child_required = Table(
+    "parent_child_required",
+    Model.metadata,
+    Column("id", Integer, primary_key=True),
+    Column("parent_id", Integer, ForeignKey("parent_required.id")),
+    Column("child_id", Integer, ForeignKey("child_required.id")),
+    UniqueConstraint("parent_id", "child_id"),
+)
+
+
+class ModelMMParentRequired(Model):
+    __tablename__ = "parent_required"
+    id = Column(Integer, primary_key=True)
+    field_string = Column(String(50), unique=True, nullable=False)
+    children = relationship(
+        "ModelMMChildRequired",
+        secondary=assoc_parent_child_required,
+        info={"required": True}
+    )
+
+
+class ModelMMChildRequired(Model):
+    __tablename__ = "child_required"
+    id = Column(Integer, primary_key=True)
+    field_string = Column(String(50), unique=True, nullable=False)
+
     """ ---------------------------------
             TEST HELPER FUNCTIONS
         ---------------------------------
@@ -130,15 +157,29 @@ def insert_data(session, count):
         session.commit()
 
     children = list()
+    children_required = list()
     for i in range(1, 4):
         model = ModelMMChild()
         model.field_string = str(i)
         children.append(model)
         session.add(model)
         session.commit()
+
+        model = ModelMMChildRequired()
+        model.field_string = str(i)
+        children_required.append(model)
+        session.add(model)
+        session.commit()
+
     for i in range(count):
         model = ModelMMParent()
         model.field_string = str(i)
         model.children = children
+        session.add(model)
+        session.commit()
+
+        model = ModelMMParentRequired()
+        model.field_string = str(i)
+        model.children = children_required
         session.add(model)
         session.commit()


### PR DESCRIPTION
Fixes #947

- M-M fields will default to not required
- Possible to add on the info dictionary a required flag

``` python
    tags = relationship("Tag", secondary=assoc_contact_tag, backref="contact", info={'required': True})
```
