### PR TITLE
[filemanager] Fix, use a sane mode for directories

### DIFF
--- a/flask_appbuilder/filemanager.py
+++ b/flask_appbuilder/filemanager.py
@@ -31,7 +31,7 @@ class FileManager(object):
         relative_path="",
         namegen=None,
         allowed_extensions=None,
-        permission=0o666,
+        permission=0o755,
         **kwargs
     ):
 
@@ -98,7 +98,7 @@ class ImageManager(FileManager):
         allowed_extensions=None,
         thumbgen=None,
         thumbnail_size=None,
-        permission=0o666,
+        permission=0o755,
         **kwargs
     ):
 


### PR DESCRIPTION
Set the executable bit so processes can read the directory.
Only make the directory writeable by its owner.