### PR TITLE
fix, change openapi tags and swagger access URL (breaking)

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -321,7 +321,7 @@ So our spec for a method that accepts two HTTP verbs::
 
 
 To access Swagger UI you must enable ``FAB_API_SWAGGER_UI = True`` on your config file
-then goto ``http://localhost:8080/swaggerview/v1`` for OpenAPI **v1** definitions
+then goto ``http://localhost:8080/swagger/v1`` for OpenAPI **v1** definitions
 On Swagger UI our example API looks like:
 
 .. image:: ./images/swagger001.png
@@ -611,7 +611,7 @@ that can be safely serialized and deserialized. Let's recall our Model definitio
         def __repr__(self):
             return self.name
 
-Swagger UI API representation for groups (http://localhost:8080/swaggerview/v1):
+Swagger UI API representation for groups (http://localhost:8080/swagger/v1):
 
 .. image:: ./images/swagger002.png
     :width: 70%

--- a/flask_appbuilder/api/manager.py
+++ b/flask_appbuilder/api/manager.py
@@ -64,6 +64,7 @@ class OpenApi(BaseApi):
 
 class SwaggerView(BaseView):
 
+    route_base = "/swagger"
     default_view = "ui"
     openapi_uri = "/api/{}/_openapi"
 

--- a/flask_appbuilder/menu.py
+++ b/flask_appbuilder/menu.py
@@ -162,6 +162,7 @@ class Menu(object):
 
 class MenuApi(BaseApi):
     resource_name = "menu"
+    openapi_spec_tag = "Menu"
 
     @expose("/", methods=["GET"])
     @protect(allow_browser_login=True)

--- a/flask_appbuilder/security/api.py
+++ b/flask_appbuilder/security/api.py
@@ -25,6 +25,7 @@ class SecurityApi(BaseApi):
 
     resource_name = "security"
     version = API_SECURITY_VERSION
+    openapi_spec_tag = "Security"
 
     def add_apispec_components(self, api_spec):
         super(SecurityApi, self).add_apispec_components(api_spec)


### PR DESCRIPTION
Minor breaking changes here:
 - to access Swagger UI you now go to http://localhost/swagger/v1 instead of http://localhost/swaggerview/v1

OpenApi tag name changes, minor cosmetic
