### PR TITLE
Fix, create filters even when search_columns is empty

### DIFF
--- a/flask_appbuilder/models/filters.py
+++ b/flask_appbuilder/models/filters.py
@@ -131,7 +131,7 @@ class Filters(object):
         self.clear_filters()
         if self.search_columns:
             self._search_filters = self._get_filters(self.search_columns)
-            self._all_filters = self._get_filters(datamodel.get_columns_list())
+        self._all_filters = self._get_filters(datamodel.get_columns_list())
 
     def get_search_filters(self):
         return self._search_filters


### PR DESCRIPTION
Without this change, filters for e.g. add endpoints on views will not
be created unless there are search_columns defined.

This leads to a KeyError when filter columns are indexed,
breaking endpoints like /fooview/add?_flt_0_bar=1 even when
bar is a column that can be filtered.
