### PR TITLE
New, [views] add edit button to show page

### DIFF
--- a/flask_appbuilder/security/views.py
+++ b/flask_appbuilder/security/views.py
@@ -225,12 +225,6 @@ class UserModelView(ModelView):
             appbuilder=self.appbuilder,
         )
 
-    @action("userinfoedit", lazy_gettext("Edit User"), "", "fa-edit", multiple=False)
-    def userinfoedit(self, item):
-        return redirect(
-            url_for(self.appbuilder.sm.userinfoeditview.__name__ + ".this_form_get")
-        )
-
 
 class UserOIDModelView(UserModelView):
     """
@@ -334,7 +328,6 @@ class UserDBModelView(UserModelView):
     def userinfo(self):
         actions = dict()
         actions["resetmypassword"] = self.actions.get("resetmypassword")
-        actions["userinfoedit"] = self.actions.get("userinfoedit")
 
         item = self.datamodel.get(g.user.id, self._base_filters)
         widgets = self._get_show_widget(

--- a/flask_appbuilder/templates/appbuilder/general/widgets/show.html
+++ b/flask_appbuilder/templates/appbuilder/general/widgets/show.html
@@ -2,6 +2,8 @@
 {% include 'appbuilder/general/confirm.html' %}
 {% include 'appbuilder/general/alert.html' %}
 
+{% set can_edit = "can_edit" | is_item_visible(modelview_name) %}
+
 {% if fieldsets %}
 
     {% for fieldset_item in fieldsets %}
@@ -44,4 +46,7 @@
 <div class="well well-sm">
     {{ lib.render_action_links(actions, pk, modelview_name) }}
     {{ lib.lnk_back() }}
+    {% if can_edit %}
+        {{ lib.lnk_edit(url_for(modelview_name + '.edit',pk=pk)) }}
+    {% endif %}
 </div>


### PR DESCRIPTION
Fixes a minor UX issue where a user might:

* open an entry
* decide they want to edit it
* hit the back button so they can do so, then have to find the entry again