### PR TITLE
New, [views] add edit button to show page

### DIFF
--- a/flask_appbuilder/templates/appbuilder/general/widgets/show.html
+++ b/flask_appbuilder/templates/appbuilder/general/widgets/show.html
@@ -2,6 +2,8 @@
 {% include 'appbuilder/general/confirm.html' %}
 {% include 'appbuilder/general/alert.html' %}
 
+{% set can_edit = "can_edit" | is_item_visible(modelview_name) %}
+
 {% if fieldsets %}
 
     {% for fieldset_item in fieldsets %}
@@ -44,4 +46,7 @@
 <div class="well well-sm">
     {{ lib.render_action_links(actions, pk, modelview_name) }}
     {{ lib.lnk_back() }}
+    {% if can_edit %}
+        {{ lib.lnk_edit(url_for(modelview_name + '.edit',pk=pk)) }}
+    {% endif %}
 </div>


### PR DESCRIPTION
Fixes a minor UX issue where a user might:

* open an entry
* decide they want to edit or delete it
* hit the back button so they can do so, then have to find the entry again

Unfortunately this introduces a non-trivial issue by not redirecting to the list page after an entry is deleted. Additionally, it is only implemented for one of the show views, even though it is likely needed for multiple.