### PR TITLE
[api] Fix, negative page size issues SQL with negative LIMIT

### DIFF
--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -1515,7 +1515,10 @@ class ModelRestApi(BaseModelApi):
         )
         # Accept special -1 to uncap the page size
         if max_page_size == -1:
-            return _page, _page_size
+            if _page_size == -1:
+                return None, None
+            else:
+                return _page, _page_size
         if _page_size > max_page_size or _page_size < 1:
             _page_size = max_page_size
         return _page, _page_size


### PR DESCRIPTION
`max_page_size` when using special `-1` value to unlimit results issues queries with LIMIT -1, that result in error 