### PR TITLE
[api] New, support custom property fields

### DIFF
--- a/flask_appbuilder/api/convert.py
+++ b/flask_appbuilder/api/convert.py
@@ -167,6 +167,10 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
             field = EnumField(enum_class, dump_by=enum_dump_by, required=required)
             field.unique = datamodel.is_unique(column.data)
             return field
+        # is custom property method field?
+        if hasattr(getattr(_model, column.data), 'fget'):
+            return fields.Str(dump_only=True)
+        # is a normal model field not a function?
         if not hasattr(getattr(_model, column.data), '__call__'):
             field = field_for(_model, column.data)
             field.unique = datamodel.is_unique(column.data)

--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -114,7 +114,11 @@ class SQLAInterface(BaseInterface):
                         Load(model_relation).load_only(column.split(".")[1])
                     )
                 else:
-                    if not self.is_relation(column) and not hasattr(
+                    # is a custom property method field?
+                    if hasattr(getattr(self.obj, column), "fget"):
+                        pass
+                    # is not a relation and not a function?
+                    elif not self.is_relation(column) and not hasattr(
                         getattr(self.obj, column), "__call__"
                     ):
                         _load_options.append(Load(self.obj).load_only(column))

--- a/flask_appbuilder/tests/sqla/models.py
+++ b/flask_appbuilder/tests/sqla/models.py
@@ -65,6 +65,15 @@ class Model3(Model):
         return str(self.field_string)
 
 
+class ModelWithProperty(Model):
+    id = Column(Integer, primary_key=True)
+    field_string = Column(String(50), unique=True, nullable=False)
+
+    @property
+    def custom_property(self):
+        return self.field_string + "_custom"
+
+
 class TmpEnum(enum.Enum):
     e1 = "a"
     e2 = 2
@@ -181,5 +190,11 @@ def insert_data(session, count):
         model = ModelMMParentRequired()
         model.field_string = str(i)
         model.children = children_required
+        session.add(model)
+        session.commit()
+
+    for i in range(count):
+        model = ModelWithProperty()
+        model.field_string = str(i)
         session.add(model)
         session.commit()


### PR DESCRIPTION
Support for custom property fields on ``ModelRestApi``

support SQLA Model fields like:
```
class SomeModel(Model):
    ....
    @property
    def some_property(self):
        return "some"
