### PR TITLE
[api] Fix, re-allow filtering by booleans (default generated list)

### DIFF
--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -586,7 +586,6 @@ class SQLAInterface(BaseInterface):
                     and (not self.is_fk(tmp_prop))
                     and (not self.is_image(col_name))
                     and (not self.is_file(col_name))
-                    and (not self.is_boolean(col_name))
                 ):
                     ret_lst.append(col_name)
             else:


### PR DESCRIPTION
Fix, don't exclude boolean from get_search_columns_list
