### PR TITLE
perf: improve perf while checking perms

### DIFF
--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -1058,6 +1058,9 @@ class BaseSecurityManager(AbstractSecurityManager):
 
     def _has_view_access(self, user, permission_name, view_name):
         roles = user.roles
+
+        # First check against builtin (statically configured) roles
+        # because no database query is needed
         for role in roles:
             if role.name in self.builtin_roles:
                 if self._has_access_builtin_roles(
@@ -1066,8 +1069,9 @@ class BaseSecurityManager(AbstractSecurityManager):
                         view_name
                 ):
                     return True
-                else:
-                    continue
+
+        # Then check against database-stored roles
+        for role in roles:
             permissions = role.permissions
             if permissions:
                 for permission in permissions:
@@ -1075,6 +1079,7 @@ class BaseSecurityManager(AbstractSecurityManager):
                         permission_name == permission.permission.name
                     ):
                         return True
+
         return False
 
     def has_access(self, permission_name, view_name):


### PR DESCRIPTION
Found this easy minor perf improvement while digging around finding
solutions for #1039

Related thoughts:
* my intuition is that the best/easiest optmization would be to simply
  run a single query joining user, roles and perms checking for that
  single
  permission very quickly. The only downside of that is if `user.roles` is
  getting iterated over later in the request cycle, you have to pay the
  cost of loading it anyways. Maybe `_has_view_access` could have
  different mode of operations where it tries to fetch and cache things
  as opposed to the single check against the db.
* noticed `re.match` being used potentially a lot for static roles, we
  may want to re.compile and cache. This may be a premature
  optimization though, unclear...

related to: https://github.com/dpgaspar/Flask-AppBuilder/issues/1039