### PR TITLE
Fix: marshmallow-sqlalchemy update breaks py2 and 3.5 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'python-dateutil>=2.3,<3',
         'marshmallow>=2.18.0,<2.20',
         'marshmallow-enum>=1.4.1,<2',
-        'marshmallow-sqlalchemy>=0.16.1<1',
+        "marshmallow-sqlalchemy>=0.16.1, <0.19.0",
         'prison==0.1.0',
         'jsonschema>=3.0.1<4',
         'PyJWT>=1.7.1'


### PR DESCRIPTION
marshmallow-sqlalchemy 0.19.0 is incompatible with py2 and py3.5 (syntax errors); Flask-AppBuilder's dependency on marshmallow-sqlalchemy breaks downstream projects on py2 and py3.5, including Apache Airflow.

This change repins the dependency in setup.py to `marshmallow-sqlalchemy>=0.16.1, <0.19.0` instead of `marshmallow-sqlalchemy>=0.16.1, <1`. (cf. the requirements.txt pin to `marshmallow-sqlalchemy==0.16.2`.