### PR TITLE
Fix, Update version of Flask-Babel to support Werkzeug 1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "colorama>=0.3.9, <1",
         "click>=6.7, <8",
         "Flask>=0.12, <2",
-        "Flask-Babel>=0.11.1, <1",
+        "Flask-Babel>=1, <2",
         "Flask-Login>=0.3, <0.5",
         "Flask-OpenID>=1.2.5, <2",
         "Flask-SQLAlchemy>=2.4, <3",


### PR DESCRIPTION
Closes #1265

The changelog for Flask-Babel 1.0.0 is:

> # Changelog
> 
> ## v1.0.0 - 06/02/2020
> 
> Starting with version 1, flask-babel has changed to
> [Semantic Versioning][semver].
> 
> ### Changed
> 
> - pytz is an explicit dependency. (#14)
> - pytz.gae, used for Google App Engine, is no longer necessary and has been
>   removed. (#153)
> - Fixed a deprecated werkzeug import (#158).
> - Fix issues switching locales in threaded contexts (#125).