### PR TITLE
Fix, Soften marshmallow version restriction

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "Flask-WTF>=0.14.2, <1",
         "Flask-JWT-Extended>=3.18, <4",
         "jsonschema>=3.0.1, <4",
-        "marshmallow>=2.18.0, <2.20",
+        "marshmallow>=2.18.0, <4.0.0",
         "marshmallow-enum>=1.4.1, <2",
         "marshmallow-sqlalchemy>=0.16.1, <1",
         "python-dateutil>=2.3, <3",


### PR DESCRIPTION
This makes it easier to combine FAB with other packages that want newer marshmallow versions. 

Fixes #1133

Replaces #1134 which was closed.