### PR TITLE
Fix, Pull back more user details from Github API

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -488,6 +488,19 @@ key is just the configuration for flask-oauthlib::
                 'request_token_url':None,
                 'access_token_url':'https://accounts.google.com/o/oauth2/token',
                 'authorize_url':'https://accounts.google.com/o/oauth2/auth'}
+        },
+        # NB: When using Github Enterprise - the base_url will become http(s)://<your_enterprise_domain>/api/v3
+        {'name':'github', 'icon':'fa-google', 'token_key':'access_token',
+            'remote_app': {
+                'consumer_key':'GITHUB_KEY',
+                'consumer_secret':'GITHUB SECRET',
+                'base_url':'https://api.github.com',
+                'request_token_params':{
+                  'scope': 'read:user,user:email'
+                },
+                'request_token_url':None,
+                'access_token_url':'https://GITHUB_DOMAIN/login/oauth/access_token',
+                'authorize_url':'https://GITHUB_DOMAIN/login/oauth/authorize'}
         }
     ]
 

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -497,7 +497,28 @@ class BaseSecurityManager(AbstractSecurityManager):
         if provider == "github" or provider == "githublocal":
             me = self.appbuilder.sm.oauth_remotes[provider].get("user")
             log.debug("User info from Github: {0}".format(me.data))
-            return {"username": "github_" + me.data.get("login")}
+            email = me.data.get("email")
+
+            if not email:
+                emails = self.appbuilder.sm.oauth_remotes[provider].get("user/emails")
+                email = emails.data[0].get("email")
+
+            name = me.data.get("name:", "no-name given")
+            name_parts = name.split(" ")
+
+            if name_parts > 1:
+                first_name = name_parts[0]
+                last_name = name_parts[-1]
+            else:
+                first_name = name
+                last_name = ""
+
+            return {
+                "username": "github_" + me.data.get("login"),
+                "email": email,
+                "first_name": first_name,
+                "last_name": last_name
+            }
         # for twitter
         if provider == "twitter":
             me = self.appbuilder.sm.oauth_remotes[provider].get("account/settings.json")


### PR DESCRIPTION
Defaulting to empty strings for emails results in the some applications
that use FAB to reject users with the same empty email address.

When trying to use Airflow (which uses FAB for RBAC) when you have more than one user register via Github OAuth it fails due to returning an empty string instead of an email. This pull request aims to bring the Github userinfo in line with some of the other providers. It adds in first name, last name and email. 

Since the email returned by /user is the public email, it might be None. Lines 501 - 503 are used to return the first private email 

Github doesn't make names mandatory - so if there's no name available it will use a placeholder value or just set the first name if that's all that's available 

Requires: 'read:user' and 'user:email' scopes to work reliably. 
