### PR TITLE
Fix autofocus login to make UX more seamless.

### DIFF
--- a/flask_appbuilder/static/appbuilder/css/ab.css
+++ b/flask_appbuilder/static/appbuilder/css/ab.css
@@ -50,3 +50,7 @@ th.action_checkboxes {
 .btn.filter {
     text-align: left;
 }
+
+#loginbox #username {
+	cursor: auto;
+}


### PR DESCRIPTION
Fix is a stretch. It's mostly an enhancement, but since the user experience of a security step can be improved, I consider it a fix. 

To reproduce the problem, and eliminate other variables, open the login page on an incognito or private browser. You will see that a user needs to more the cursor to the username. If they are there, they want to login most likely, so we should simplify the process for the user and focus on the username field in the login form.