### PR TITLE
Release 2.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Flask-AppBuilder ChangeLog
 ==========================
 
+Improvements and Bug fixes on 2.3.0
+-----------------------------------
+
+- New, [i18n] Add korean language (#1297)
+- New, [api] support one to many relations (#1307)
+- Fix, [mvc] reverts select2 to version 3.5.2 (#1308)
+- Fix, [mvc] Upgrade to Jquery 3 and select2 4
+- Fix, [api] List filters validation schema (#1303)
+- Fix, [api] Soften marshmallow version restriction (#1295)
+- Fix, [mvc] GET delete and action endpoints (#1294)
+- Fix, [style] impose black code style (#1292)
+
 Improvements and Bug fixes on 2.2.4
 -----------------------------------
 

--- a/flask_appbuilder/__init__.py
+++ b/flask_appbuilder/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Daniel Vaz Gaspar"
-__version__ = "2.2.4"
+__version__ = "2.3.0"
 
 from .actions import action  # noqa: F401
 from .api import ModelRestApi  # noqa: F401


### PR DESCRIPTION
Release 2.3.0

Improvements and Bug fixes on 2.3.0
-----------------------------------

- New, [i18n] Add korean language (#1297)
- New, [api] support one to many relations (#1307)
- Fix, [mvc] reverts select2 to version 3.5.2 (#1308)
- Fix, [mvc] Upgrade to Jquery 3 and select2 4
- Fix, [api] List filters validation schema (#1303)
- Fix, [api] Soften marshmallow version restriction (#1295)
- Fix, [mvc] GET delete and action endpoints (#1294)
- Fix, [style] impose black code style (#1292)
