### PR TITLE
New, version 1.14.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,16 @@
 Flask-AppBuilder ChangeLog
 ==========================
 
-Improvements and Bug fixes on 1.13.1
+Improvements and Bug fixes on 1.14.0
 ------------------------------------
 
+- Fix, #951 M-M fields are always required, now they default to not required with optional required flag on col info dict
 - Fix, #885 list view ordering problem of related model with dotted notation, fixes #884
+- Fix, #946 Factory app pattern
+- (DEPRECATION) New, command line integrated with Flask cli, fabmanager is deprecated and will be removed on 1.16.X
+- New, config key, FAB_SECURITY_MANAGER_CLASS to declare custom SecurityManager classes.
+- New, sub command 'create-permissions' to create all permissions when update_perms is False.
+- New, config key, FAB_UPDATE_PERMS to flag FAB to update or not update permissions.
 
 Improvements and Bug fixes on 1.13.0
 ------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,8 @@ Change Log
 
 `Versions <https://github.com/dpgaspar/Flask-AppBuilder/tree/master/CHANGELOG.rst>`_ for further detail on what changed.
 
+Since 1.14.0 that `fabmanager` command line is considered **deprecated**, use the new `flask fab <command>` instead
+
 Fixes, Bugs and contributions
 -----------------------------
 

--- a/flask_appbuilder/__init__.py
+++ b/flask_appbuilder/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Daniel Vaz Gaspar"
-__version__ = '1.13.0'
+__version__ = '1.14.0'
 
 from .actions import action  # noqa: F401
 from .api import ModelRestApi  # noqa: F401

--- a/flask_appbuilder/console.py
+++ b/flask_appbuilder/console.py
@@ -23,7 +23,7 @@ except ImportError:
     from urllib2 import urlopen
 
 click.echo(click.style("fabmanager is going to be deprecated in 1.16.X, you can use "
-           " the same commands on the improved 'flask fab <command>'", fg="red"))
+           "the same commands on the improved 'flask fab <command>'", fg="red"))
 
 SQLA_REPO_URL = (
     "https://github.com/dpgaspar/Flask-AppBuilder-Skeleton/archive/master.zip"


### PR DESCRIPTION
New 1.14.0

Improvements and Bug fixes on 1.14.0
------------------------------------

- Fix, #951 M-M fields are always required, now they default to not required with optional required flag on col info dict
- Fix, #885 list view ordering problem of related model with dotted notation, fixes #884
- Fix, #946 Factory app pattern
- (DEPRECATION) New, command line integrated with Flask cli, fabmanager is deprecated and will be removed on 1.16.X
- New, config key, FAB_SECURITY_MANAGER_CLASS to declare custom SecurityManager classes.
- New, sub command 'create-permissions' to create all permissions when update_perms is False.
- New, config key, FAB_UPDATE_PERMS to flag FAB to update or not update permissions.

