### PR TITLE
Bump FAB to 2.2.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,25 @@
 Flask-AppBuilder ChangeLog
 ==========================
 
+Improvements and Bug fixes on 2.2.1
+-----------------------------------
+
+ - Fix, [api] OpenAPI method and config exclusions (#1211)
+ - Fix, [mvc] default page size out of sync with jinja macro (#1209)
+ - New, [api] Support for json encoded content on URI parameter (#1205)
+ - Fix, [api] Re-allow filtering by booleans (default generated list) (#1204)
+ - Fix, [api] [menu] openapi spec (#1203)
+ - New, [api] Exclude route methods from ModelRestApi (#1202)
+ - Fix, [api] Don't crash on invalid filters (#1200)
+ - Fix, authentication error when using oracle (#1193)
+ - Fix, [api] openapi spec for the info endpoint (#1197)
+ - Fix, New, Show widget template: Add some basic blocks (#1158)
+ - New, State reason for LDAP login failure (#1164)
+ - Fix, [docs] Get list result (#1196)
+ - Fix, [examples] Update views.py (#1165)
+ - Fix, create filters even when search_columns is empty (#1173)
+ - Fix, jwt refresh endpoint should return new access_token (#1187)
+
 Improvements and Bug fixes on 2.2.0
 -----------------------------------
 

--- a/flask_appbuilder/__init__.py
+++ b/flask_appbuilder/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Daniel Vaz Gaspar"
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 
 from .actions import action  # noqa: F401
 from .api import ModelRestApi  # noqa: F401


### PR DESCRIPTION
Improvements and Bug fixes on 2.2.1
-----------------------------------

 - Fix, [api] OpenAPI method and config exclusions (#1211)
 - Fix, [mvc] default page size out of sync with jinja macro (#1209)
 - New, [api] Support for json encoded content on URI parameter (#1205)
 - Fix, [api] Re-allow filtering by booleans (default generated list) (#1204)
 - Fix, [api] [menu] openapi spec (#1203)
 - New, [api] Exclude route methods from ModelRestApi (#1202)
 - Fix, [api] Don't crash on invalid filters (#1200)
 - Fix, authentication error when using oracle (#1193)
 - Fix, [api] openapi spec for the info endpoint (#1197)
 - Fix, New, Show widget template: Add some basic blocks (#1158)
 - New, State reason for LDAP login failure (#1164)
 - Fix, [docs] Get list result (#1196)
 - Fix, [examples] Update views.py (#1165)
 - Fix, create filters even when search_columns is empty (#1173)
 - Fix, jwt refresh endpoint should return new access_token (#1187)
