### PR TITLE
[api] Fix, missing count fields on crud get list openapi spec

### DIFF
--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -1446,6 +1446,8 @@ class ModelRestApi(BaseModelApi):
                         type: array
                         items:
                           type: string
+                      count:
+                        type: number
                       order_columns:
                         type: array
                         items:


### PR DESCRIPTION
Simple fix for CRUD REST API get_list openapi spec, missing count attr