### PR TITLE
Bump to 2.1.8, new RELEASE doc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Flask-AppBuilder ChangeLog
 ==========================
 
+Improvements and Bug fixes on 2.1.8
+-----------------------------------
+
+- Fix, #1069 API label_columns for get item returning labels for list columns
+- Fix, #1072 API max_page_size class property override for FAB_API_MAX_SIZE
+
 Improvements and Bug fixes on 2.1.7
 -----------------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Flask-AppBuilder ChangeLog
 Improvements and Bug fixes on 2.1.8
 -----------------------------------
 
+- Fix, #1077 API Info not translating labels and description
 - Fix, #1069 API label_columns for get item returning labels for list columns
 - Fix, #1072 API max_page_size class property override for FAB_API_MAX_SIZE
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,20 @@
+Release protocol
+----------------
+
+1 - Create a release branch named `release/<VERSION>`
+
+2 - Update CHANGELOG.rst with all the changes since last release
+
+3 - Bump version on `flask_appbuilder/__init__.py`
+
+4 - Submit PR and check all tests pass
+
+5 - tag latest commit with `v<VERSION>` ex: v2.1.8
+
+6 - merge PR
+
+7 - checkout and pull master branch
+
+8 - Upload package to Pypi: `python setup.py sdist upload`
+
+9 - Update readthedocs with the new master version

--- a/flask_appbuilder/__init__.py
+++ b/flask_appbuilder/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Daniel Vaz Gaspar"
-__version__ = "2.1.7"
+__version__ = "2.1.8"
 
 from .actions import action  # noqa: F401
 from .api import ModelRestApi  # noqa: F401

--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -517,7 +517,7 @@ class BaseApi(object):
         """
             Sets initialized inner views
         """
-        pass
+        pass  # pragma: no cover
 
     def get_method_permission(self, method_name: str) -> str:
         """
@@ -531,7 +531,7 @@ class BaseApi(object):
 
     def set_response_key_mappings(self, response, func, rison_args, **kwargs):
         if not hasattr(func, "_response_key_func_mappings"):
-            return
+            return  # pragma: no cover
         _keys = rison_args.get("keys", None)
         if not _keys:
             for k, v in func._response_key_func_mappings.items():
@@ -1044,7 +1044,7 @@ class ModelRestApi(BaseModelApi):
             elif kwargs.get("caller") == "show":
                 columns = self.show_columns
             else:
-                columns = self.label_columns
+                columns = self.label_columns  # pragma: no cover
         response[API_LABEL_COLUMNS_RES_KEY] = self._label_columns_json(columns)
 
     def merge_list_label_columns(self, response, **kwargs):


### PR DESCRIPTION
New release 2.1.8

- Fix, #1077 API Info not translating labels and description
- Fix, #1069 API label_columns for get item returning labels for list columns
- Fix, #1072 API max_page_size class property override for FAB_API_MAX_SIZE
