### PR TITLE
[openapi] Fix, require refresh security token

### DIFF
--- a/flask_appbuilder/security/api.py
+++ b/flask_appbuilder/security/api.py
@@ -30,6 +30,7 @@ class SecurityApi(BaseApi):
         super(SecurityApi, self).add_apispec_components(api_spec)
         jwt_scheme = {"type": "http", "scheme": "bearer", "bearerFormat": "JWT"}
         api_spec.components.security_scheme("jwt", jwt_scheme)
+        api_spec.components.security_scheme("jwt_refresh", jwt_scheme)
 
     @expose("/login", methods=["POST"])
     @safe
@@ -128,6 +129,8 @@ class SecurityApi(BaseApi):
               $ref: '#/components/responses/401'
             500:
               $ref: '#/components/responses/500'
+          security:
+            - jwt_refresh: []
         """
         resp = {
             API_SECURITY_REFRESH_TOKEN_KEY: create_access_token(


### PR DESCRIPTION
Fixes #1047 

Add a second JWT security schema for the refresh token. This adds a second input for the refresh token to the auth form in the interactive swagger docs.

<img width="300" alt="Screen Shot 2019-06-28 at 11 46 04 AM" src="https://user-images.githubusercontent.com/3108007/60358464-beb4a080-999b-11e9-8127-a8b5903900b0.png">

Set the security schema on the refresh operation to the refresh token schema. This adds a lock icon to the refresh operation and automatically includes the refresh token in the header of refresh requests.

<img width="300" alt="Screen Shot 2019-06-28 at 11 58 00 AM" src="https://user-images.githubusercontent.com/3108007/60358567-05a29600-999c-11e9-813f-a48ff99f71b5.png">

---

This allows the refresh API to be tested through the swagger docs and documents how the refresh API should be used.

<img width="300" align="top" alt="Screen Shot 2019-06-28 at 11 47 56 AM" src="https://user-images.githubusercontent.com/3108007/60358647-4e5a4f00-999c-11e9-9191-48bb4c616cb0.png">

<img width="300" alighn="top" alt="Screen Shot 2019-06-28 at 11 47 48 AM" src="https://user-images.githubusercontent.com/3108007/60358690-6fbb3b00-999c-11e9-94f0-b3777edeb72f.png">

<img width="300" align="top" alt="Screen Shot 2019-06-28 at 11 48 35 AM" src="https://user-images.githubusercontent.com/3108007/60358668-5c0fd480-999c-11e9-805b-6455b51f02ae.png">
