### PR TITLE
New, 1172 support jsonapi

### DIFF
--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -936,7 +936,7 @@ class ModelRestApi(BaseModelApi):
                     self.add_columns, nested=False, enum_dump_by_name=True
                 )
             )
-        if self.edit_model_schema [requested_type()]is None:
+        if self.edit_model_schema[requested_type()] is None:
             self.edit_model_schema = defaultdict(
                 lambda: self.model2schemaconverter.convert(
                     self.edit_columns, nested=False, enum_dump_by_name=True
@@ -982,9 +982,7 @@ class ModelRestApi(BaseModelApi):
             list(self.list_model_schema[requested_type()]._declared_fields.keys())
         else:
             self.list_columns = self.list_columns or [
-                x
-                for x in list_cols
-                if x not in self.list_exclude_columns
+                x for x in list_cols if x not in self.list_exclude_columns
             ]
 
         self.order_columns = (
@@ -1453,13 +1451,17 @@ class ModelRestApi(BaseModelApi):
         try:
             self.datamodel.add(item.data, raise_exception=True)
             self.post_add(item.data)
-            result = self.add_model_schema[requested_type()].dump(
-                item.data, many=False
-            ).data
-            response_body = result if jsonapi_requested() else {
-                API_RESULT_RES_KEY: result,
-                "id": self.datamodel.get_pk_value(item.data),
-            }
+            result = (
+                self.add_model_schema[requested_type()].dump(item.data, many=False).data
+            )
+            response_body = (
+                result
+                if jsonapi_requested()
+                else {
+                    API_RESULT_RES_KEY: result,
+                    "id": self.datamodel.get_pk_value(item.data),
+                }
+            )
             return self.response(201, **response_body)
         except IntegrityError as e:
             return self.response_422(message=str(e.orig))
@@ -1537,9 +1539,9 @@ class ModelRestApi(BaseModelApi):
             return self.response_404()
         data = request.json["data"]
         if str(data["id"]) != pk:
-            return self.response(400, errors=[
-                {"detail": "ID mismatch between URL and body"},
-            ])
+            return self.response(
+                400, errors=[{"detail": "ID mismatch between URL and body"}]
+            )
         if data["type"] != self.datamodel.obj.__name__:
             msg = f"Got type {data['type']}, should be {self.datamodel.obj.__name__}"
             return self.response(400, errors=[{"detail": msg}])
@@ -1617,9 +1619,9 @@ class ModelRestApi(BaseModelApi):
             return self.response(
                 200,
                 **{
-                    API_RESULT_RES_KEY: self.edit_model_schema[requested_type()].dump(
-                        item.data, many=False
-                    ).data
+                    API_RESULT_RES_KEY: self.edit_model_schema[requested_type()]
+                    .dump(item.data, many=False)
+                    .data
                 },
             )
         except IntegrityError as e:
@@ -1834,9 +1836,9 @@ class ModelRestApi(BaseModelApi):
         :param data: python data structure
         :return: python data structure
         """
-        data_item = self.edit_model_schema[requested_type()].dump(
-            model_item, many=False
-        ).data
+        data_item = (
+            self.edit_model_schema[requested_type()].dump(model_item, many=False).data
+        )
         for _col in self.edit_columns:
             if _col not in data.keys():
                 data[_col] = data_item[_col]

--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -17,7 +17,7 @@ import yaml
 
 from .convert import Model2SchemaConverter
 from .schemas import get_info_schema, get_item_schema, get_list_schema
-from .util import requested_type
+from .util import requested_type, jsonapi_requested
 from .._compat import as_unicode
 from ..const import (
     API_ADD_COLUMNS_RES_KEY,
@@ -976,6 +976,7 @@ class ModelRestApi(BaseModelApi):
         self.edit_exclude_columns = self.edit_exclude_columns or []
         self.order_rel_fields = self.order_rel_fields or {}
         # Generate base props
+        self.primary_key_columns = self.datamodel.get_primary_key_columns()
         list_cols = self.datamodel.get_user_columns_list()
         if not self.list_columns and self.list_model_schema[requested_type()]:
             list(self.list_model_schema[requested_type()]._declared_fields.keys())
@@ -1300,6 +1301,8 @@ class ModelRestApi(BaseModelApi):
             _args,
             **{API_SELECT_COLUMNS_RIS_KEY: _pruned_select_cols},
         )
+        if _pruned_select_cols and jsonapi_requested():
+            _pruned_select_cols.extend(self.primary_key_columns)
 
         if _pruned_select_cols:
             _list_model_schema = self.model2schemaconverter.convert(_pruned_select_cols)

--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -982,7 +982,7 @@ class ModelRestApi(BaseModelApi):
         else:
             self.list_columns = self.list_columns or [
                 x
-                for x in self.datamodel.get_user_columns_list()
+                for x in list_cols
                 if x not in self.list_exclude_columns
             ]
 

--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -1,8 +1,8 @@
+from collections import defaultdict
 import functools
 import logging
 import re
 import traceback
-from collections import defaultdict
 
 from apispec import yaml_utils
 from flask import Blueprint, current_app, jsonify, make_response, request
@@ -17,7 +17,7 @@ import yaml
 
 from .convert import Model2SchemaConverter
 from .schemas import get_info_schema, get_item_schema, get_list_schema
-from .util import requested_type, jsonapi_requested
+from .util import jsonapi_requested, requested_type
 from .._compat import as_unicode
 from ..const import (
     API_ADD_COLUMNS_RES_KEY,

--- a/flask_appbuilder/api/convert.py
+++ b/flask_appbuilder/api/convert.py
@@ -26,7 +26,7 @@ class Tree:
     """
 
     def __init__(self):
-        self.root = TreeNode('+')
+        self.root = TreeNode("+")
 
     def add(self, data):
         node = TreeNode(data)
@@ -52,18 +52,14 @@ class Tree:
 def columns2Tree(columns):
     tree = Tree()
     for column in columns:
-        if '.' in column:
-            tree.add_child(
-                column.split('.')[0],
-                column.split('.')[1]
-            )
+        if "." in column:
+            tree.add_child(column.split(".")[0], column.split(".")[1])
         else:
             tree.add(column)
     return tree
 
 
 class BaseModel2SchemaConverter(object):
-
     def __init__(self, datamodel, validators_columns):
         """
         :param datamodel: SQLAInterface
@@ -143,11 +139,7 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
             required = not datamodel.is_nullable(column.data)
             nested_model = datamodel.get_related_model(column.data)
             lst = [item.data for item in column.childs]
-            nested_schema = self.convert(
-                lst,
-                nested_model,
-                nested=False
-            )
+            nested_schema = self.convert(lst, nested_model, nested=False)
             if datamodel.is_relation_many_to_one(column.data):
                 many = False
             elif datamodel.is_relation_many_to_many(column.data):
@@ -160,9 +152,10 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
             return field
         # Handle bug on marshmallow-sqlalchemy #163
         elif datamodel.is_relation(column.data):
-            if (datamodel.is_relation_many_to_many(column.data) or
-                    datamodel.is_relation_one_to_many(column.data)):
-                if datamodel.get_info(column.data).get('required', False):
+            if datamodel.is_relation_many_to_many(
+                column.data
+            ) or datamodel.is_relation_one_to_many(column.data):
+                if datamodel.get_info(column.data).get("required", False):
                     required = True
                 else:
                     required = False
@@ -176,8 +169,7 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
         elif datamodel.is_enum(column.data):
             required = not datamodel.is_nullable(column.data)
             enum_class = datamodel.list_columns[column.data].info.get(
-                'enum_class',
-                datamodel.list_columns[column.data].type
+                "enum_class", datamodel.list_columns[column.data].type
             )
             if enum_dump_by_name:
                 enum_dump_by = EnumField.NAME
@@ -187,10 +179,10 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
             field.unique = datamodel.is_unique(column.data)
             return field
         # is custom property method field?
-        if hasattr(getattr(_model, column.data), 'fget'):
+        if hasattr(getattr(_model, column.data), "fget"):
             return fields_module.Raw(dump_only=True)
         # is a normal model field not a function?
-        if not hasattr(getattr(_model, column.data), '__call__'):
+        if not hasattr(getattr(_model, column.data), "__call__"):
             field = field_for(_model, column.data)
             field.unique = datamodel.is_unique(column.data)
             if column.data in self.validators_columns:
@@ -199,13 +191,13 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
 
     @staticmethod
     def get_column_child_model(column):
-        if '.' in column:
-            return column.split('.')[0]
+        if "." in column:
+            return column.split(".")[0]
         return column
 
     @staticmethod
     def is_column_dotted(column):
-        return '.' in column
+        return "." in column
 
     def convert(self, columns, model=None, nested=True, enum_dump_by_name=False):
         """
@@ -217,11 +209,7 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
         :param nested: Generate relation with nested schemas
         :return: ModelSchema object
         """
-        super(Model2SchemaConverter, self).convert(
-            columns,
-            model=model,
-            nested=nested
-        )
+        super(Model2SchemaConverter, self).convert(columns, model=model, nested=nested)
 
         class SchemaMixin:
             pass
@@ -236,10 +224,7 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
         for column in tree_columns.root.childs:
             # Get child model is column is dotted notation
             ma_sqla_fields_override[column.data] = self._column2field(
-                _datamodel,
-                column,
-                nested,
-                enum_dump_by_name
+                _datamodel, column, nested, enum_dump_by_name
             )
             _columns.append(column.data)
         for k, v in ma_sqla_fields_override.items():

--- a/flask_appbuilder/api/convert.py
+++ b/flask_appbuilder/api/convert.py
@@ -94,20 +94,17 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
         :return: ModelSchema
         """
         _model = model
+        attrs = {}
+        meta_attrs = {
+            "model": _model,
+            "strict": True,
+            "sqla_session": self.datamodel.session,
+        }
+        parent_classes = (ModelSchema, class_mixin)
         if columns:
-            class MetaSchema(ModelSchema, class_mixin):
-                class Meta:
-                    model = _model
-                    fields = columns
-                    strict = True
-                    sqla_session = self.datamodel.session
-        else:
-            class MetaSchema(ModelSchema, class_mixin):
-                class Meta:
-                    model = _model
-                    strict = True
-                    sqla_session = self.datamodel.session
-        return MetaSchema
+            meta_attrs["fields"] = columns
+        attrs["Meta"] = type("Meta", (), meta_attrs)
+        return type("MetaSchema", parent_classes, attrs)
 
     def _column2field(self, datamodel, column, nested=True, enum_dump_by_name=False):
         """

--- a/flask_appbuilder/api/convert.py
+++ b/flask_appbuilder/api/convert.py
@@ -1,10 +1,10 @@
 from marshmallow import fields
+from marshmallow_enum import EnumField
 from marshmallow_jsonapi import (
     fields as jsonapi_fields,
     Schema as JsonApiSchema,
     SchemaOpts as JsonApiSchemaOpts,
 )
-from marshmallow_enum import EnumField
 from marshmallow_sqlalchemy import field_for
 from marshmallow_sqlalchemy.schema import ModelSchema, ModelSchemaOpts
 

--- a/flask_appbuilder/api/util.py
+++ b/flask_appbuilder/api/util.py
@@ -1,0 +1,12 @@
+from flask import request
+
+
+JSON_MIME = "application/json"
+
+
+def requested_type():
+    """Get requested response mime-type."""
+    try:
+        return request.headers.get("Accept", JSON_MIME)
+    except RuntimeError:  # Called outside request context
+        return JSON_MIME

--- a/flask_appbuilder/api/util.py
+++ b/flask_appbuilder/api/util.py
@@ -2,6 +2,7 @@ from flask import request
 
 
 JSON_MIME = "application/json"
+JSONAPI_MIME = "application/vnd.api+json"
 
 
 def requested_type():
@@ -10,3 +11,11 @@ def requested_type():
         return request.headers.get("Accept", JSON_MIME)
     except RuntimeError:  # Called outside request context
         return JSON_MIME
+
+
+def jsonapi_requested():
+    """
+    Check whether the requester explicitly requested a response in the
+    JSON:API format.
+    """
+    return requested_type() == JSONAPI_MIME

--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -169,10 +169,10 @@ class SQLAInterface(BaseInterface):
 
         # MSSQL exception page/limit must have an order by
         if (
-                page
-                and page_size
-                and not order_column
-                and self.session.bind.dialect.name == "mssql"
+            page
+            and page_size
+            and not order_column
+            and self.session.bind.dialect.name == "mssql"
         ):
             pk_name = self.get_pk_name()
             query = query.order_by(pk_name)

--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -565,6 +565,9 @@ class SQLAInterface(BaseInterface):
         """
         return list(self.list_properties.keys())
 
+    def get_primary_key_columns(self):
+        return [pk.name for pk in self.obj.__mapper__.primary_key]
+
     def get_user_columns_list(self):
         """
             Returns all model's columns except pk or fk
@@ -650,7 +653,7 @@ class SQLAInterface(BaseInterface):
         return self.session.query(self.obj).get(id)
 
     def get_pk_name(self):
-        pk = [pk.name for pk in self.obj.__mapper__.primary_key]
+        pk = self.get_primary_key_columns()
         if pk:
             return pk if self.is_pk_composite() else pk[0]
 

--- a/flask_appbuilder/tests/base.py
+++ b/flask_appbuilder/tests/base.py
@@ -11,8 +11,9 @@ from flask_appbuilder.const import (
 
 class FABTestCase(unittest.TestCase):
     @staticmethod
-    def auth_client_get(client, token, uri):
-        return client.get(uri, headers={"Authorization": "Bearer {}".format(token)})
+    def auth_client_get(client, token, uri, extra_headers=None):
+        headers = {"Authorization": f"Bearer {token}", **(extra_headers or {})}
+        return client.get(uri, headers=headers)
 
     @staticmethod
     def auth_client_delete(client, token, uri):

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import json
 import logging
 import os
@@ -301,6 +302,7 @@ class APITestCase(FABTestCase):
                 "get_list": "access",
                 "get": "access",
                 "put": "access",
+                "patch": "access",
                 "post": "access",
                 "delete": "access",
                 "info": "access",
@@ -1296,6 +1298,7 @@ class APITestCase(FABTestCase):
             "can_delete",
             "can_get",
             "can_info",
+            "can_patch",
             "can_post",
             "can_put",
         ]
@@ -1711,7 +1714,7 @@ class APITestCase(FABTestCase):
         from .sqla.models import Model1CustomSchema
 
         class Model1ApiCustomSchema(self.model1api):
-            add_model_schema = Model1CustomSchema()
+            add_model_schema = defaultdict(Model1CustomSchema)
 
         self.appbuilder.add_api(Model1ApiCustomSchema)
 
@@ -1939,6 +1942,7 @@ class APITestCase(FABTestCase):
                 "get_list": "access",
                 "get": "access",
                 "put": "access",
+                "patch": "access",
                 "post": "access",
                 "delete": "access",
                 "info": "access",
@@ -1985,6 +1989,7 @@ class APITestCase(FABTestCase):
                 "get_list": "read",
                 "get": "read",
                 "put": "write",
+                "patch": "write",
                 "post": "write",
                 "delete": "write",
                 "info": "read",
@@ -2032,6 +2037,7 @@ class APITestCase(FABTestCase):
                 "get_list": "read",
                 "get": "read",
                 "put": "write",
+                "patch": "write",
                 "post": "write",
                 "delete": "write",
                 "info": "read",
@@ -2063,6 +2069,7 @@ class APITestCase(FABTestCase):
                 "get_list": "access2",
                 "get": "access2",
                 "put": "access2",
+                "patch": "access2",
                 "post": "access2",
                 "delete": "access2",
                 "info": "access2",
@@ -2091,10 +2098,12 @@ class APITestCase(FABTestCase):
                 ("Model1Api", "can_delete"): {("api2", "can_access2")},
                 ("Model1Api", "can_info"): {("api2", "can_access2")},
                 ("Model1Api", "can_put"): {("api2", "can_access2")},
+                ("Model1Api", "can_patch"): {("api2", "can_access2")},
                 ("Model1Api", "can_post"): {("api2", "can_access2")},
             },
             "del_role_pvm": {
                 ("Model1Api", "can_put"),
+                ("Model1Api", "can_patch"),
                 ("Model1Api", "can_delete"),
                 ("Model1Api", "can_get"),
                 ("Model1Api", "can_info"),
@@ -2130,6 +2139,7 @@ class APITestCase(FABTestCase):
                 "get_list": "get",
                 "get": "get",
                 "put": "put",
+                "patch": "patch",
                 "post": "post",
                 "delete": "delete",
                 "info": "info",
@@ -2138,6 +2148,7 @@ class APITestCase(FABTestCase):
                 "get_list": "access",
                 "get": "access",
                 "put": "access",
+                "patch": "access",
                 "post": "access",
                 "delete": "access",
                 "info": "access",
@@ -2162,6 +2173,7 @@ class APITestCase(FABTestCase):
                     ("Model1PermOverride", "can_get"),
                     ("Model1PermOverride", "can_post"),
                     ("Model1PermOverride", "can_put"),
+                    ("Model1PermOverride", "can_patch"),
                     ("Model1PermOverride", "can_delete"),
                     ("Model1PermOverride", "can_info"),
                 }
@@ -2173,4 +2185,4 @@ class APITestCase(FABTestCase):
         state_transitions = self.appbuilder.security_converge()
         self.assertEqual(state_transitions, target_state_transitions)
         role = self.appbuilder.sm.find_role("Test")
-        self.assertEqual(len(role.permissions), 5)
+        self.assertEqual(len(role.permissions), 6)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ jinja2==2.10.1            # via flask, flask-babel
 jsonschema==3.0.1
 markupsafe==1.1.1         # via jinja2
 marshmallow-enum==1.4.1
+marshmallow-jsonapi==0.22.0
 marshmallow-sqlalchemy==0.16.2
 marshmallow==2.18.0
 prison==0.1.2

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         "jsonschema>=3.0.1, <4",
         "marshmallow>=2.18.0, <2.20",
         "marshmallow-enum>=1.4.1, <2",
+        "marshmallow-jsonapi<0.30,>=0.22.0",
         "marshmallow-sqlalchemy>=0.16.1, <1",
         "python-dateutil>=2.3, <3",
         "prison>=0.1.2, <1.0.0",


### PR DESCRIPTION
This PR adds support for accepting JSON:API-compliant requests and producing JSON:API-compliant responses when the `Accept` header is set to `application/vnd.api+json`. Ideally we would want to separate the expected request format and the produced response format because the HTTP standard governs them with respectively the `Content-Type` and `Accept` headers, but because they use the same Marshmallow schema and are nearly impossible to decouple, I used `Accept` for both.

In order to implement this change, I had to proxy some function calls with a defaultdict, and key them with a value that is not passed to the function in question, but is still available to it through a side-effect and influences its result. I wrote a pretty long comment in the code to explain this, but it may still prove to be a source of confusion, so do not hesitate to tell me if you have suggestions that would help further clarify this.

Finally, the diff of this pull request may be a bit overwhelming if you view it all at once, but if you review this PR on a commit-by-commit basis then every individual commit should have an easy-to-understand scope.

I did some API calls to test the new functionality as well as the old functionality, and it seemed to work, but my tests have been far from extensive. I also have not taken a look at how to run the unit tests yet, which also means I have not run any tests, nor have I added any tests for the new functionality.

Finally, this PR contains the basis to make the API mostly JSON:API-compliant, but a lot of error responses are still non-conformant to the standard, some HTTP response codes may or may not be nonconformant, and the OpenAPI spec bits I added do not specify any request/response body elements beyond what is included in `data`. I also have not tested with any models that include relationships, nor have I paid any attention to relationship-related functionality.

I feel that the scope of this PR would grow waaay too big if I aimed for full JSON:API compliance from the get-go, so probably we will have to create smaller issues for any non-compliant things that we find, and not pull them in scope of this PR. More extensive testing (especially for "old-style" (non-JSON:API) requests in more complex apps than the Hello World one I tested with) is still advisable before merging though, even if just to check that I did not break anything that worked before. Because of this, I will mark the PR as a draft for now, even though it very well may turn out to be ready.

Closes #1172.