### PR TITLE
Bump to 2.1.6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Flask-AppBuilder ChangeLog
 ==========================
 
+Improvements and Bug fixes on 2.1.6
+-----------------------------------
+
+- Fix, #1050 Catch exceptions on populating forms
+- Fix, #1046 API include openapi security spec on paths
+- Fix, #1048 API include refresh token on openapi security specs
+- Fix, #1045, #1044 Performance improvement on permission checks
+
 Improvements and Bug fixes on 2.1.5
 -----------------------------------
 

--- a/flask_appbuilder/__init__.py
+++ b/flask_appbuilder/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Daniel Vaz Gaspar"
-__version__ = '2.1.5'
+__version__ = '2.1.6'
 
 from .actions import action  # noqa: F401
 from .api import ModelRestApi  # noqa: F401


### PR DESCRIPTION
New 2.1.6

Improvements and Bug fixes on 2.1.6
-----------------------------------

- Fix, #1050 Catch exceptions on populating forms
- Fix, #1046 API include openapi security spec on paths
- Fix, #1048 API include refresh token on openapi security specs
- Fix, #1045, #1044 Performance improvement on permission checks

