### PR TITLE
SQLAlchemyAutoSchema needs marshmallow-sqlalchemy>=0.22.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         "jsonschema>=3.0.1, <4",
         "marshmallow>=3, <4",
         "marshmallow-enum>=1.5.1, <2",
-        "marshmallow-sqlalchemy>=0.16.1, <1",
+        "marshmallow-sqlalchemy>=0.22.0, <1",
         "python-dateutil>=2.3, <3",
         "prison>=0.1.3, <1.0.0",
         "PyJWT>=1.7.1",


### PR DESCRIPTION
#1334 started using this class, but didn't update the requirements in setup.py, so it would fail in an existing environment