### PR TITLE
fix: add a panel body to panel_begin/panel_end macros

### DIFF
--- a/flask_appbuilder/templates/appbuilder/general/lib.html
+++ b/flask_appbuilder/templates/appbuilder/general/lib.html
@@ -259,10 +259,12 @@
 {% macro panel_begin(title, extra_class="") %}
 <div class="panel panel-primary {{ extra_class }}">
 	<div class="panel-heading">
-	<h4 class="panel-title">{{title}}</h4>
+	  <h4 class="panel-title">{{title}}</h4>
 	</div>
+  <div class="panel-body">
 {% endmacro %}
 {% macro panel_end() %}
+  </div>
 </div>
 {% endmacro %}
 


### PR DESCRIPTION
It seems to me like proper bootstrap panels should have a header and a body.

# before
<img width="521" alt="Screen Shot 2020-05-22 at 2 45 05 PM" src="https://user-images.githubusercontent.com/487433/82711669-e4453b00-9c3a-11ea-86c1-a4f3fe33c961.png">

# after
<img width="546" alt="Screen Shot 2020-05-22 at 2 44 04 PM" src="https://user-images.githubusercontent.com/487433/82711675-e7d8c200-9c3a-11ea-9d24-514737b62767.png">
