### PR TITLE
[WiP] [api] HTTP method GET item can optionally show results for an edit form

### DIFF
--- a/examples/crud_rest_api/app/api.py
+++ b/examples/crud_rest_api/app/api.py
@@ -22,6 +22,7 @@ class ContactModelApi(ModelRestApi):
     resource_name = "contact"
     datamodel = SQLAInterface(Contact)
     allow_browser_login = True
+    show_columns = ['name', 'contact_group.name']
 
 
 appbuilder.add_api(ContactModelApi)


### PR DESCRIPTION
If we want to dynamically generate an edit form (client side, using React for example) current API will only return results associated with `show_columns`