### PR TITLE
New, version 2.1.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Flask-AppBuilder ChangeLog
 ==========================
 
+Improvements and Bug fixes on 2.1.2
+-----------------------------------
+
+- Fix, #993 App factory pattern, AppBuilder object can be fully configured using config keys
+- Fix, #994 If builtin role don't check db also, higher permission on DB would allow access
+
 Improvements and Bug fixes on 2.1.1
 -----------------------------------
 

--- a/flask_appbuilder/__init__.py
+++ b/flask_appbuilder/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Daniel Vaz Gaspar"
-__version__ = '2.1.1'
+__version__ = '2.1.2'
 
 from .actions import action  # noqa: F401
 from .api import ModelRestApi  # noqa: F401


### PR DESCRIPTION
New 2.1.1

- Fix, #993 App factory pattern, AppBuilder object can be fully configured using config keys
- Fix, #994 If builtin role don't check db also, higher permission on DB would allow access
