### PR TITLE
[api] Fix, openapi spec for the info endpoint

### DIFF
--- a/flask_appbuilder/api/schemas.py
+++ b/flask_appbuilder/api/schemas.py
@@ -110,5 +110,15 @@ get_info_schema = {
                 },
             },
         },
+        API_EDIT_COLUMNS_RIS_KEY: {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    API_PAGE_SIZE_RIS_KEY: {"type": "integer"},
+                    API_PAGE_INDEX_RIS_KEY: {"type": "integer"},
+                },
+            },
+        },
     },
 }


### PR DESCRIPTION
Adds a missing key (edit_columns) on the OpenApi spec for the `_info` endpoint
