### PR TITLE
[api] new, override merge openapi docs specs

### DIFF
--- a/examples/crud_rest_api/app/api.py
+++ b/examples/crud_rest_api/app/api.py
@@ -1,4 +1,5 @@
 from flask_appbuilder import ModelRestApi
+from flask_appbuilder.api import BaseApi, expose
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 
 from . import appbuilder, db
@@ -19,10 +20,50 @@ db.create_all()
 fill_gender()
 
 
+class GreetingApi(BaseApi):
+    resource_name = "greeting"
+    openapi_spec_methods = {
+        "greeting": {
+            "get": {
+               "description": "Override description",
+            }
+        }
+    }
+
+    @expose('/')
+    def greeting(self):
+        """Send a greeting
+        ---
+        get:
+          responses:
+            200:
+              description: Greet the user
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+        """
+        return self.response(200, message="Hello")
+
+
+appbuilder.add_api(GreetingApi)
+
+
 class ContactModelApi(ModelRestApi):
     resource_name = "contact"
     datamodel = SQLAInterface(Contact)
     allow_browser_login = True
+
+    openapi_spec_methods = {
+        "get_list": {
+            "get": {
+                "description": "Get all contacts, filter and pagination",
+            }
+        }
+    }
 
 
 appbuilder.add_api(ContactModelApi)


### PR DESCRIPTION
Makes it possible to override OpenAPI specs for methods that are usually defined on the method's doc itself

This override will make a dict update with the spec defined on the doc itself, for example:

``` python
class ContactModelApi(ModelRestApi):
    resource_name = "contact"
    datamodel = SQLAInterface(Contact)
    allow_browser_login = True

    openapi_spec_methods = {
        "get_list": {
            "get": {
                "description": "Get all contacts, filter and pagination",
            }
        }
    }

```

Will use the automatic `get_list` spec and adds a custom description for the method
