### PR TITLE
[api] New, allow excluding columns from serialization

### DIFF
--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -427,6 +427,13 @@ class BaseModelView(BaseView):
 
     """
 
+    marshmallow_exclude_columns = None
+    """
+        List or tuple of column names to exclude from serialization.
+        If any ModelRestApi classes refer to this model, these columns will
+        not be accessible via the API created.
+    """
+
     label_columns = None
     """
         Dictionary of labels for your columns,


### PR DESCRIPTION
Marshmallow is incapable of operating on certain data types.
There is a mechanism for excluding columns from a model-based
API, but it does not work consistently when relationships are
defined and exposed by the API.

This change adds an additional mechanism for controlling which
columns are serialized using marshmallow by way of an attribute
on the model itself.

This is a more dependable and accessible mechanism, and the only
one that was found to work with relationships.

Closes #1126