### PR TITLE
[api] Fix, api dotted notation joins to same table

### DIFF
--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -95,6 +95,20 @@ class SQLAInterface(BaseInterface):
                 query = query.order_by(self._get_attr(order_column).desc())
         return query
 
+    def _query_join_dotted_column(self, query, column) -> (object, tuple):
+        relation_tuple = tuple()
+        if len(column.split('.')) >= 2:
+            for join_relation in column.split('.')[:-1]:
+                relation_tuple = self.get_related_model_and_join(join_relation)
+                model_relation, relation_join = relation_tuple
+                if not self.is_model_already_joined(query, model_relation):
+                    query = query.join(
+                        model_relation,
+                        relation_join,
+                        isouter=True
+                    )
+        return query, relation_tuple
+
     def _query_select_options(self, query, select_columns=None):
         """
             Add select load options to query. The goal
@@ -107,16 +121,12 @@ class SQLAInterface(BaseInterface):
         if select_columns:
             _load_options = list()
             for column in select_columns:
-                if len(column.split('.')) >= 2:
-                    for join_relation in column.split('.')[:-1]:
-                        relation_tuple = self.get_related_model_and_join(join_relation)
-                        model_relation, relation_join = relation_tuple
-                        if not self.is_model_already_joined(query, model_relation):
-                            query = query.join(
-                                model_relation,
-                                relation_join,
-                                isouter=True
-                            )
+                query, relation_tuple = self._query_join_dotted_column(
+                    query,
+                    column,
+                )
+                model_relation, relation_join = relation_tuple or (None, None)
+                if model_relation:
                     _load_options.append(
                         Load(model_relation).load_only(column.split(".")[1])
                     )
@@ -159,12 +169,7 @@ class SQLAInterface(BaseInterface):
         """
         query = self.session.query(self.obj)
         query = self._query_select_options(query, select_columns)
-        if len(order_column.split('.')) >= 2:
-            for join_relation in order_column.split('.')[:-1]:
-                relation_tuple = self.get_related_model_and_join(join_relation)
-                model_relation, relation_join = relation_tuple
-                if not self.is_model_already_joined(query, model_relation):
-                    query = query.join(model_relation, relation_join, isouter=True)
+        query, relation_tuple = self._query_join_dotted_column(query, order_column)
         query_count = self.session.query(func.count('*')).select_from(self.obj)
 
         query_count = self._get_base_query(query=query_count, filters=filters)

--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -101,15 +101,12 @@ class SQLAInterface(BaseInterface):
             for join_relation in column.split('.')[:-1]:
                 relation_tuple = self.get_related_model_and_join(join_relation)
                 model_relation, relation_join = relation_tuple
-                print(f"MODEL {model_relation} {relation_join}")
                 if not self.is_model_already_joined(query, model_relation):
                     query = query.join(
                         model_relation,
                         relation_join,
                         isouter=True
                     )
-                else:
-                    print(f"ALREADY JOINED")
         return query, relation_tuple
 
     def _query_select_options(self, query, select_columns=None):

--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -101,12 +101,15 @@ class SQLAInterface(BaseInterface):
             for join_relation in column.split('.')[:-1]:
                 relation_tuple = self.get_related_model_and_join(join_relation)
                 model_relation, relation_join = relation_tuple
+                print(f"MODEL {model_relation} {relation_join}")
                 if not self.is_model_already_joined(query, model_relation):
                     query = query.join(
                         model_relation,
                         relation_join,
                         isouter=True
                     )
+                else:
+                    print(f"ALREADY JOINED")
         return query, relation_tuple
 
     def _query_select_options(self, query, select_columns=None):
@@ -168,8 +171,8 @@ class SQLAInterface(BaseInterface):
 
         """
         query = self.session.query(self.obj)
-        query = self._query_select_options(query, select_columns)
         query, relation_tuple = self._query_join_dotted_column(query, order_column)
+        query = self._query_select_options(query, select_columns)
         query_count = self.session.query(func.count('*')).select_from(self.obj)
 
         query_count = self._get_base_query(query=query_count, filters=filters)

--- a/flask_appbuilder/tests/sqla/models.py
+++ b/flask_appbuilder/tests/sqla/models.py
@@ -78,6 +78,18 @@ class Model3(Model):
         return str(self.field_string)
 
 
+class Model4(Model):
+    id = Column(Integer(), primary_key=True)
+    field_string = Column(String(50), unique=True, nullable=False)
+    model1_1_id = Column(Integer, ForeignKey("model1.id"), nullable=False)
+    model1_1 = relationship("Model1", foreign_keys=[model1_1_id])
+    model1_2_id = Column(Integer, ForeignKey("model1.id"), nullable=False)
+    model1_2 = relationship("Model1", foreign_keys=[model1_2_id])
+
+    def __repr__(self):
+        return str(self.field_string)
+
+
 class ModelWithProperty(Model):
     id = Column(Integer, primary_key=True)
     field_string = Column(String(50), unique=True, nullable=False)
@@ -155,6 +167,7 @@ class ModelMMChildRequired(Model):
 
 def insert_data(session, count):
     model1_collection = list()
+    # Fill model1
     for i in range(count):
         model = Model1()
         model.field_string = "test{}".format(i)
@@ -163,6 +176,7 @@ def insert_data(session, count):
         session.add(model)
         session.commit()
         model1_collection.append(model)
+    # Fill model2
     for i in range(count):
         model = Model2()
         model.field_string = "test{}".format(i)
@@ -171,10 +185,19 @@ def insert_data(session, count):
         model.group = model1_collection[i]
         session.add(model)
         session.commit()
+    # Fill model with enums
     for i in range(count):
         model = ModelWithEnums()
         model.enum1 = "e1"
         model.enum2 = TmpEnum.e2
+        session.add(model)
+        session.commit()
+    # Fill Model4
+    for i in range(count):
+        model = Model4()
+        model.field_string = "test{}".format(i)
+        model.model1_1 = model1_collection[i]
+        model.model1_2 = model1_collection[i]
         session.add(model)
         session.commit()
 

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -2,9 +2,7 @@ import json
 import logging
 import os
 
-from flask_appbuilder import ModelRestApi
-from flask_appbuilder.models.sqla.interface import SQLAInterface
-from flask_appbuilder import SQLA
+from flask_appbuilder import ModelRestApi, SQLA
 from flask_appbuilder.const import (
     API_ADD_COLUMNS_RES_KEY,
     API_ADD_COLUMNS_RIS_KEY,
@@ -32,6 +30,7 @@ from flask_appbuilder.const import (
     API_URI_RIS_KEY,
 )
 from flask_appbuilder.models.sqla.filters import FilterGreater, FilterSmaller
+from flask_appbuilder.models.sqla.interface import SQLAInterface
 from nose.tools import eq_
 import prison
 

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -2,6 +2,8 @@ import json
 import logging
 import os
 
+from flask_appbuilder import ModelRestApi
+from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder import SQLA
 from flask_appbuilder.const import (
     API_ADD_COLUMNS_RES_KEY,
@@ -27,7 +29,7 @@ from flask_appbuilder.const import (
     API_SELECT_KEYS_RIS_KEY,
     API_SHOW_COLUMNS_RIS_KEY,
     API_SHOW_TITLE_RIS_KEY,
-    API_URI_RIS_KEY
+    API_URI_RIS_KEY,
 )
 from flask_appbuilder.models.sqla.filters import FilterGreater, FilterSmaller
 from nose.tools import eq_
@@ -38,13 +40,14 @@ from .sqla.models import (
     insert_data,
     Model1,
     Model2,
+    Model4,
     ModelMMChild,
     ModelMMParent,
     ModelMMParentRequired,
     ModelWithEnums,
     ModelWithProperty,
     TmpEnum,
-    validate_name
+    validate_name,
 )
 
 
@@ -756,6 +759,71 @@ class APITestCase(FABTestCase):
         eq_(
             data[API_RESULT_RES_KEY][i],
             {'field_string': 'test9', 'group': {'field_string': 'test9'}}
+        )
+
+    def test_get_list_multiple_dotted_order(self):
+        """
+            REST Api: Test get list order multiple dotted notation
+        """
+        class Model4Api(ModelRestApi):
+            datamodel = SQLAInterface(Model4)
+            list_columns = [
+                'field_string',
+                'model1_1.field_string',
+                'model1_2.field_string',
+            ]
+
+        self.appbuilder.add_api(Model4Api)
+
+        client = self.app.test_client()
+        token = self.login(client, USERNAME, PASSWORD)
+
+        # Test order asc for model1_1
+        arguments = {
+            "order_column": "model1_1.field_string",
+            "order_direction": "desc"
+        }
+        uri = "api/v1/model4api/?{}={}".format(
+            API_URI_RIS_KEY, prison.dumps(arguments)
+        )
+        rv = self.auth_client_get(client, token, uri)
+        data = json.loads(rv.data.decode("utf-8"))
+        # Tests count property
+        eq_(data["count"], MODEL1_DATA_SIZE)
+        # Tests data result default page size
+        eq_(len(data[API_RESULT_RES_KEY]), self.model1api.page_size)
+        i = 0
+        eq_(
+            data[API_RESULT_RES_KEY][i],
+            {
+                'field_string': 'test9',
+                'model1_1': {'field_string': 'test9'},
+                'model1_2': {'field_string': 'test9'}
+            }
+        )
+
+        # Test order desc for model1_2
+        arguments = {
+            "order_column": "model1_2.field_string",
+            "order_direction": "asc"
+        }
+        uri = "api/v1/model4api/?{}={}".format(
+            API_URI_RIS_KEY, prison.dumps(arguments)
+        )
+        rv = self.auth_client_get(client, token, uri)
+        data = json.loads(rv.data.decode("utf-8"))
+        # Tests count property
+        eq_(data["count"], MODEL1_DATA_SIZE)
+        # Tests data result default page size
+        eq_(len(data[API_RESULT_RES_KEY]), self.model1api.page_size)
+        i = 0
+        eq_(
+            data[API_RESULT_RES_KEY][i],
+            {
+                'field_string': 'test0',
+                'model1_1': {'field_string': 'test0'},
+                'model1_2': {'field_string': 'test0'}
+            }
         )
 
     def test_get_list_order(self):
@@ -1692,9 +1760,6 @@ class APITestCase(FABTestCase):
         """
             REST Api: Test class method permission name override
         """
-        from flask_appbuilder import ModelRestApi
-        from flask_appbuilder.models.sqla.interface import SQLAInterface
-
         class Model2PermOverride1(ModelRestApi):
             datamodel = SQLAInterface(Model2)
             class_permission_name = 'api'
@@ -1736,9 +1801,6 @@ class APITestCase(FABTestCase):
         """
             REST Api: Test method permission name override
         """
-        from flask_appbuilder import ModelRestApi
-        from flask_appbuilder.models.sqla.interface import SQLAInterface
-
         class Model2PermOverride2(ModelRestApi):
             datamodel = SQLAInterface(Model2)
             method_permission_name = {
@@ -1779,9 +1841,6 @@ class APITestCase(FABTestCase):
         """
             REST Api: Test base perms with permission name override
         """
-        from flask_appbuilder import ModelRestApi
-        from flask_appbuilder.models.sqla.interface import SQLAInterface
-
         class Model2PermOverride3(ModelRestApi):
             datamodel = SQLAInterface(Model2)
             method_permission_name = {
@@ -1812,9 +1871,6 @@ class APITestCase(FABTestCase):
         """
             REST Api: Test permission name converge compress
         """
-        from flask_appbuilder import ModelRestApi
-        from flask_appbuilder.models.sqla.interface import SQLAInterface
-
         class Model1PermConverge(ModelRestApi):
             datamodel = SQLAInterface(Model1)
             class_permission_name = 'api2'
@@ -1880,9 +1936,6 @@ class APITestCase(FABTestCase):
         """
             REST Api: Test permission name converge expand
         """
-        from flask_appbuilder import ModelRestApi
-        from flask_appbuilder.models.sqla.interface import SQLAInterface
-
         class Model1PermConverge(ModelRestApi):
             datamodel = SQLAInterface(Model1)
             class_permission_name = 'Model1PermOverride'


### PR DESCRIPTION
On `ModelRestApi` using dotted notation for two relation to the same model raises exception: AmbiguousForeignKeysError

Fixes #1026 
