### PR TITLE
New, added roles parameter to add_user.

### DIFF
--- a/flask_appbuilder/security/sqla/manager.py
+++ b/flask_appbuilder/security/sqla/manager.py
@@ -170,18 +170,21 @@ class SecurityManager(BaseSecurityManager):
         role,
         password="",
         hashed_password="",
+        roles=None
     ):
         """
             Generic function to create user
         """
         try:
+            if roles is None:
+                roles = [role]
             user = self.user_model()
             user.first_name = first_name
             user.last_name = last_name
             user.username = username
             user.email = email
             user.active = True
-            user.roles.append(role)
+            user.roles.extend(roles)
             if hashed_password:
                 user.password = hashed_password
             else:


### PR DESCRIPTION
Added parameter for add_user which allows to create user with multiple roles with single add_user call, the backward compatibility with `role` parameter is kept .