### PR TITLE
fix: using default method name when unspecified in method_permission_name dict

### DIFF
--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -564,7 +564,7 @@ class BaseApi(object):
             Returns the permission name for a method
         """
         if self.method_permission_name:
-            return self.method_permission_name.get(method_name)
+            return self.method_permission_name.get(method_name, method_name)
         else:
             if hasattr(getattr(self, method_name), "_permission_name"):
                 return getattr(getattr(self, method_name), "_permission_name")


### PR DESCRIPTION
I was hitting a hard to interpret stack trace error message when I
added a method to `ModelRestApi`. (I went from using `ModelRestApi` to
using `BaseSupersetModelRestApi`).

This simple fix should prevent that.

Stack trace:
```
  File "/Users/maximebeauchemin/code/superset/superset/app.py", line 183, in init_views
    appbuilder.add_api(DatabaseRestApi)
  File "/Users/maximebeauchemin/code/superset/env/lib/python3.6/site-packages/flask_appbuilder/base.py", line 532, in add_api
    return self.add_view_no_menu(baseview)
  File "/Users/maximebeauchemin/code/superset/env/lib/python3.6/site-packages/flask_appbuilder/base.py", line 509, in add_view_no_menu
    baseview = self._check_and_init(baseview)
  File "/Users/maximebeauchemin/code/superset/env/lib/python3.6/site-packages/flask_appbuilder/base.py", line 354, in _check_and_init
    baseview = baseview()
  File "/Users/maximebeauchemin/code/superset/env/lib/python3.6/site-packages/flask_appbuilder/api/__init__.py", line 934, in __init__
    super(ModelRestApi, self).__init__()
  File "/Users/maximebeauchemin/code/superset/env/lib/python3.6/site-packages/flask_appbuilder/api/__init__.py", line 736, in __init__
    super(BaseModelApi, self).__init__()
  File "/Users/maximebeauchemin/code/superset/env/lib/python3.6/site-packages/flask_appbuilder/api/__init__.py", line 411, in __init__
    print("_permission_name:" + _permission_name)
TypeError: must be str, not NoneType
```


Thank you for contributing to Flask-Appbuilder. 

For Fixes:

Please, prefix the title with "Fix, " and describe in detail what you're fixing and the steps required to reproduce the problem.

For new features:

Please, prefix the title with "New, " and describe this new feature in detail, remember to update documentation.

