### PR TITLE
Bump FAB to 2.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Flask-AppBuilder ChangeLog
 ==========================
 
+Improvements and Bug fixes on 2.1.1
+-----------------------------------
+
+- Fix, #991 Make Admin builtin optional, only if declared on config
+
 Improvements and Bug fixes on 2.1.0
 -----------------------------------
 

--- a/flask_appbuilder/__init__.py
+++ b/flask_appbuilder/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Daniel Vaz Gaspar"
-__version__ = '2.1.0'
+__version__ = '2.1.1'
 
 from .actions import action  # noqa: F401
 from .api import ModelRestApi  # noqa: F401


### PR DESCRIPTION
New 2.1.1

- Fix, #991 Make Admin builtin optional, only if declared on config

