### PR TITLE
Fix, Catch exception with populating form

### DIFF
--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -1110,9 +1110,9 @@ class BaseCRUDView(BaseModelView):
             if form.validate():
                 self.process_form(form, True)
                 item = self.datamodel.obj()
-                form.populate_obj(item)
 
                 try:
+                    form.populate_obj(item)
                     self.pre_add(item)
                 except Exception as e:
                     flash(str(e), "danger")
@@ -1154,8 +1154,9 @@ class BaseCRUDView(BaseModelView):
             form._id = pk
             if form.validate():
                 self.process_form(form, False)
-                form.populate_obj(item)
+
                 try:
+                    form.populate_obj(item)
                     self.pre_update(item)
                 except Exception as e:
                     flash(str(e), "danger")


### PR DESCRIPTION
Related to https://github.com/apache/incubator-superset/pull/5449 which uses SQLAlchemy listeners for pre-insert and pre-update validation (this is required as Superset also contains a React component for editing models), this PR catches potential exceptions which may be thrown by the listener when WTForms attempts to populating the object.

to: @dpgaspar @mistercrunch 

