### PR TITLE
Bump to 2.3.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Flask-AppBuilder ChangeLog
 ==========================
 
+Improvements and Bug fixes on 2.3.4
+-----------------------------------
+
+- Fix, [api] SQL selects and many to many joins (#1361)
+- Fix, [frontend] Revert "Bump jQuery to 3.5 (#1351)" (#1363)
+
 Improvements and Bug fixes on 2.3.3
 -----------------------------------
 

--- a/flask_appbuilder/__init__.py
+++ b/flask_appbuilder/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Daniel Vaz Gaspar"
-__version__ = "2.3.3"
+__version__ = "2.3.4"
 
 from .actions import action  # noqa: F401
 from .api import ModelRestApi  # noqa: F401


### PR DESCRIPTION
Release 2.3.4

Improvements and Bug fixes on 2.3.4
-----------------------------------

- Fix, [api] SQL selects and many to many joins (#1361)
- Fix, [frontend] Revert "Bump jQuery to 3.5 (#1351)" (#1363)
