### PR TITLE
New: Add logging options for ldap

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -63,6 +63,19 @@ Use config.py to configure the following parameters. By default it will use SQLL
 +-----------------------------------+--------------------------------------------+-----------+
 | AUTH_LDAP_TLS_KEYFILE             | Certificate key file for client aut        |   No      |
 +-----------------------------------+--------------------------------------------+-----------+
+| AUTH_LDAP_TRACE_LEVEL             | The amount of information being logged.    |   No      |
+|                                   | Possible values for trace_level are 0 for  |           |
+|                                   | no logging, 1 for only logging the method  |           |
+|                                   | calls with arguments, 2 for logging the    |           |
+|                                   | method calls with arguments and the        |           |
+|                                   | complete results and 9 for also logging    |           |
+|                                   | the traceback of method calls. Default = 0 |           |
++-----------------------------------+--------------------------------------------+-----------+
+| AUTH_LDAP_TRACE_FILE              | A file-like object as target of the debug  |   No      |
+|                                   | log. Default: sys.stdout                   |           |
++-----------------------------------+--------------------------------------------+-----------+
+| AUTH_LDAP_TRACE_STACK_LIMIT       | The stack limit of tracebacks in debug log |   No      |
++-----------------------------------+--------------------------------------------+-----------+
 | AUTH_LDAP_SEARCH                  | Use search with self user                  |   No      |
 |                                   | registration or when using                 |           |
 |                                   | AUTH_LDAP_BIND_USER.                       |           |

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -895,7 +895,8 @@ class BaseSecurityManager(AbstractSecurityManager):
                 con = ldap.initialize(self.auth_ldap_server,
                                       trace_level=self.auth_ldap_trace_level,
                                       trace_file=self.auth_ldap_trace_file,
-                                      trace_stack_limit=self.auth_ldap_trace_stack_limit)
+                                      trace_stack_limit=self.auth_ldap_trace_stack_limit,
+                                      )
                 con.set_option(ldap.OPT_REFERRALS, 0)
                 if self.auth_ldap_use_tls:
                     try:

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import logging
 import re
+import sys
 from typing import Dict, List
 
 from flask import g, session, url_for
@@ -237,6 +238,9 @@ class BaseSecurityManager(AbstractSecurityManager):
             app.config.setdefault("AUTH_LDAP_TLS_CACERTFILE", "")
             app.config.setdefault("AUTH_LDAP_TLS_CERTFILE", "")
             app.config.setdefault("AUTH_LDAP_TLS_KEYFILE", "")
+            app.config.setdefault("AUTH_LDAP_TRACE_LEVEL", 0)
+            app.config.setdefault("AUTH_LDAP_TRACE_FILE", sys.stdout)
+            app.config.setdefault("AUTH_LDAP_TRACE_STACK_LIMIT", None)
             # Mapping options
             app.config.setdefault("AUTH_LDAP_UID_FIELD", "uid")
             app.config.setdefault("AUTH_LDAP_FIRSTNAME_FIELD", "givenName")
@@ -410,6 +414,18 @@ class BaseSecurityManager(AbstractSecurityManager):
     @property
     def auth_ldap_tls_keyfile(self):
         return self.appbuilder.get_app.config["AUTH_LDAP_TLS_KEYFILE"]
+
+    @property
+    def auth_ldap_trace_level(self):
+        return self.appbuilder.get_app.config["AUTH_LDAP_TRACE_LEVEL"]
+
+    @property
+    def auth_ldap_trace_file(self):
+        return self.appbuilder.get_app.config["AUTH_LDAP_TRACE_FILE"]
+
+    @property
+    def auth_ldap_trace_stack_limit(self):
+        return self.appbuilder.get_app.config["AUTH_LDAP_TRACE_STACK_LIMIT"]
 
     @property
     def openid_providers(self):
@@ -876,7 +892,10 @@ class BaseSecurityManager(AbstractSecurityManager):
                         ldap.OPT_X_TLS_CERTFILE, self.auth_ldap_tls_certfile
                     )
                     ldap.set_option(ldap.OPT_X_TLS_KEYFILE, self.auth_ldap_tls_keyfile)
-                con = ldap.initialize(self.auth_ldap_server)
+                con = ldap.initialize(self.auth_ldap_server,
+                                      trace_level=self.auth_ldap_trace_level,
+                                      trace_file=self.auth_ldap_trace_file,
+                                      trace_stack_limit=self.auth_ldap_trace_stack_limit)
                 con.set_option(ldap.OPT_REFERRALS, 0)
                 if self.auth_ldap_use_tls:
                     try:


### PR DESCRIPTION
Currently FAB does not support logging for LDAP, making it difficult to identify problems during configuration. This PR adds trace options to `ldap.initialize()` call for logging as described here: https://www.python-ldap.org/en/latest/reference/ldap.html#ldap.initialize