### PR TITLE
[api] New, exclude route methods from ModelRestApi

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -1431,6 +1431,26 @@ on all HTTP methods. These methods are nice places to change data before submiss
         :members: pre_get, pre_get_list, pre_update, post_update, pre_add, post_add, pre_delete, post_delete
         :noindex:
 
+Excluding builtin generated routes
+----------------------------------
+
+There may be the case where you want to leverage some of the auto generated endpoints but want to disable others.
+For example you may want to just expose the GET endpoints for fetching a single record or records.
+You can declare which methods don't get registered on the Flask blueprint for the class (no permissions are created
+also, since it's like the methods do not exist)::
+
+
+    class ContactApi(ModelRestApi):
+        datamodel = SQLAInterface(Contact)
+        exclude_route_methods = ("put", "post", "delete", "info")
+
+    appbuilder.add_api(ContactApi)
+
+
+On the previous example only the ``get`` and ``get_list`` methods are registered
+
+Note that using by normal OOP, you can override any builtin methods or create new ones
+
 Enum Fields
 -----------
 
@@ -1438,8 +1458,8 @@ Enum Fields
 on a specific way::
 
     class GenderEnum(enum.Enum):
-    male = 'Male'
-    female = 'Female'
+        male = 'Male'
+        female = 'Female'
 
 
     class Contact(Model):

--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -343,12 +343,12 @@ class BaseApi(object):
     """
         Does not register routes for a set builtin ModelRestApi functions.
         example::
-        
+
             class ContactModelView(ModelRestApi):
                 datamodel = SQLAModel(Contact)
-                exclude_route_methods = ("info", "get_list", "get")            
-    
-        
+                exclude_route_methods = ("info", "get_list", "get")
+
+
         The previous examples will only register the `put`, `post` and `delete` routes
     """
 

--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -341,7 +341,7 @@ class BaseApi(object):
 
     exclude_route_methods = set()
     """
-        Does not register routes for a set builtin ModelRestApi functions.
+        Does not register routes for a set of builtin ModelRestApi functions.
         example::
 
             class ContactModelView(ModelRestApi):

--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -339,6 +339,19 @@ class BaseApi(object):
         Override custom OpenApi responses
     """
 
+    exclude_route_methods = set()
+    """
+        Does not register routes for a set builtin ModelRestApi functions.
+        example::
+        
+            class ContactModelView(ModelRestApi):
+                datamodel = SQLAModel(Contact)
+                exclude_route_methods = ("info", "get_list", "get")            
+    
+        
+        The previous examples will only register the `put`, `post` and `delete` routes
+    """
+
     def __init__(self):
         """
             Initialization of base permissions
@@ -372,6 +385,9 @@ class BaseApi(object):
             self.base_permissions = set()
             is_add_base_permissions = True
         for attr_name in dir(self):
+            # Don't create permission for excluded routes
+            if attr_name in self.exclude_route_methods:
+                continue
             if hasattr(getattr(self, attr_name), "_permission_name"):
                 if is_collect_previous:
                     self.previous_method_permission_name[attr_name] = getattr(
@@ -436,6 +452,9 @@ class BaseApi(object):
 
     def _register_urls(self):
         for attr_name in dir(self):
+            if attr_name in self.exclude_route_methods:
+                log.info(f"Not registering route for method {attr_name}")
+                continue
             attr = getattr(self, attr_name)
             if hasattr(attr, "_urls"):
                 for url, methods in attr._urls:
@@ -1148,7 +1167,7 @@ class ModelRestApi(BaseModelApi):
         self.set_response_key_mappings(_response, self.info, _args, **_args)
         return self.response(200, **_response)
 
-    @expose("/<pk>", methods=["GET"])
+    @expose("/<int:pk>", methods=["GET"])
     @protect()
     @safe
     @permission_name("get")


### PR DESCRIPTION
New, BaseApi property to exclude route methods:

`exclude_route_methods`: Will not register the route on the blueprint and will not create a permission for it