### PR TITLE
[security] Fix, authentication error when using oracle dialect

### DIFF
--- a/flask_appbuilder/security/sqla/manager.py
+++ b/flask_appbuilder/security/sqla/manager.py
@@ -311,8 +311,8 @@ class SecurityManager(BaseSecurityManager):
             )
             .exists()
         )
-        # Special case for MSSQL (works on PG and MySQL > 8)
-        if self.appbuilder.get_session.bind.dialect.name == "mssql":
+        # Special case for MSSQL/Oracle (works on PG and MySQL > 8)
+        if self.appbuilder.get_session.bind.dialect.name in ("mssql", "oracle"):
             return self.appbuilder.get_session.query(literal(True)).filter(q).scalar()
         return self.appbuilder.get_session.query(q).scalar()
 


### PR DESCRIPTION
This commit applies for oralce dialect the same query strategy already implemeted for MSSQL in
security manager when checking for authentication/permissions, since a
query like "SELECT EXISTS(1) FROM DUAL" in oracle databases would raise
an ORA-00936: missing expression error (observed from version 18c on)

Steps to reproduce the error:
1 - Configure a connection through the oracle dialect to an oracle instance (>=18c)
2 - Create an admin user through flask fab create-admin
3 - Login into the application


Thank you for contributing to Flask-Appbuilder. 

For Fixes:

Please, prefix the title with "Fix, " and describe in detail what you're fixing and the steps required to reproduce the problem.

For new features:

Please, prefix the title with "New, " and describe this new feature in detail, remember to update documentation.

