### PR TITLE
Bump to 2.2.0rc2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Flask-AppBuilder ChangeLog
 ==========================
 
+Improvements and Bug fixes on 2.2.0
+-----------------------------------
+
+- Fix, #1157 Improve API get menu data performance
+- Fix, #1143 [mvc] pagination
+- Fix, #1147 [babel] crash with empty LANGUAGES config key
+- New, #1116 Expose menu data as serializable objects
+- Fix, #1127 MSSQL issue with pagination
+- Fix, #1132 Add autofocus for login screen (#1132)
+- Fix, #1125 Support absence of the public role (#1125)
+- New, #1124 hide tabs when only 'Detail' (no related_views)
+- Fix, #1119 ldap: safely retrieve error object when loggin exception
+
 Improvements and Bug fixes on 2.1.13
 ------------------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Flask-AppBuilder ChangeLog
 ==========================
 
-Improvements and Bug fixes on 2.2.0
------------------------------------
+Improvements and Bug fixes on 2.2.0rc2
+--------------------------------------
 
 - Fix, #1157 Improve API get menu data performance
 - Fix, #1143 [mvc] pagination

--- a/flask_appbuilder/__init__.py
+++ b/flask_appbuilder/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Daniel Vaz Gaspar"
-__version__ = "2.1.13"
+__version__ = "2.2.0rc2"
 
 from .actions import action  # noqa: F401
 from .api import ModelRestApi  # noqa: F401


### PR DESCRIPTION
Improvements and Bug fixes on 2.2.0rc2
--------------------------------------

- Fix, #1157 Improve API get menu data performance
- Fix, #1143 [mvc] pagination
- Fix, #1147 [babel] crash with empty LANGUAGES config key
- New, #1116 Expose menu data as serializable objects
- Fix, #1127 MSSQL issue with pagination
- Fix, #1132 Add autofocus for login screen (#1132)
- Fix, #1125 Support absence of the public role (#1125)
- New, #1124 hide tabs when only 'Detail' (no related_views)
- Fix, #1119 ldap: safely retrieve error object when loggin exception
