### PR TITLE
New, Dynamic user registration role

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -34,6 +34,13 @@ Use config.py to configure the following parameters. By default it will use SQLL
 |                                        | exist. Mandatory when using user           |           |
 |                                        | registration                               |           |
 +----------------------------------------+--------------------------------------------+-----------+
+| AUTH_USER_REGISTRATION_ROLE_JMESPATH   | The `JMESPath <http://jmespath.org/>`_     |   No      |
+|                                        | expression used to evaluate user role on   |           |
+|                                        | registration. If set, takes precedence     |           |
+|                                        | over ``AUTH_USER_REGISTRATION_ROLE``.      |           |
+|                                        | Requires ``jmespath`` to be installed.     |           |
+|                                        | See :ref:`jmespath-examples` for examples  |           |
++----------------------------------------+--------------------------------------------+-----------+
 | AUTH_LDAP_SERVER                       | define your ldap server when AUTH_TYPE=2   |   Cond.   |
 |                                        | example:                                   |           |
 |                                        |                                            |           |
@@ -261,3 +268,25 @@ Next you only have to import them to the Flask app object, like this
     app.config.from_object('config')
 
 Take a look at the skeleton `config.py <https://github.com/dpgaspar/Flask-AppBuilder-Skeleton/blob/master/config.py>`_
+
+
+.. _jmespath-examples:
+
+Using JMESPath to map user registration role
+--------------------------------------------
+
+If user self registration is enabled and ``AUTH_USER_REGISTRATION_ROLE_JMESPATH`` is set, it is 
+used as a `JMESPath <http://jmespath.org/>`_ expression to evalate user registration role. The input
+values is ``userinfo`` dict, returned by ``get_oauth_user_info`` function of Security Manager.
+Usage of JMESPath expressions requires `jmespath <https://pypi.org/project/jmespath/>`_ package 
+to be installed.
+
+In case of Google OAuth, userinfo contains user's email that can be used to map some users as admins
+and rest of the domain users as read only users. For example, this expression:
+``contains(['user1@domain.com', 'user2@domain.com'], email) && 'Admin' || 'Viewer'``
+causes users 1 and 2 to be registered with role ``Admin`` and rest with the role ``Viewer``.
+
+JMESPath expression allow more groups to be evaluated:
+``email == 'user1@domain.com' && 'Admin' || (email == 'user2@domain.com' && 'Op' || 'Viewer')``
+
+For more example, see `specification <https://jmespath.org/specification.html>`_.

--- a/examples/oauth/config.py
+++ b/examples/oauth/config.py
@@ -94,8 +94,11 @@ OAUTH_PROVIDERS = [
 # Will allow user self registration
 AUTH_USER_REGISTRATION = True
 
-# The default user self registration role
+# The default user self registration role for all users
 AUTH_USER_REGISTRATION_ROLE = "Admin"
+
+# Self registration role based on user info
+AUTH_USER_REGISTRATION_ROLE_JMESPATH = "contains(['alice', 'celine'], username) && 'Admin' || 'Public'"
 
 # When using LDAP Auth, setup the ldap server
 # AUTH_LDAP_SERVER = "ldap://ldapserver.new"

--- a/examples/oauth/config.py
+++ b/examples/oauth/config.py
@@ -98,7 +98,7 @@ AUTH_USER_REGISTRATION = True
 AUTH_USER_REGISTRATION_ROLE = "Admin"
 
 # Self registration role based on user info
-AUTH_USER_REGISTRATION_ROLE_JMESPATH = "contains(['alice', 'celine'], username) && 'Admin' || 'Public'"
+AUTH_USER_REGISTRATION_ROLE_JMESPATH = "contains(['alice@example.com', 'celine@example.com'], email) && 'Admin' || 'Public'"
 
 # When using LDAP Auth, setup the ldap server
 # AUTH_LDAP_SERVER = "ldap://ldapserver.new"

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -349,7 +349,7 @@ class BaseSecurityManager(AbstractSecurityManager):
         return self.appbuilder.get_app.config["AUTH_USER_REGISTRATION_ROLE"]
 
     @property
-    def auth_user_registration_role_jmespath(self):
+    def auth_user_registration_role_jmespath(self) -> str:
         return self.appbuilder.get_app.config["AUTH_USER_REGISTRATION_ROLE_JMESPATH"]
 
     @property

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -1028,16 +1028,16 @@ class BaseSecurityManager(AbstractSecurityManager):
             role_name = self.auth_user_registration_role
             if self.auth_user_registration_role_jmespath:
                 import jmespath
+
                 role_name = jmespath.search(
-                    self.auth_user_registration_role_jmespath,
-                    userinfo
+                    self.auth_user_registration_role_jmespath, userinfo
                 )
             user = self.add_user(
                 username=userinfo["username"],
                 first_name=userinfo.get("first_name", ""),
                 last_name=userinfo.get("last_name", ""),
                 email=userinfo.get("email", ""),
-                role=self.find_role(role_name)
+                role=self.find_role(role_name),
             )
             if not user:
                 log.error("Error creating a new OAuth user %s" % userinfo["username"])

--- a/flask_appbuilder/tests/_test_oauth_registration_role.py
+++ b/flask_appbuilder/tests/_test_oauth_registration_role.py
@@ -1,0 +1,63 @@
+import logging
+import unittest
+
+from flask import Flask
+from flask_appbuilder import AppBuilder, SQLA
+
+
+logging.basicConfig(format="%(asctime)s:%(levelname)s:%(name)s:%(message)s")
+logging.getLogger().setLevel(logging.DEBUG)
+log = logging.getLogger(__name__)
+
+
+class OAuthRegistrationRoleTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+        self.db = SQLA(self.app)
+
+    def tearDown(self):
+        self.appbuilder = None
+        self.app = None
+        self.db = None
+
+    def test_self_registration_not_enabled(self):
+        self.app.config["AUTH_USER_REGISTRATION"] = False
+        self.appbuilder = AppBuilder(self.app, self.db.session)
+        
+        result = self.appbuilder.sm.auth_user_oauth(
+            userinfo={'username': 'testuser'}
+        )
+
+        self.assertIsNone(result)
+        self.assertEqual(len(self.appbuilder.sm.get_all_users()), 0)
+
+    def test_register_and_attach_static_role(self):
+        self.app.config["AUTH_USER_REGISTRATION"] = True
+        self.app.config["AUTH_USER_REGISTRATION_ROLE"] = "Public"
+        self.appbuilder = AppBuilder(self.app, self.db.session)
+        
+        user = self.appbuilder.sm.auth_user_oauth(
+            userinfo={'username': 'testuser'}
+        )
+
+        self.assertEqual(user.roles[0].name, "Public")
+
+    def test_register_and_attach_dynamic_role(self):
+        self.app.config["AUTH_USER_REGISTRATION"] = True
+        self.app.config["AUTH_USER_REGISTRATION_ROLE_JMESPATH"] = \
+            "contains(['alice', 'celine'], username) && 'Admin' || 'Public'"
+        self.appbuilder = AppBuilder(self.app, self.db.session)
+        
+        # Role for admin
+        user = self.appbuilder.sm.auth_user_oauth(
+            userinfo={'username': 'alice', 'email': 'alice@example.com'}
+        )
+        self.assertEqual(user.roles[0].name, "Admin")
+
+        # Role for non-admin
+        user = self.appbuilder.sm.auth_user_oauth(
+            userinfo={'username': 'bob', 'email': 'bob@example.com'}
+        )
+        self.assertEqual(user.roles[0].name, "Public")

--- a/flask_appbuilder/tests/_test_oauth_registration_role.py
+++ b/flask_appbuilder/tests/_test_oauth_registration_role.py
@@ -11,7 +11,6 @@ log = logging.getLogger(__name__)
 
 
 class OAuthRegistrationRoleTestCase(unittest.TestCase):
-
     def setUp(self):
         self.app = Flask(__name__)
         self.app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
@@ -25,10 +24,8 @@ class OAuthRegistrationRoleTestCase(unittest.TestCase):
     def test_self_registration_not_enabled(self):
         self.app.config["AUTH_USER_REGISTRATION"] = False
         self.appbuilder = AppBuilder(self.app, self.db.session)
-        
-        result = self.appbuilder.sm.auth_user_oauth(
-            userinfo={'username': 'testuser'}
-        )
+
+        result = self.appbuilder.sm.auth_user_oauth(userinfo={"username": "testuser"})
 
         self.assertIsNone(result)
         self.assertEqual(len(self.appbuilder.sm.get_all_users()), 0)
@@ -37,27 +34,26 @@ class OAuthRegistrationRoleTestCase(unittest.TestCase):
         self.app.config["AUTH_USER_REGISTRATION"] = True
         self.app.config["AUTH_USER_REGISTRATION_ROLE"] = "Public"
         self.appbuilder = AppBuilder(self.app, self.db.session)
-        
-        user = self.appbuilder.sm.auth_user_oauth(
-            userinfo={'username': 'testuser'}
-        )
+
+        user = self.appbuilder.sm.auth_user_oauth(userinfo={"username": "testuser"})
 
         self.assertEqual(user.roles[0].name, "Public")
 
     def test_register_and_attach_dynamic_role(self):
         self.app.config["AUTH_USER_REGISTRATION"] = True
-        self.app.config["AUTH_USER_REGISTRATION_ROLE_JMESPATH"] = \
-            "contains(['alice', 'celine'], username) && 'Admin' || 'Public'"
+        self.app.config[
+            "AUTH_USER_REGISTRATION_ROLE_JMESPATH"
+        ] = "contains(['alice', 'celine'], username) && 'Admin' || 'Public'"
         self.appbuilder = AppBuilder(self.app, self.db.session)
-        
+
         # Role for admin
         user = self.appbuilder.sm.auth_user_oauth(
-            userinfo={'username': 'alice', 'email': 'alice@example.com'}
+            userinfo={"username": "alice", "email": "alice@example.com"}
         )
         self.assertEqual(user.roles[0].name, "Admin")
 
         # Role for non-admin
         user = self.appbuilder.sm.auth_user_oauth(
-            userinfo={'username': 'bob', 'email': 'bob@example.com'}
+            userinfo={"username": "bob", "email": "bob@example.com"}
         )
         self.assertEqual(user.roles[0].name, "Public")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,4 @@ mysqlclient>=1.4.2, < 2.0.0
 cython==0.29.17
 pymssql==2.1.4
 black==19.3b0
+jmespath==0.9.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ flask==1.1.1
 idna==2.9                 # via email-validator
 itsdangerous==1.1.0       # via flask
 jinja2==2.10.1            # via flask, flask-babel
-jmespath==0.9.5
 jsonschema==3.0.1
 markupsafe==1.1.1         # via jinja2
 marshmallow-enum==1.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ flask==1.1.1
 idna==2.9                 # via email-validator
 itsdangerous==1.1.0       # via flask
 jinja2==2.10.1            # via flask, flask-babel
+jmespath==0.9.5
 jsonschema==3.0.1
 markupsafe==1.1.1         # via jinja2
 marshmallow-enum==1.5.1

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         "PyJWT>=1.7.1",
         "sqlalchemy-utils>=0.32.21, <1",
     ],
+    extras_require={"jmespath": ["jmespath>=0.9.5"]},
     tests_require=["nose>=1.0", "mockldap>=0.3.0"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This PR brings dynamic user role on registration based on OAuth userinfo.

The current approach sets static `AUTH_USER_REGISTRATION_ROLE` for all users if self-registration is enabled. In our case, with OAuth authentication on GSuite domain (with FAB being auth engine for Airflow), we'd like to set team members as Admins and every other employee as read-only user ("Viewer"). 

This PR implements method that is used in Grafana ([docs](https://grafana.com/docs/grafana/latest/auth/generic-oauth/#jmespath-examples)), it uses [JMESPath](https://jmespath.org/) to resolve the role from userinfo retrieved from OAuth. It's quite flexible, as some OAuth providers return only username (like Google does), but others, like Okta, can return groups, so they can be utilized by the dynamic expression.

If needed, I'm more than happy to extend the docs by adding more examples of JMESPath.