### PR TITLE
New, Fixes #1154 by adding LOGOUT_REDIRECT_URL

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -194,6 +194,8 @@ Use config.py to configure the following parameters. By default it will use SQLL
 |                                   | the existing languages with the countries  |           |
 |                                   | name and flag                              |           |
 +-----------------------------------+--------------------------------------------+-----------+
+| LOGOUT_REDIRECT_URL               | The location to redirect to after logout   |   No      |
++-----------------------------------+--------------------------------------------+-----------+
 | FAB_API_SHOW_STACKTRACE           | Sends api stack trace on uncaught          |   No      |
 |                                   | exceptions. (Boolean)                      |           |
 +-----------------------------------+--------------------------------------------+-----------+

--- a/flask_appbuilder/security/views.py
+++ b/flask_appbuilder/security/views.py
@@ -477,7 +477,11 @@ class AuthView(BaseView):
     @expose("/logout/")
     def logout(self):
         logout_user()
-        return redirect(self.appbuilder.get_url_for_index)
+        return redirect(
+            self.appbuilder.app.config.get(
+                "LOGOUT_REDIRECT_URL", self.appbuilder.get_url_for_index
+            )
+        )
 
 
 class AuthDBView(AuthView):

--- a/flask_appbuilder/tests/test_menu.py
+++ b/flask_appbuilder/tests/test_menu.py
@@ -5,14 +5,10 @@ from flask_appbuilder import SQLA
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 
 from .base import FABTestCase
+from .const import MAX_PAGE_SIZE, PASSWORD_ADMIN, USERNAME_ADMIN
 from .sqla.models import Model1
+
 log = logging.getLogger(__name__)
-
-DEFAULT_ADMIN_USER = "admin"
-DEFAULT_ADMIN_PASSWORD = "general"
-
-LIMITED_USER = "user1"
-LIMITED_USER_PASSWORD = "user1"
 
 
 class FlaskTestCase(FABTestCase):
@@ -23,13 +19,8 @@ class FlaskTestCase(FABTestCase):
 
         self.app = Flask(__name__)
         self.basedir = os.path.abspath(os.path.dirname(__file__))
-        self.app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///"
-        self.app.config["CSRF_ENABLED"] = False
-        self.app.config["SECRET_KEY"] = "thisismyscretkey"
-        self.app.config["WTF_CSRF_ENABLED"] = False
-        self.app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-
-        logging.basicConfig(level=logging.ERROR)
+        self.app.config.from_object("flask_appbuilder.tests.config_api")
+        self.app.config["FAB_API_MAX_PAGE_SIZE"] = MAX_PAGE_SIZE
 
         self.db = SQLA(self.app)
         self.appbuilder = AppBuilder(self.app, self.db.session)
@@ -38,35 +29,6 @@ class FlaskTestCase(FABTestCase):
             datamodel = SQLAInterface(Model1)
 
         self.appbuilder.add_view(Model1View, "Model1")
-        role_admin = self.appbuilder.sm.find_role("Admin")
-        self.appbuilder.sm.add_user(
-            DEFAULT_ADMIN_USER,
-            "admin",
-            "user",
-            "admin@fab.org",
-            role_admin,
-            DEFAULT_ADMIN_PASSWORD
-        )
-
-        role_limited = self.appbuilder.sm.add_role("LimitedUser")
-        pvm = self.appbuilder.sm.find_permission_view_menu(
-            "menu_access",
-            "Model1"
-        )
-        self.appbuilder.sm.add_permission_role(role_limited, pvm)
-        pvm = self.appbuilder.sm.find_permission_view_menu(
-            "can_get",
-            "MenuApi"
-        )
-        self.appbuilder.sm.add_permission_role(role_limited, pvm)
-        self.appbuilder.sm.add_user(
-            LIMITED_USER,
-            "user1",
-            "user1",
-            "user1@fab.org",
-            role_limited,
-            LIMITED_USER_PASSWORD
-        )
 
     def tearDown(self):
         self.appbuilder = None
@@ -74,50 +36,109 @@ class FlaskTestCase(FABTestCase):
         self.db = None
         log.debug("TEAR DOWN")
 
+    def test_menu_access_denied(self):
+        """
+            REST Api: Test menu logged out access denied
+        :return:
+        """
+        uri = "/api/v1/menu/"
+        client = self.app.test_client()
+
+        # as logged out user
+        rv = client.get(uri)
+        self.assertEqual(rv.status_code, 401)
+
     def test_menu_api(self):
         """
             REST Api: Test menu data
         """
-        uri = '/api/v1/menu/'
+        uri = "/api/v1/menu/"
         client = self.app.test_client()
 
-        # as loged out user
-        rv = client.get(uri)
-        self.assertEqual(rv.status_code, 401)
-
-        # as limited user
-        token = self.login(client, LIMITED_USER, LIMITED_USER_PASSWORD)
+        token = self.login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
         rv = self.auth_client_get(client, token, uri)
         self.assertEqual(rv.status_code, 200)
-        data = rv.data.decode('utf-8')
+        data = rv.data.decode("utf-8")
+        self.assertIn("Security", data)
+        self.assertIn("Model1", data)
+
+    def test_menu_api_limited(self):
+        """
+            REST Api: Test limited menu data
+        """
+        limited_user = "user1"
+        limited_password = "user1"
+        limited_role = "Limited"
+
+        role = self.appbuilder.sm.add_role(limited_role)
+        pvm = self.appbuilder.sm.find_permission_view_menu("menu_access", "Model1")
+        self.appbuilder.sm.add_permission_role(role, pvm)
+        pvm = self.appbuilder.sm.find_permission_view_menu("can_get", "MenuApi")
+        self.appbuilder.sm.add_permission_role(role, pvm)
+        self.appbuilder.sm.add_user(
+            limited_user, "user1", "user1", "user1@fab.org", role, limited_password
+        )
+
+        uri = "/api/v1/menu/"
+        client = self.app.test_client()
+        # as limited user
+        token = self.login(client, limited_user, limited_password)
+        rv = self.auth_client_get(client, token, uri)
+        self.assertEqual(rv.status_code, 200)
+        data = rv.data.decode("utf-8")
         self.assertNotIn("Security", data)
         self.assertIn("Model1", data)
 
         self.browser_logout(client)
 
-        # as admin
-        token = self.login(client, DEFAULT_ADMIN_USER, DEFAULT_ADMIN_PASSWORD)
-        rv = self.auth_client_get(client, token, uri)
+        # Revert test data
+        self.appbuilder.get_session.delete(
+            self.appbuilder.sm.find_user(username=limited_user)
+        )
+        self.appbuilder.get_session.delete(self.appbuilder.sm.find_role(limited_role))
+        self.appbuilder.get_session.commit()
+
+    def test_menu_api_public(self):
+        """
+            REST Api: Test public menu data
+        """
+        role = self.appbuilder.sm.find_role("Public")
+        pvm = self.appbuilder.sm.find_permission_view_menu("menu_access", "Model1")
+        self.appbuilder.sm.add_permission_role(role, pvm)
+        pvm = self.appbuilder.sm.find_permission_view_menu("can_get", "MenuApi")
+        self.appbuilder.sm.add_permission_role(role, pvm)
+
+        uri = "/api/v1/menu/"
+        client = self.app.test_client()
+        # as limited user
+        rv = client.get(uri)
         self.assertEqual(rv.status_code, 200)
-        data = rv.data.decode('utf-8')
-        self.assertIn("Security", data)
+        data = rv.data.decode("utf-8")
         self.assertIn("Model1", data)
+
+        # Revert test data
+        role = self.appbuilder.sm.find_role("Public")
+        role.permissions = []
+        self.appbuilder.get_session.commit()
 
     def test_redirect_after_logout(self):
         """
             REST Api: Test redirect after logout
         """
+        limited_user = "user1"
+        limited_password = "user1"
+
         client = self.app.test_client()
 
-        self.login(client, LIMITED_USER, LIMITED_USER_PASSWORD)
+        self.login(client, limited_user, limited_password)
         rv = self.browser_logout(client)
 
         # make sure that browser is redirected to /
-        self.assertEqual(rv.headers["Location"].split('/')[-1], '')
+        self.assertEqual(rv.headers["Location"].split("/")[-1], "")
 
-        self.login(client, LIMITED_USER, LIMITED_USER_PASSWORD)
+        self.login(client, limited_user, limited_password)
         self.app.config["LOGOUT_REDIRECT_URL"] = "/logged_out"
         rv = self.browser_logout(client)
 
         # make sure that browser is redirected to LOGOUT_REDIRECT_URL
-        self.assertEqual(rv.headers["Location"].split('/')[-1], 'logged_out')
+        self.assertEqual(rv.headers["Location"].split("/")[-1], "logged_out")

--- a/flask_appbuilder/tests/test_menu.py
+++ b/flask_appbuilder/tests/test_menu.py
@@ -102,3 +102,22 @@ class FlaskTestCase(FABTestCase):
         data = rv.data.decode('utf-8')
         self.assertIn("Security", data)
         self.assertIn("Model1", data)
+
+    def test_redirect_after_logout(self):
+        """
+            REST Api: Test redirect after logout
+        """
+        client = self.app.test_client()
+
+        self.login(client, LIMITED_USER, LIMITED_USER_PASSWORD)
+        rv = self.browser_logout(client)
+
+        # make sure that browser is redirected to /
+        self.assertEqual(rv.headers["Location"].split('/')[-1], '')
+
+        self.login(client, LIMITED_USER, LIMITED_USER_PASSWORD)
+        self.app.config["LOGOUT_REDIRECT_URL"] = "/logged_out"
+        rv = self.browser_logout(client)
+
+        # make sure that browser is redirected to LOGOUT_REDIRECT_URL
+        self.assertEqual(rv.headers["Location"].split('/')[-1], 'logged_out')


### PR DESCRIPTION
This pull request addresses #1154, by redirecting to `LOGOUT_REDIRECT_URL` in the *logout* view if `LOGOUT_REDIRECT_URL` is set in the config, falling back to `self.appbuilder.get_url_for_index`.
It also adds `LOGOUT_REDIRECT_URL` to the **Configuration keys** table in `docs/config.rst`, and adds a unit test.