### PR TITLE
Fix: Removed microseconds from created_on/changed_on

### DIFF
--- a/flask_appbuilder/models/mixins.py
+++ b/flask_appbuilder/models/mixins.py
@@ -46,11 +46,14 @@ class AuditMixin(object):
         :changed by:
     """
 
-    created_on = Column(DateTime, default=datetime.datetime.now, nullable=False)
+    def datetime_now_without_microseconds():
+        return datetime.datetime.now().replace(microsecond=0)
+
+    created_on = Column(DateTime, default=datetime_now_without_microseconds, nullable=False)
     changed_on = Column(
         DateTime,
-        default=datetime.datetime.now,
-        onupdate=datetime.datetime.now,
+        default=datetime_now_without_microseconds,
+        onupdate=datetime_now_without_microseconds,
         nullable=False,
     )
 

--- a/flask_appbuilder/models/mixins.py
+++ b/flask_appbuilder/models/mixins.py
@@ -49,7 +49,11 @@ class AuditMixin(object):
     def datetime_now_without_microseconds():
         return datetime.datetime.now().replace(microsecond=0)
 
-    created_on = Column(DateTime, default=datetime_now_without_microseconds, nullable=False)
+    created_on = Column(
+        DateTime, 
+        default=datetime_now_without_microseconds, 
+        nullable=False,
+    )
     changed_on = Column(
         DateTime,
         default=datetime_now_without_microseconds,

--- a/flask_appbuilder/models/mixins.py
+++ b/flask_appbuilder/models/mixins.py
@@ -50,8 +50,8 @@ class AuditMixin(object):
         return datetime.datetime.now().replace(microsecond=0)
 
     created_on = Column(
-        DateTime, 
-        default=datetime_now_without_microseconds, 
+        DateTime,
+        default=datetime_now_without_microseconds,
         nullable=False,
     )
     changed_on = Column(


### PR DESCRIPTION
Removed microseconds from created_on/changed_on in AuditMixIn. The microseconds was creating problems when creating new objects. Solution based on issue #603. Problem also mentioned here: https://github.com/dpgaspar/Flask-AppBuilder/issues/131#issuecomment-91206726

To reproduce problem:
 - Create a model with AuditMixIn and try to add a row using a view that inherits from ModelView.
 - On saving it will throw and error that says "Not a valid datetime value" and goes aways when removed the microsecond portion of datetime.datetime.now.