### PR TITLE
Fix, name column resizing in ab_view_menu table #1367

### DIFF
--- a/flask_appbuilder/security/sqla/models.py
+++ b/flask_appbuilder/security/sqla/models.py
@@ -33,7 +33,7 @@ class Permission(Model):
 class ViewMenu(Model):
     __tablename__ = "ab_view_menu"
     id = Column(Integer, Sequence("ab_view_menu_id_seq"), primary_key=True)
-    name = Column(String(100), unique=True, nullable=False)
+    name = Column(String(250), unique=True, nullable=False)
 
     def __eq__(self, other):
         return (isinstance(other, self.__class__)) and (self.name == other.name)


### PR DESCRIPTION
While working with apache-airflow when we enable rbac, all the tables related to flask-ui are added into the metadata. On that note, system tries to insert the rows in ab_view_menu table with respect to all the available DAGs. The length of the dag_id is 250 chars but in ab_view_menu the aligned column's (name) length is 100 chars and in turn value is truncated. Thereafter, it throws the Integrity Error when tries to insert the same value of name because of the truncation. And finally database goes down.

So, to improve this, we need to keep in sync with the ab_view_menu table. For that, I need to change the size of the column from 100 to 250.

https://github.com/dpgaspar/Flask-AppBuilder/issues/1367