### PR TITLE
[api] New, max_page_size class property override for FAB_API_MAX_SIZE

### DIFF
--- a/flask_appbuilder/__init__.py
+++ b/flask_appbuilder/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Daniel Vaz Gaspar"
-__version__ = '2.1.7'
+__version__ = "2.1.7"
 
 from .actions import action  # noqa: F401
 from .api import ModelRestApi  # noqa: F401
@@ -17,5 +17,5 @@ from .views import (  # noqa: F401
     MultipleView,
     PublicFormView,
     RestCRUDView,
-    SimpleFormView
+    SimpleFormView,
 )  # noqa: F401

--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -798,6 +798,11 @@ class ModelRestApi(BaseModelApi):
     """
         Use this property to change default page size
     """
+    max_page_size = None
+    """
+        class override for the FAB_API_MAX_SIZE, use special -1 to allow for any page
+        size
+    """
     description_columns = None
     """
         Dictionary with column descriptions that will be shown on the forms::
@@ -1505,7 +1510,11 @@ class ModelRestApi(BaseModelApi):
     def _sanitize_page_args(self, page, page_size):
         _page = page or 0
         _page_size = page_size or self.page_size
-        max_page_size = current_app.config.get("FAB_API_MAX_PAGE_SIZE")
+        max_page_size = (self.max_page_size or
+                         current_app.config.get("FAB_API_MAX_PAGE_SIZE"))
+        # Accept special -1 to uncap the page size
+        if max_page_size == -1:
+            return _page, _page_size
         if _page_size > max_page_size or _page_size < 1:
             _page_size = max_page_size
         return _page, _page_size

--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -1510,8 +1510,9 @@ class ModelRestApi(BaseModelApi):
     def _sanitize_page_args(self, page, page_size):
         _page = page or 0
         _page_size = page_size or self.page_size
-        max_page_size = (self.max_page_size or
-                         current_app.config.get("FAB_API_MAX_PAGE_SIZE"))
+        max_page_size = self.max_page_size or current_app.config.get(
+            "FAB_API_MAX_PAGE_SIZE"
+        )
         # Accept special -1 to uncap the page size
         if max_page_size == -1:
             return _page, _page_size

--- a/flask_appbuilder/base.py
+++ b/flask_appbuilder/base.py
@@ -160,7 +160,7 @@ class AppBuilder(object):
         app.config.setdefault("APP_ICON", "")
         app.config.setdefault("LANGUAGES", {"en": {"flag": "gb", "name": "English"}})
         app.config.setdefault("ADDON_MANAGERS", [])
-        app.config.setdefault("FAB_API_MAX_PAGE_SIZE", 20)
+        app.config.setdefault("FAB_API_MAX_PAGE_SIZE", 100)
         app.config.setdefault("FAB_BASE_TEMPLATE", self.base_template)
         app.config.setdefault("FAB_STATIC_FOLDER", self.static_folder)
         app.config.setdefault("FAB_STATIC_URL_PATH", self.static_url_path)

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -955,7 +955,7 @@ class APITestCase(FABTestCase):
         """
             REST Api: Test get list max page size config setting
         """
-        page_size = 100  # Max is globally set to MAX_PAGE_SIZE
+        page_size = 200  # Max is globally set to MAX_PAGE_SIZE
         client = self.app.test_client()
         token = self.login(client, USERNAME, PASSWORD)
 
@@ -967,6 +967,47 @@ class APITestCase(FABTestCase):
             "order_direction": "asc",
         }
         uri = "api/v1/model1api/?{}={}".format(API_URI_RIS_KEY, prison.dumps(arguments))
+        rv = self.auth_client_get(client, token, uri)
+        data = json.loads(rv.data.decode("utf-8"))
+        eq_(len(data[API_RESULT_RES_KEY]), MAX_PAGE_SIZE)
+
+    def test_get_list_max_page_size_override(self):
+        """
+            REST Api: Test get list max page size property override
+        """
+
+        class Model1PageSizeOverride(ModelRestApi):
+            datamodel = SQLAInterface(Model1)
+            max_page_size = -1
+            list_columns = [
+                "field_integer",
+                "field_float",
+                "field_string",
+                "field_date",
+            ]
+            description_columns = {
+                "field_integer": "Field Integer",
+                "field_float": "Field Float",
+                "field_string": "Field String",
+            }
+
+        self.model1api = Model1PageSizeOverride
+        self.appbuilder.add_api(Model1PageSizeOverride)
+
+        page_size = 200  # Max is globally set to MAX_PAGE_SIZE
+        client = self.app.test_client()
+        token = self.login(client, USERNAME, PASSWORD)
+
+        # test page zero
+        arguments = {
+            "page_size": page_size,
+            "page": 0,
+            "order_column": "field_integer",
+            "order_direction": "asc",
+        }
+        uri = "api/v1/model1pagesizeoverride/?{}={}".format(
+            API_URI_RIS_KEY, prison.dumps(arguments)
+        )
         rv = self.auth_client_get(client, token, uri)
         data = json.loads(rv.data.decode("utf-8"))
         eq_(len(data[API_RESULT_RES_KEY]), MAX_PAGE_SIZE)

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -1010,7 +1010,7 @@ class APITestCase(FABTestCase):
         )
         rv = self.auth_client_get(client, token, uri)
         data = json.loads(rv.data.decode("utf-8"))
-        eq_(len(data[API_RESULT_RES_KEY]), MAX_PAGE_SIZE)
+        eq_(len(data[API_RESULT_RES_KEY]), MODEL1_DATA_SIZE)
 
     def test_get_list_filters(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 
 with io.open("flask_appbuilder/__init__.py", "rt", encoding="utf8") as f:
-    version = re.search(r"__version__ = \'(.*?)\'", f.read()).group(1)
+    version = re.search(r"__version__ = \"(.*?)\"", f.read()).group(1)
 
 
 def fpath(name):


### PR DESCRIPTION
Introduces a class property `max_page_size` to override global setting FAB_API_MAX_SIZE

``` python
# Uncapped API
class TestApi(ModelRestApi):
    datamodel = SQLAInterface(Model1)
    max_page_size = -1

# Override default of 100 on FAB_API_MAX_SIZE
class TestApi(ModelRestApi):
    datamodel = SQLAInterface(Model1)
    max_page_size = 200

```
