### PR TITLE
Fix, ldap: safely retrieve error object attribute

### DIFF
--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -925,7 +925,10 @@ class BaseSecurityManager(AbstractSecurityManager):
                 return user
 
             except ldap.LDAPError as e:
-                if type(e.message) == dict and "desc" in e.message:
+                msg = None
+                if isinstance(e, dict):
+                    msg = getattr(e, 'message', None)
+                if msg is not None and "desc" in msg:
                     log.error(LOGMSG_ERR_SEC_AUTH_LDAP.format(e.message["desc"]))
                     return None
                 else:


### PR DESCRIPTION
@AlexisLessard Please try to apply these changes and let me know if you still see the issue. I do not have access to an LDAP server to test with at the moment.

Closes #1118