### PR TITLE
[view] New, non-attachment download endpoint

### DIFF
--- a/flask_appbuilder/views.py
+++ b/flask_appbuilder/views.py
@@ -610,6 +610,14 @@ class ModelView(RestCRUDView):
             as_attachment=True,
         )
 
+    @expose("/viewfile/<string:filename>")
+    @has_access
+    @permission_name('download')
+    def viewfile(self, filename):
+        return send_file(
+            self.appbuilder.app.config["UPLOAD_FOLDER"] + filename
+        )
+
     def get_action_permission_name(self, name: str) -> str:
         """
             Get the permission name of an action name


### PR DESCRIPTION
This provides an endpoint like the download endpoint, but more suitable for images that can be viewed standalone in a browser tab without being downloaded.

I used the same permission name because the content is the same.
Only the metadata of the response differ.
