### PR TITLE
Fix, JWT refresh endpoint should return new access_token

### DIFF
--- a/flask_appbuilder/security/api.py
+++ b/flask_appbuilder/security/api.py
@@ -123,7 +123,7 @@ class SecurityApi(BaseApi):
                   schema:
                     type: object
                     properties:
-                      refresh_token:
+                      access_token:
                         type: string
             401:
               $ref: '#/components/responses/401'
@@ -133,7 +133,7 @@ class SecurityApi(BaseApi):
             - jwt_refresh: []
         """
         resp = {
-            API_SECURITY_REFRESH_TOKEN_KEY: create_access_token(
+            API_SECURITY_ACCESS_TOKEN_KEY: create_access_token(
                 identity=get_jwt_identity(), fresh=False
             )
         }


### PR DESCRIPTION
When calling the JWT refresh endpoint (/security/refresh) using the refresh_token it should return a new access_token
But it's returning a new refresh_token
However looking at the FAB source code I think it is indeed returning a new access_token but naming it as refresh_token
