### PR TITLE
[docs] Fix, lack of @expose decorator in rest api example

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -16,6 +16,7 @@ custom API endpoints::
 
 
     class ExampleApi(BaseApi):
+        @expose('/greeting')
         def greeting(self):
             return self.response(200, message="Hello")
 


### PR DESCRIPTION
The first REST API doesn't work if @expose decorator is missed.
So add it back into this doc, and it won't make readers like me confused.


Thank you for contributing to Flask-Appbuilder. 

For Fixes:

Please, prefix the title with "Fix, " and describe in detail what you're fixing and the steps required to reproduce the problem.

For new features:

Please, prefix the title with "New, " and describe this new feature in detail, remember to update documentation.

