### PR TITLE
New: Adds sqlalchemy_utils.types.uuid.UUIDType support to String fields

### DIFF
--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -7,6 +7,7 @@ from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Load
 from sqlalchemy.orm.descriptor_props import SynonymProperty
+from sqlalchemy_utils.types.uuid import UUIDType
 
 from . import filters
 from ..base import BaseInterface
@@ -215,7 +216,8 @@ class SQLAInterface(BaseInterface):
 
     def is_string(self, col_name):
         try:
-            return _is_sqla_type(self.list_columns[col_name].type, sa.types.String)
+            return _is_sqla_type(self.list_columns[col_name].type, sa.types.String) or \
+                self.list_columns[col_name].type.__class__ == UUIDType
         except Exception:
             return False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ pyyaml==5.1               # via apispec
 requests==2.21.0          # via prison
 six==1.12.0               # via flask-jwt-extended, jsonschema, prison, pyrsistent, python-dateutil
 sqlalchemy==1.3.1         # via flask-sqlalchemy, marshmallow-sqlalchemy
+sqlalchemy-utils==0.33.9
 urllib3==1.24.1           # via requests
 werkzeug==0.14.1          # via flask, flask-jwt-extended
 wtforms==2.2.1            # via flask-wtf

--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,9 @@ setup(
         'marshmallow-enum>=1.4.1,<2',
         'marshmallow-sqlalchemy>=0.16.1<1',
         'python-dateutil>=2.3,<3',
-        'prison>=0.1.0<1.0.0'
-        'PyJWT>=1.7.1'
+        'prison>=0.1.0<1.0.0',
+        'PyJWT>=1.7.1',
+        'sqlalchemy-utils>=0.33.9'
     ],
     tests_require=[
         'nose>=1.0',


### PR DESCRIPTION
Fixes #1009.

I need to add a `sqlalchemy_utils.types.uuid.UUIDType` field to Superset and have it work with `Flask-AppBuilder`. We are adding a uuid field to `superset.models.helpers.ImportMixin` to help import/export unique assets without the IDs clobbering one another or getting confused.

```python
class ImportMixin(object):
    export_parent = None
    # The name of the attribute
    # with the SQL Alchemy back reference

    export_children = []
    # List of (str) names of attributes
    # with the SQL Alchemy forward references

    export_fields = []
    # The names of the attributes
    # that are available for import and export

    uuid = sa.Column(UUIDType(binary=False), unique=True, default=uuid.uuid4) 

...

class Slice(Model, AuditMixinNullable, ImportMixin):

    """A slice is essentially a report or a view on data"""
    # Now I have a uuid field!
```

At the moment errors are thrown because the uuid field does not return is_string (it is a CHAR(32) unless a UUID type is present), as it does not turn up in models.sqla.interface._is_sqla_type. A 'Column uuid Type not supported` error will be thrown when the view tries to render, and this gives Mad Max the sad face :(

```bash
superset examples

2019-05-19 09:48:40,026:ERROR:flask_appbuilder.forms:Column uuid Type not supported
2019-05-19 09:48:40,047:ERROR:flask_appbuilder.forms:Column uuid Type not supported
2019-05-19 09:48:40,111:ERROR:flask_appbuilder.forms:Column uuid Type not supported
2019-05-19 09:48:40,133:ERROR:flask_appbuilder.forms:Column uuid Type not supported
2019-05-19 09:48:40,156:ERROR:flask_appbuilder.forms:Column uuid Type not supported
2019-05-19 09:48:40,172:ERROR:flask_appbuilder.forms:Column uuid Type not supported
2019-05-19 09:48:40,190:ERROR:flask_appbuilder.forms:Column uuid Type not supported
2019-05-19 09:48:40,206:ERROR:flask_appbuilder.forms:Column uuid Type not supported
2019-05-19 09:48:40,647:ERROR:flask_appbuilder.forms:Column uuid Type not supported
2019-05-19 09:48:40,663:ERROR:flask_appbuilder.forms:Column uuid Type not supported
```
