### PR TITLE
Fix, docs for overwriting show template is wrong

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -288,23 +288,23 @@ To insert your template section before the a block, say "show_form" just create 
 
 ::
 
-    {% extends "appbuilder/general/model/edit.html" %}
+    {% extends "appbuilder/general/model/show.html" %}
 
         {% block show_form %}
             This Text is before the show widget
             {{ super() }}
         {% endblock %}
 
-To use your template define you ModelView with **edit_template** declaration to your templates relative path
+To use your template define you ModelView with **show_template** declaration to your templates relative path
 
-If you have your template on ./your_project/app/templates/edit_contacts.html
+If you have your template on ./your_project/app/templates/show_contacts.html
 
 ::
 
     class ContactModelView(ModelView):
         datamodel = SQLAInterface(Contact)
 
-        edit_template = 'edit_contacts.html'
+        show_template = 'show_contacts.html'
 
 
 Edit/Show Cascade Templates


### PR DESCRIPTION
The docs for overwriting the show template say `edit` instead of `show`.


Thank you for contributing to Flask-Appbuilder. 

For Fixes:

Please, prefix the title with "Fix, " and describe in detail what you're fixing and the steps required to reproduce the problem.

For new features:

Please, prefix the title with "New, " and describe this new feature in detail, remember to update documentation.

