### PR TITLE
[mvc] [api] New, exclude route methods

### DIFF
--- a/flask_appbuilder/__init__.py
+++ b/flask_appbuilder/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Daniel Vaz Gaspar"
-__version__ = "2.2.1"
+__version__ = "2.2.2rc1"
 
 from .actions import action  # noqa: F401
 from .api import ModelRestApi  # noqa: F401

--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -412,7 +412,10 @@ class BaseApi(object):
             is_add_base_permissions = True
         for attr_name in dir(self):
             # If include_route_methods is not None white list
-            if self.include_route_methods is not None and attr_name not in self.include_route_methods:
+            if (
+                self.include_route_methods is not None
+                and attr_name not in self.include_route_methods
+            ):
                 continue
             # Don't create permission for excluded routes
             if attr_name in self.exclude_route_methods:
@@ -454,7 +457,10 @@ class BaseApi(object):
             if hasattr(attr, "_urls"):
                 for url, methods in attr._urls:
                     # If include_route_methods is not None white list
-                    if self.include_route_methods is not None and attr_name not in self.include_route_methods:
+                    if (
+                        self.include_route_methods is not None
+                        and attr_name not in self.include_route_methods
+                    ):
                         continue
                     if attr_name in self.exclude_route_methods:
                         log.info(f"Not registering api spec for method {attr_name}")
@@ -491,7 +497,10 @@ class BaseApi(object):
 
     def _register_urls(self):
         for attr_name in dir(self):
-            if self.include_route_methods is not None and attr_name not in self.include_route_methods:
+            if (
+                self.include_route_methods is not None
+                and attr_name not in self.include_route_methods
+            ):
                 continue
             if attr_name in self.exclude_route_methods:
                 log.info(f"Not registering route for method {attr_name}")
@@ -1650,7 +1659,7 @@ class ModelRestApi(BaseModelApi):
         ret["type"] = field.__class__.__name__
         ret["required"] = field.required
         # When using custom marshmallow schemas fields don't have unique property
-        ret["unique"] = getattr(field, 'unique', False)
+        ret["unique"] = getattr(field, "unique", False)
         return ret
 
     def _get_fields_info(self, cols, model_schema, filter_rel_fields, **kwargs):

--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -358,11 +358,24 @@ class BaseApi(object):
         example::
 
             class ContactModelView(ModelRestApi):
-                datamodel = SQLAModel(Contact)
-                exclude_route_methods = ("info", "get_list", "get")
+                datamodel = SQLAInterface(Contact)
+                exclude_route_methods = {"info", "get_list", "get"}
 
 
         The previous examples will only register the `put`, `post` and `delete` routes
+    """
+    include_route_methods = None
+    """
+        If defined will assume a white list setup, where all endpoints are excluded
+        except those define on this attribute
+        example::
+
+            class ContactModelView(ModelRestApi):
+                datamodel = SQLAInterface(Contact)
+                include_route_methods = {"list"}
+
+
+        The previous example will exclude all endpoints except the `list` endpoint
     """
 
     def __init__(self):
@@ -398,6 +411,9 @@ class BaseApi(object):
             self.base_permissions = set()
             is_add_base_permissions = True
         for attr_name in dir(self):
+            # If include_route_methods is not None white list
+            if self.include_route_methods is not None and attr_name not in self.include_route_methods:
+                continue
             # Don't create permission for excluded routes
             if attr_name in self.exclude_route_methods:
                 continue
@@ -437,6 +453,9 @@ class BaseApi(object):
             attr = getattr(self, attr_name)
             if hasattr(attr, "_urls"):
                 for url, methods in attr._urls:
+                    # If include_route_methods is not None white list
+                    if self.include_route_methods is not None and attr_name not in self.include_route_methods:
+                        continue
                     if attr_name in self.exclude_route_methods:
                         log.info(f"Not registering api spec for method {attr_name}")
                         continue
@@ -472,6 +491,8 @@ class BaseApi(object):
 
     def _register_urls(self):
         for attr_name in dir(self):
+            if self.include_route_methods is not None and attr_name not in self.include_route_methods:
+                continue
             if attr_name in self.exclude_route_methods:
                 log.info(f"Not registering route for method {attr_name}")
                 continue

--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -129,8 +129,8 @@ class BaseView(object):
             class ContactModelView(ModelRestApi):
                 datamodel = SQLAModel(Contact)
                 include_route_methods = ("list")
-        
-        
+
+
         The previous example will exclude all endpoints except the `list` endpoint
     """
     default_view = "list"

--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -165,7 +165,10 @@ class BaseView(object):
         if self.base_permissions is None:
             self.base_permissions = set()
             is_add_base_permissions = True
+
         for attr_name in dir(self):
+            if self.include_route_methods and attr_name not in self.include_route_methods:
+                continue
             # Don't create permission for excluded routes
             if attr_name in self.exclude_route_methods:
                 continue

--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -115,20 +115,20 @@ class BaseView(object):
         Does not register routes for a set of builtin ModelView functions.
         example::
 
-            class ContactModelView(ModelRestApi):
-                datamodel = SQLAModel(Contact)
-                exclude_route_methods = ("delete", "edit")
+            class ContactModelView(ModelView):
+                datamodel = SQLAInterface(Contact)
+                exclude_route_methods = {"delete", "edit"}
 
     """
-    include_route_methods = set()
+    include_route_methods = None
     """
         If defined will assume a white list setup, where all endpoints are excluded
         except those define on this attribute
         example::
 
-            class ContactModelView(ModelRestApi):
-                datamodel = SQLAModel(Contact)
-                include_route_methods = ("list")
+            class ContactModelView(ModelView):
+                datamodel = SQLAInterface(Contact)
+                include_route_methods = {"list"}
 
 
         The previous example will exclude all endpoints except the `list` endpoint
@@ -167,7 +167,8 @@ class BaseView(object):
             is_add_base_permissions = True
 
         for attr_name in dir(self):
-            if self.include_route_methods and attr_name not in self.include_route_methods:
+            # If include_route_methods is not None white list
+            if self.include_route_methods is not None and attr_name not in self.include_route_methods:
                 continue
             # Don't create permission for excluded routes
             if attr_name in self.exclude_route_methods:
@@ -234,7 +235,7 @@ class BaseView(object):
 
     def _register_urls(self):
         for attr_name in dir(self):
-            if self.include_route_methods and attr_name not in self.include_route_methods:
+            if self.include_route_methods is not None and attr_name not in self.include_route_methods:
                 continue
             if attr_name in self.exclude_route_methods:
                 log.info(f"Not registering route for method {attr_name}")

--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -234,6 +234,8 @@ class BaseView(object):
 
     def _register_urls(self):
         for attr_name in dir(self):
+            if self.include_route_methods and attr_name not in self.include_route_methods:
+                continue
             if attr_name in self.exclude_route_methods:
                 log.info(f"Not registering route for method {attr_name}")
                 continue

--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -15,7 +15,7 @@ from .urltools import (
     get_order_args,
     get_page_args,
     get_page_size_args,
-    Stack
+    Stack,
 )
 from .widgets import FormWidget, ListWidget, SearchWidget, ShowWidget
 
@@ -150,8 +150,9 @@ class BaseView(object):
         # Init class permission override attrs
         if not self.previous_class_permission_name and self.class_permission_name:
             self.previous_class_permission_name = self.__class__.__name__
-        self.class_permission_name = (self.class_permission_name or
-                                      self.__class__.__name__)
+        self.class_permission_name = (
+            self.class_permission_name or self.__class__.__name__
+        )
 
         # Init previous permission override attrs
         is_collect_previous = False
@@ -168,7 +169,10 @@ class BaseView(object):
 
         for attr_name in dir(self):
             # If include_route_methods is not None white list
-            if self.include_route_methods is not None and attr_name not in self.include_route_methods:
+            if (
+                self.include_route_methods is not None
+                and attr_name not in self.include_route_methods
+            ):
                 continue
             # Don't create permission for excluded routes
             if attr_name in self.exclude_route_methods:
@@ -235,7 +239,10 @@ class BaseView(object):
 
     def _register_urls(self):
         for attr_name in dir(self):
-            if self.include_route_methods is not None and attr_name not in self.include_route_methods:
+            if (
+                self.include_route_methods is not None
+                and attr_name not in self.include_route_methods
+            ):
                 continue
             if attr_name in self.exclude_route_methods:
                 log.info(f"Not registering route for method {attr_name}")
@@ -334,8 +341,7 @@ class BaseView(object):
         if permission:
             return permission
         else:
-            return getattr(
-                getattr(self, method_name), "_permission_name")
+            return getattr(getattr(self, method_name), "_permission_name")
 
 
 class BaseFormView(BaseView):
@@ -794,8 +800,9 @@ class BaseCRUDView(BaseModelView):
                 if self.method_permission_name.get(attr_name):
                     if not self.previous_method_permission_name.get(attr_name):
                         self.previous_method_permission_name[attr_name] = action.name
-                    permission_name = \
+                    permission_name = (
                         PERMISSION_PREFIX + self.method_permission_name.get(attr_name)
+                    )
                 if permission_name not in self.base_permissions:
                     self.base_permissions.append(permission_name)
                 self.actions[action.name] = action
@@ -862,8 +869,8 @@ class BaseCRUDView(BaseModelView):
         self.list_columns = self.list_columns or [list_cols[0]]
         self._gen_labels_columns(self.list_columns)
         self.order_columns = (
-            self.order_columns or
-            self.datamodel.get_order_columns_list(list_columns=self.list_columns)
+            self.order_columns
+            or self.datamodel.get_order_columns_list(list_columns=self.list_columns)
         )
         if self.show_fieldsets:
             self.show_columns = []
@@ -906,13 +913,13 @@ class BaseCRUDView(BaseModelView):
     """
 
     def _get_related_view_widget(
-            self,
-            item,
-            related_view,
-            order_column="",
-            order_direction="",
-            page=None,
-            page_size=None,
+        self,
+        item,
+        related_view,
+        order_column="",
+        order_direction="",
+        page=None,
+        page_size=None,
     ):
 
         fk = related_view.datamodel.get_related_fk(self.datamodel.obj)
@@ -947,7 +954,7 @@ class BaseCRUDView(BaseModelView):
         )
 
     def _get_related_views_widgets(
-            self, item, orders=None, pages=None, page_sizes=None, widgets=None, **args
+        self, item, orders=None, pages=None, page_sizes=None, widgets=None, **args
     ):
         """
             :return:
@@ -981,15 +988,15 @@ class BaseCRUDView(BaseModelView):
         return self._get_list_widget(**kwargs).get("list")
 
     def _get_list_widget(
-            self,
-            filters,
-            actions=None,
-            order_column="",
-            order_direction="",
-            page=None,
-            page_size=None,
-            widgets=None,
-            **args
+        self,
+        filters,
+        actions=None,
+        order_column="",
+        order_direction="",
+        page=None,
+        page_size=None,
+        widgets=None,
+        **args,
     ):
 
         """ get joined base filter and current active filter for query """
@@ -1028,7 +1035,7 @@ class BaseCRUDView(BaseModelView):
         return widgets
 
     def _get_show_widget(
-            self, pk, item, widgets=None, actions=None, show_fieldsets=None
+        self, pk, item, widgets=None, actions=None, show_fieldsets=None
     ):
         widgets = widgets or {}
         actions = actions or self.actions

--- a/flask_appbuilder/filters.py
+++ b/flask_appbuilder/filters.py
@@ -42,6 +42,13 @@ class TemplateFilters(object):
                 res_actions[action_key] = action
         return res_actions
 
+    @app_template_filter("safe_url_for")
+    def safe_url_for(self, endpoint, **values):
+        try:
+            return url_for(endpoint, **values)
+        except Exception:
+            return None
+
     @app_template_filter("link_order")
     def link_order_filter(self, column, modelview_name):
         """

--- a/flask_appbuilder/templates/appbuilder/general/lib.html
+++ b/flask_appbuilder/templates/appbuilder/general/lib.html
@@ -282,12 +282,15 @@
         {{ render_pagination(page, page_size, count, modelview_name) }}
         {{ render_set_page_size(page, page_size, count, modelview_name) }}
     	{% if can_add %}
-		    {% set path = url_for(modelview_name + '.add') %}
-			{% set path = path | set_link_filters(filters) %}
-			&nbsp;{{ lnk_add(path) }}
+            {% set endpoint = modelview_name + '.add' %}
+            {% set path = endpoint | safe_url_for %}
+            {% if path %}
+                {% set path = path | set_link_filters(filters) %}
+                {{ lnk_add(path) }}
+            {% endif %}
         {% endif %}
-        &nbsp;{{ render_actions(actions, modelview_name) }}
-        &nbsp;{{ lnk_back() }}
+        {{ render_actions(actions, modelview_name) }}
+        {{ lnk_back() }}
 		<div class="pull-right">
 			<strong>{{ _('Record Count') }}:</strong> {{ count }}
 		</div>
@@ -296,17 +299,27 @@
 {% macro btn_crud(can_show, can_edit, can_delete, pk, modelview_name, filters) %}
     <div class="btn-group btn-group-xs" style="display: flex;">
         {% if can_show %}
-            {% set path = url_for(modelview_name + '.show',pk=pk) %}
-            {% set path = path | set_link_filters(filters) %}
-            {{ lnk_show(path) }}
+            {% set endpoint = modelview_name + '.show' %}
+            {% set path = endpoint | safe_url_for(pk=pk) %}
+            {% if path %}
+                {% set path = path | set_link_filters(filters) %}
+                {{ lnk_show(path) }}
+            {% endif %}
         {% endif %}
         {% if can_edit %}
-            {% set path = url_for(modelview_name + '.edit',pk=pk) %}
-            {% set path = path | set_link_filters(filters) %}
-            {{ lnk_edit(path) }}
+            {% set endpoint = modelview_name + '.edit' %}
+            {% set path = endpoint | safe_url_for(pk=pk) %}
+            {% if path %}
+                {% set path = path | set_link_filters(filters) %}
+                {{ lnk_edit(path) }}
+            {% endif %}
         {% endif %}
         {% if can_delete %}
-            {{ lnk_delete(url_for(modelview_name + '.delete',pk=pk)) }}
+            {% set endpoint = modelview_name + '.delete' %}
+            {% set path = endpoint | safe_url_for(pk=pk) %}
+            {% if path %}
+                {{ lnk_delete(path) }}
+            {% endif %}
         {% endif %}
     </div>
 {% endmacro %}

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -322,6 +322,13 @@ class APITestCase(FABTestCase):
         self.model1permoverride = ModelWithPropertyApi
         self.appbuilder.add_api(ModelWithPropertyApi)
 
+        class Model1ApiIncludeRoutes(ModelRestApi):
+            datamodel = SQLAInterface(Model1)
+            exclude_route_methods = ("get")
+
+        self.appbuilder.add_api(Model1ApiIncludeRoutes)
+
+
     def tearDown(self):
         self.appbuilder = None
         self.app = None
@@ -543,6 +550,38 @@ class APITestCase(FABTestCase):
         self.assertIsNone(pvm)
         pvm = self.appbuilder.sm.find_permission_view_menu(
             "can_delete", "Model1ApiExcludeRoutes"
+        )
+        self.assertIsNone(pvm)
+
+    def test_include_route_methods(self):
+        """
+            REST Api: Test include route methods
+        """
+        client = self.app.test_client()
+        token = self.login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
+        uri = "api/v1/model1apiincluderoutes/_info"
+        rv = self.auth_client_get(client, token, uri)
+        self.assertEqual(rv.status_code, 404)
+
+        uri = "api/v1/model1apiincluderoutes/1"
+        rv = self.auth_client_delete(client, token, uri)
+        self.assertEqual(rv.status_code, 200)
+
+        # Check that permissions do not exist
+        pvm = self.appbuilder.sm.find_permission_view_menu(
+            "can_info", "Model1ApiIncludeRoutes"
+        )
+        self.assertIsNone(pvm)
+        pvm = self.appbuilder.sm.find_permission_view_menu(
+            "can_put", "Model1ApiIncludeRoutes"
+        )
+        self.assertIsNone(pvm)
+        pvm = self.appbuilder.sm.find_permission_view_menu(
+            "can_post", "Model1ApiIncludeRoutes"
+        )
+        self.assertIsNone(pvm)
+        pvm = self.appbuilder.sm.find_permission_view_menu(
+            "can_delete", "Model1ApiIncludeRoutes"
         )
         self.assertIsNone(pvm)
 

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -324,10 +324,9 @@ class APITestCase(FABTestCase):
 
         class Model1ApiIncludeRoutes(ModelRestApi):
             datamodel = SQLAInterface(Model1)
-            exclude_route_methods = ("get")
+            include_route_methods = "get"
 
         self.appbuilder.add_api(Model1ApiIncludeRoutes)
-
 
     def tearDown(self):
         self.appbuilder = None

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -563,7 +563,7 @@ class APITestCase(FABTestCase):
         self.assertEqual(rv.status_code, 404)
 
         uri = "api/v1/model1apiincluderoutes/1"
-        rv = self.auth_client_delete(client, token, uri)
+        rv = self.auth_client_get(client, token, uri)
         self.assertEqual(rv.status_code, 200)
 
         # Check that permissions do not exist


### PR DESCRIPTION
Exclude route methods on MVC and `include_route_methods` on API that will work like a white list

Default MVC endpoints method names are:

- api
- api_read
- api_get
- api_create
- api_update
- api_delete
- api_column_add
- api_column_edit
- api_readvalues
- list
- show
- add
- edit
- delete
- download
- action
- action_post
