### PR TITLE
[api] Fix, OpenAPI method and config exclusions

### DIFF
--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -437,6 +437,9 @@ class BaseApi(object):
             attr = getattr(self, attr_name)
             if hasattr(attr, "_urls"):
                 for url, methods in attr._urls:
+                    if attr_name in self.exclude_route_methods:
+                        log.info(f"Not registering api spec for method {attr_name}")
+                        continue
                     operations = dict()
                     path = self.path_helper(path=url, operations=operations)
                     self.operation_helper(
@@ -1625,7 +1628,8 @@ class ModelRestApi(BaseModelApi):
             ret["validate"] = [str(field.validate)]
         ret["type"] = field.__class__.__name__
         ret["required"] = field.required
-        ret["unique"] = field.unique
+        # When using custom marshmallow schemas fields don't have unique property
+        ret["unique"] = getattr(field, 'unique', False)
         return ret
 
     def _get_fields_info(self, cols, model_schema, filter_rel_fields, **kwargs):

--- a/flask_appbuilder/api/manager.py
+++ b/flask_appbuilder/api/manager.py
@@ -78,6 +78,6 @@ class OpenApiManager(BaseManager):
     def register_views(self):
         if not self.appbuilder.app.config.get('FAB_ADD_SECURITY_VIEWS', True):
             return
-        self.appbuilder.add_api(OpenApi)
         if self.appbuilder.get_app.config.get('FAB_API_SWAGGER_UI', False):
+            self.appbuilder.add_api(OpenApi)
             self.appbuilder.add_view_no_menu(SwaggerView)

--- a/flask_appbuilder/tests/test_mongoengine.py
+++ b/flask_appbuilder/tests/test_mongoengine.py
@@ -218,7 +218,7 @@ class FlaskTestCase(FABTestCase):
         """
             Test views creation and registration
         """
-        eq_(len(self.appbuilder.baseviews), 27)  # current minimal views are 26
+        eq_(len(self.appbuilder.baseviews), 26)  # current minimal views are 26
 
     def test_index(self):
         """


### PR DESCRIPTION
Fixes:
- OpenAPi route exclusion when swagger is disabled
- Don't register openapi spec on excluded methods
- Allow for non marshmallow-sqlalchemy declarations (support schemas without unique)

