### PR TITLE
[babel] Fix, crash with empty LANGUAGES config key

### DIFF
--- a/flask_appbuilder/babel/manager.py
+++ b/flask_appbuilder/babel/manager.py
@@ -16,7 +16,8 @@ class BabelManager(BaseManager):
         super(BabelManager, self).__init__(appbuilder)
         app = appbuilder.get_app
         app.config.setdefault("BABEL_DEFAULT_LOCALE", "en")
-        app.config.setdefault("LANGUAGES", {"en": {"flag": "us", "name": "English"}})
+        if not app.config.get("LANGUAGES"):
+            app.config["LANGUAGES"] = {"en": {"flag": "us", "name": "English"}}
         appbuilder_parent_dir = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), os.pardir
         )
@@ -44,12 +45,19 @@ class BabelManager(BaseManager):
     def babel_default_locale(self):
         return self.appbuilder.get_app.config["BABEL_DEFAULT_LOCALE"]
 
+    @property
+    def languages(self):
+        return self.appbuilder.get_app.config["LANGUAGES"]
+
     def get_locale(self):
         if has_request_context():
             # locale selector for API searches for request args
             for arg, value in request.args.items():
                 if arg == "_l_":
-                    return value
+                    if value in self.languages:
+                        return value
+                    else:
+                        return self.babel_default_locale
             locale = session.get("locale")
             if locale:
                 return locale

--- a/flask_appbuilder/babel/manager.py
+++ b/flask_appbuilder/babel/manager.py
@@ -16,6 +16,7 @@ class BabelManager(BaseManager):
         super(BabelManager, self).__init__(appbuilder)
         app = appbuilder.get_app
         app.config.setdefault("BABEL_DEFAULT_LOCALE", "en")
+        app.config.setdefault("LANGUAGES", {"en": {"flag": "us", "name": "English"}})
         appbuilder_parent_dir = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), os.pardir
         )

--- a/flask_appbuilder/templates/appbuilder/navbar_right.html
+++ b/flask_appbuilder/templates/appbuilder/navbar_right.html
@@ -4,12 +4,12 @@
 {% if not locale %}
     {% set locale = 'en' %}
 {% endif %}
+{% if languages.keys()|length > 1 %}
 <li class="dropdown">
     <a class="dropdown-toggle" data-toggle="dropdown" href="javascript:void(0)">
        <div class="f16"><i class="flag {{languages[locale].get('flag')}}"></i><b class="caret"></b>
        </div>
     </a>
-    {% if languages.keys()|length > 1 %}
     <ul class="dropdown-menu">
     <li class="dropdown">
         {% for lang in languages %}
@@ -17,12 +17,12 @@
                 <a tabindex="-1" href="{{appbuilder.get_url_for_locale(lang)}}">
                   <div class="f16"><i class="flag {{languages[lang].get('flag')}}"></i> - {{languages[lang].get('name')}}
                 </div></a>
-                {% endif %}
-            {% endfor %}
+            {% endif %}
+        {% endfor %}
         </li>
         </ul>
-    {% endif %}
 </li>
+{% endif %}
 {% endmacro %}
 
 

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -341,16 +341,6 @@ class APITestCase(FABTestCase):
         rv = self.auth_client_get(client, token, uri)
         self.assertEqual(rv.status_code, 200)
 
-    def test_babel_wrong_language(self):
-        """
-            REST Api: Test babel with a wrong language
-        """
-        client = self.app.test_client()
-        token = self.login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
-        uri = "api/v1/model1api/?_l_=xx"
-        rv = self.auth_client_get(client, token, uri)
-        self.assertEqual(rv.status_code, 200)
-
     def test_auth_login(self):
         """
             REST Api: Test auth login

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -326,19 +326,29 @@ class APITestCase(FABTestCase):
             REST Api: Test babel simple test
         """
         client = self.app.test_client()
-        rv = self._login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
+        token = self.login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
         uri = "api/v1/model1api/?_l_=en"
-        rv = client.get(uri)
+        rv = self.auth_client_get(client, token, uri)
         self.assertEqual(rv.status_code, 200)
 
     def test_babel_wrong_language(self):
         """
-            REST Api: Test babel with a wrong languge
+            REST Api: Test babel with a wrong language
         """
         client = self.app.test_client()
-        rv = self._login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
+        token = self.login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
         uri = "api/v1/model1api/?_l_=xx"
-        rv = client.get(uri)
+        rv = self.auth_client_get(client, token, uri)
+        self.assertEqual(rv.status_code, 200)
+
+    def test_babel_wrong_language(self):
+        """
+            REST Api: Test babel with a wrong language
+        """
+        client = self.app.test_client()
+        token = self.login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
+        uri = "api/v1/model1api/?_l_=xx"
+        rv = self.auth_client_get(client, token, uri)
         self.assertEqual(rv.status_code, 200)
 
     def test_auth_login(self):

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -321,6 +321,26 @@ class APITestCase(FABTestCase):
         self.app = None
         self.db = None
 
+    def test_babel(self):
+        """
+            REST Api: Test babel simple test
+        """
+        client = self.app.test_client()
+        rv = self._login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
+        uri = "api/v1/model1api/?_l_=en"
+        rv = client.get(uri)
+        self.assertEqual(rv.status_code, 200)
+
+    def test_babel_wrong_language(self):
+        """
+            REST Api: Test babel with a wrong languge
+        """
+        client = self.app.test_client()
+        rv = self._login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
+        uri = "api/v1/model1api/?_l_=xx"
+        rv = client.get(uri)
+        self.assertEqual(rv.status_code, 200)
+
     def test_auth_login(self):
         """
             REST Api: Test auth login

--- a/flask_appbuilder/tests/test_mvc.py
+++ b/flask_appbuilder/tests/test_mvc.py
@@ -56,6 +56,52 @@ NOTNULL_VALIDATION_STRING = "This field is required"
 log = logging.getLogger(__name__)
 
 
+class AMVCBabelTestCase(FABTestCase):
+    def test_babel_empty_languages(self):
+        """
+            MVC: Test babel empty languages
+        """
+        from flask import Flask
+        from flask_appbuilder import AppBuilder
+
+        app = Flask(__name__)
+        app.config.from_object("flask_appbuilder.tests.config_api")
+        app.config["LANGUAGES"] = {}
+        db = SQLA(app)
+        appbuilder = AppBuilder(app, db.session)
+
+        client = app.test_client()
+        self.browser_login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
+        rv = client.get("/users/list/")
+        self.assertEqual(rv.status_code, 200)
+
+        data = rv.data.decode("utf-8")
+        self.assertNotIn('class="f16', data)
+
+    def test_babel_languages(self):
+        """
+            MVC: Test babel languages
+        """
+        from flask import Flask
+        from flask_appbuilder import AppBuilder
+
+        app = Flask(__name__)
+        app.config.from_object("flask_appbuilder.tests.config_api")
+        app.config["LANGUAGES"] = {
+            "en": {"flag": "gb", "name": "English"},
+            "pt": {"flag": "pt", "name": "Portuguese"},
+        }
+        db = SQLA(app)
+        appbuilder = AppBuilder(app, db.session)
+
+        client = app.test_client()
+        self.browser_login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
+        rv = client.get("/users/list/")
+        self.assertEqual(rv.status_code, 200)
+        data = rv.data.decode("utf-8")
+        self.assertIn('href="/lang/pt"', data)
+
+
 class FlaskTestCase(FABTestCase):
     def setUp(self):
         from flask import Flask

--- a/flask_appbuilder/tests/test_mvc.py
+++ b/flask_appbuilder/tests/test_mvc.py
@@ -106,8 +106,6 @@ class AMVCBabelTestCase(FABTestCase):
         self.assertEqual(rv.status_code, 302)
 
 
-
-
 class FlaskTestCase(FABTestCase):
     def setUp(self):
         from flask import Flask

--- a/flask_appbuilder/tests/test_mvc.py
+++ b/flask_appbuilder/tests/test_mvc.py
@@ -68,7 +68,7 @@ class AMVCBabelTestCase(FABTestCase):
         app.config.from_object("flask_appbuilder.tests.config_api")
         app.config["LANGUAGES"] = {}
         db = SQLA(app)
-        appbuilder = AppBuilder(app, db.session)
+        AppBuilder(app, db.session)
 
         client = app.test_client()
         self.browser_login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
@@ -92,7 +92,7 @@ class AMVCBabelTestCase(FABTestCase):
             "pt": {"flag": "pt", "name": "Portuguese"},
         }
         db = SQLA(app)
-        appbuilder = AppBuilder(app, db.session)
+        AppBuilder(app, db.session)
 
         client = app.test_client()
         self.browser_login(client, USERNAME_ADMIN, PASSWORD_ADMIN)

--- a/flask_appbuilder/tests/test_mvc.py
+++ b/flask_appbuilder/tests/test_mvc.py
@@ -101,6 +101,12 @@ class AMVCBabelTestCase(FABTestCase):
         data = rv.data.decode("utf-8")
         self.assertIn('href="/lang/pt"', data)
 
+        # Test babel language switch endpoint
+        rv = client.get("/lang/pt")
+        self.assertEqual(rv.status_code, 302)
+
+
+
 
 class FlaskTestCase(FABTestCase):
     def setUp(self):


### PR DESCRIPTION
Fixed:

- Empty LANGUAGES definition crash

- Remove drop down language selection if LANGUAGES is empty or just one

- Fix API requesting a non existing language crash
