### PR TITLE
Fix quoting attribute in jquery

### DIFF
--- a/flask_appbuilder/static/appbuilder/js/ab_keep_tab.js
+++ b/flask_appbuilder/static/appbuilder/js/ab_keep_tab.js
@@ -14,7 +14,7 @@ $(function()
     //go to the latest tab, if it exists:
     var lastTab = localStorage.getItem('lastTab');
     if (lastTab) {
-        $('a[href=' + lastTab + ']').tab('show');
+        $('a[href="' + lastTab + '"]').tab('show');
     }
     else
     {


### PR DESCRIPTION
Since jquery 1.5, quoting attribute values is mandatory.

Thank you for contributing to Flask-Appbuilder. 

For Fixes:

Please, prefix the title with "Fix, " and describe in detail what you're fixing and the steps required to reproduce the problem.

For new features:

Please, prefix the title with "New, " and describe this new feature in detail, remember to update documentation.

