### PR TITLE
New FAB 2.1.12

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Flask-AppBuilder ChangeLog
 ==========================
 
+Improvements and Bug fixes on 2.1.12
+------------------------------------
+
+- Fix, #1096 Bootstrap and Bootswatch bump to 3.4.1
+- Fix, #1097 python version restriction on setup > 3.6 < 4
+- Fix, #1095 OAuth set fallback when next url in state is empty
+
 Improvements and Bug fixes on 2.1.11
 ------------------------------------
 

--- a/flask_appbuilder/__init__.py
+++ b/flask_appbuilder/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Daniel Vaz Gaspar"
-__version__ = "2.1.11"
+__version__ = "2.1.12"
 
 from .actions import action  # noqa: F401
 from .api import ModelRestApi  # noqa: F401


### PR DESCRIPTION
New FAB 2.1.12

Improvements and Bug fixes on 2.1.12
------------------------------------

- Fix, #1096 Bootstrap and Bootswatch bump to 3.4.1
- Fix, #1097 python version restriction on setup > 3.6 < 4
- Fix, #1095 OAuth set fallback when next url in state is empty

Related issues: #1093 
