### PR TITLE
Syntax error when showing picture

### DIFF
--- a/examples/productsale/app/models.py
+++ b/examples/productsale/app/models.py
@@ -37,7 +37,7 @@ class Product(Model):
         else:
             return Markup(
                 '<a href="' +
-                + url_for("ProductPubView.show", pk=str(self.id)) +
+                url_for("ProductPubView.show", pk=str(self.id)) +
                 '" class="thumbnail"><img src="//:0" alt="Photo" class="img-responsive">'
                 '</a>'
             )


### PR DESCRIPTION
The plus sign is not allowed. Causing an error when showing the product.


Thank you for contributing to Flask-Appbuilder. 

For Fixes:

Please, prefix the title with "Fix, " and describe in detail what you're fixing and the steps required to reproduce the problem.

For new features:

Please, prefix the title with "New, " and describe this new feature in detail, remember to update documentation.

