### PR TITLE
[security] Fix, make possible to override when using FAB_ADD_SECURITY_VIEWS

### DIFF
--- a/flask_appbuilder/__init__.py
+++ b/flask_appbuilder/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Daniel Vaz Gaspar"
-__version__ = "2.1.10"
+__version__ = "2.1.9"
 
 from .actions import action  # noqa: F401
 from .api import ModelRestApi  # noqa: F401

--- a/flask_appbuilder/__init__.py
+++ b/flask_appbuilder/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Daniel Vaz Gaspar"
-__version__ = "2.1.9"
+__version__ = "2.1.10"
 
 from .actions import action  # noqa: F401
 from .api import ModelRestApi  # noqa: F401

--- a/flask_appbuilder/api/manager.py
+++ b/flask_appbuilder/api/manager.py
@@ -76,6 +76,8 @@ class SwaggerView(BaseView):
 
 class OpenApiManager(BaseManager):
     def register_views(self):
+        if not self.appbuilder.app.config.get('FAB_ADD_SECURITY_VIEWS', True):
+            return
         self.appbuilder.add_api(OpenApi)
         if self.appbuilder.get_app.config.get('FAB_API_SWAGGER_UI', False):
             self.appbuilder.add_view_no_menu(SwaggerView)

--- a/flask_appbuilder/base.py
+++ b/flask_appbuilder/base.py
@@ -320,10 +320,8 @@ class AppBuilder(object):
         self.add_view_no_menu(self.indexview)
         self.add_view_no_menu(UtilView())
         self.bm.register_views()
-        if self.get_app.config.get('FAB_ADD_SECURITY_VIEWS', True):
-            self.sm.register_views()
-        if self.get_app.config.get('FAB_ADD_OPENAPI_VIEWS', True):
-            self.openapi_manager.register_views()
+        self.sm.register_views()
+        self.openapi_manager.register_views()
 
     def _add_addon_views(self):
         """

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -579,7 +579,8 @@ class BaseSecurityManager(AbstractSecurityManager):
         return jwt_decoded_payload
 
     def register_views(self):
-
+        if not self.appbuilder.app.config.get('FAB_ADD_SECURITY_VIEWS', True):
+            return
         # Security APIs
         self.appbuilder.add_api(self.security_api)
 

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -94,7 +94,6 @@ class APICSRFTestCase(FABTestCase):
 class APIDisableSecViewTestCase(FABTestCase):
     def setUp(self):
         from flask import Flask
-        from flask_wtf import CSRFProtect
         from flask_appbuilder import AppBuilder
 
         self.app = Flask(__name__)
@@ -103,17 +102,25 @@ class APIDisableSecViewTestCase(FABTestCase):
         self.app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
         self.app.config["FAB_ADD_SECURITY_VIEWS"] = False
 
-        self.csrf = CSRFProtect(self.app)
         self.db = SQLA(self.app)
         self.appbuilder = AppBuilder(self.app, self.db.session)
 
         self.create_admin_user(self.appbuilder, USERNAME, PASSWORD)
 
+    base_fab_endpoint = [
+        "IndexView.index",
+        "appbuilder.static",
+        "static",
+        "LocaleView.index",
+        "UtilView.back",
+    ]
+
     def test_disabled_security_views(self):
         """
             REST Api: Test disabled security views
         """
-        eq_(self.appbuilder.get_app.url_map, [])
+        for rule in self.appbuilder.get_app.url_map.iter_rules():
+            self.assertIn(rule.endpoint, self.base_fab_endpoint)
 
 
 class APITestCase(FABTestCase):

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -91,6 +91,31 @@ class APICSRFTestCase(FABTestCase):
         )
 
 
+class APIDisableSecViewTestCase(FABTestCase):
+    def setUp(self):
+        from flask import Flask
+        from flask_wtf import CSRFProtect
+        from flask_appbuilder import AppBuilder
+
+        self.app = Flask(__name__)
+        self.app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///"
+        self.app.config["SECRET_KEY"] = "thisismyscretkey"
+        self.app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+        self.app.config["FAB_ADD_SECURITY_VIEWS"] = False
+
+        self.csrf = CSRFProtect(self.app)
+        self.db = SQLA(self.app)
+        self.appbuilder = AppBuilder(self.app, self.db.session)
+
+        self.create_admin_user(self.appbuilder, USERNAME, PASSWORD)
+
+    def test_disabled_security_views(self):
+        """
+            REST Api: Test disabled security views
+        """
+        eq_(self.appbuilder.get_app.url_map, [])
+
+
 class APITestCase(FABTestCase):
     def setUp(self):
         from flask import Flask


### PR DESCRIPTION
FAB_ADD_SECURITY_VIEWS=False will not include any security view, give devs
the chance to override `register_views` and add their custom views
instead
