### PR TITLE
Fix: change the default email value for auth_remote_user in security manager

### DIFF
--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -947,7 +947,7 @@ class BaseSecurityManager(AbstractSecurityManager):
                 username=username,
                 first_name=username,
                 last_name="-",
-                email="-",
+                email=username + '@email.notfound',
                 role=self.find_role(self.auth_user_registration_role),
             )
 


### PR DESCRIPTION
The ab_user SQL table may have a unique constraint for the
'email' attribute, leading to failures while inserting data
for a new user registration. Changing the default to a
unique value should fix the problem.

Issue: #965
