### PR TITLE
Fix: Updated Marshmallow dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "Flask-WTF>=0.14.2, <1",
         "Flask-JWT-Extended>=3.18, <4",
         "jsonschema>=3.0.1, <4",
-        "marshmallow>=2.18.0, <2.20",
+        "marshmallow>=2.18.0, <4.0.0",
         "marshmallow-enum>=1.4.1, <2",
         "marshmallow-sqlalchemy>=0.16.1, <1",
         "python-dateutil>=2.3, <3",


### PR DESCRIPTION
The Marshmallow dependency version is restrictive and out of date. Since this package is included with Airflow, this basically precludes running any packages that depend on a newer version of Marshmallow along with Airflow. This update should fix this issue. I also filed an issue in the tracker system.

https://github.com/dpgaspar/Flask-AppBuilder/issues/1133