### PR TITLE
New version 2.1.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Flask-AppBuilder ChangeLog
 ==========================
 
+Improvements and Bug fixes on 2.1.5
+-----------------------------------
+
+- New, #1040, #1041 Bump prison to 0.1.2 and remove requests dependency
+- Fix, #1042 is_item_visible confusing behaviour with base_permissions when perm is still on DB
+
 Improvements and Bug fixes on 2.1.4
 -----------------------------------
 

--- a/flask_appbuilder/__init__.py
+++ b/flask_appbuilder/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Daniel Vaz Gaspar"
-__version__ = '2.1.4'
+__version__ = '2.1.5'
 
 from .actions import action  # noqa: F401
 from .api import ModelRestApi  # noqa: F401


### PR DESCRIPTION
New version 2.1.5

- New, #1040, #1041 Bump prison to 0.1.2 and remove requests dependency
- Fix, #1042 is_item_visible confusing behaviour with base_permissions when perm is still on DB
