### PR TITLE
Fix, missing import in views example

### DIFF
--- a/docs/views.rst
+++ b/docs/views.rst
@@ -209,6 +209,7 @@ On your form_post method, you can also return None, or a Flask response to rende
 
 ::
 
+    from flask import flash
     from flask_appbuilder import SimpleFormView
     from flask_babel import lazy_gettext as _
 


### PR DESCRIPTION
The last example in **BaseViews** documentation uses the `flash` function from flask, but the import was missing.