### PR TITLE
Fix: lack of @expose decorator in rest api example

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -16,6 +16,7 @@ custom API endpoints::
 
 
     class ExampleApi(BaseApi):
+        @expose('/gretting')
         def greeting(self):
             return self.response(200, message="Hello")
 


### PR DESCRIPTION
The first REST API doesn't work if @expose decorator is missed.
So add it back into this doc, and it won't make readers like me confused.