### PR TITLE
[security] Fix, is item visible returns true is perm exists on role

### DIFF
--- a/flask_appbuilder/filters.py
+++ b/flask_appbuilder/filters.py
@@ -155,9 +155,12 @@ class TemplateFilters(object):
         else:
             if hasattr(_view, 'actions') and _view.actions.get(permission):
                 permission_name = _view.get_action_permission_name(permission)
+                if permission_name not in _view.base_permissions:
+                    return False
                 return self.security_manager.has_access(permission_name, item)
             else:
                 method = permission
-        permission = _view.get_method_permission(method)
-        return self.security_manager.has_access(
-            PERMISSION_PREFIX + permission, item)
+        permission_name = PERMISSION_PREFIX + _view.get_method_permission(method)
+        if permission_name not in _view.base_permissions:
+            return False
+        return self.security_manager.has_access(permission_name, item)


### PR DESCRIPTION
If role still contains a permission that is missing on `BaseView` or `BaseApi` `base_permissions` override, `is_item_visible` returns True. This behavior may be confusing and saves a round trip to the DB.
