### PR TITLE
[mvc] Fix, default page size

### DIFF
--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -614,7 +614,7 @@ class BaseCRUDView(BaseModelView):
     """
     order_columns = None
     """ Allowed order columns """
-    page_size = 10
+    page_size = 25
     """
         Use this property to change default page size
     """


### PR DESCRIPTION
Default page size should match the minimal step defined on the
MVC macro, the user was not getting info about the size of the page
