### PR TITLE
fix: Update SQLAlchemy query for count_users

### DIFF
--- a/flask_appbuilder/security/sqla/manager.py
+++ b/flask_appbuilder/security/sqla/manager.py
@@ -217,11 +217,7 @@ class SecurityManager(BaseSecurityManager):
             return False
 
     def count_users(self):
-        return (
-            self.get_session.query(func.count("*"))
-            .select_from(self.user_model)
-            .scalar()
-        )
+        return self.get_session.query(func.count(self.user_model.id)).scalar()
 
     def update_user(self, user):
         try:


### PR DESCRIPTION
### Description

@dpgaspar I'm not sure if this is merely a red herring (tracking down the root cause of a non-thread safe operation can be challenging) but per https://github.com/apache/incubator-superset/pull/10427 we were seeing issues with PyMySQL producing errors of the form,

```
pymysql.err.InternalError: Packet sequence number wrong - got 4 expected 1
```

which seems to indicate that there is some non-thread-safe activity. The code where the error was being thrown was the `count_users` method. Per the documentation there's no indication that the [`select_from`](https://docs.sqlalchemy.org/en/13/orm/query.html#sqlalchemy.orm.query.Query.select_from) method is not thread-safe but when I applied the proposed change it seemed to remedy the problem.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature

cc: @etr2460 
