### PR TITLE
[Feat] Support for OpenShift OAuth

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -486,6 +486,19 @@ key is just the configuration for authlib::
                 'request_token_url':None,
                 'access_token_url':'https://accounts.google.com/o/oauth2/token',
                 'authorize_url':'https://accounts.google.com/o/oauth2/auth'}
+        },
+        {'name':'openshift', 'icon':'fa-circle-o', 'token_key':'access_token',
+            'remote_app': {
+                'client_id':'system:serviceaccount:mynamespace:mysa',
+                'client_secret':'<mysa serviceaccount token here>',
+                'api_base_url':'https://openshift.default.svc.cluster.local:443',
+                'client_kwargs':{
+                  'scope': 'user:info'
+                },
+                'redirect_uri':'https://myapp-mynamespace.apps.<cluster_domain>',
+                'access_token_url':'https://oauth-openshift.apps.<cluster_domain>/oauth/token',
+                'authorize_url':'https://oauth-openshift.apps.<cluster_domain>/oauth/authorize',
+                'token_endpoint_auth_method':'client_secret_post'}
         }
     ]
 
@@ -493,7 +506,7 @@ This needs a small explanation, you basically have five special keys:
 
 :name: The name of the provider, you can choose whatever you want. But the framework as some 
     builtin logic to retrieve information about a user that you can make use of if you choose:
-    'twitter', 'google', 'github','linkedin'.
+    'twitter', 'google', 'github', 'linkedin', 'openshift'.
  
 :icon: The font-awesome icon for this provider.
 :token_key: The token key name that this provider uses, google and github uses *'access_token'*,

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -562,6 +562,14 @@ class BaseSecurityManager(AbstractSecurityManager):
                 "id": me["oid"],
                 "username": me["oid"],
             }
+        # for OpenShift
+        if provider == "openshift":
+            me = self.appbuilder.sm.oauth_remotes[provider].get(
+                "apis/user.openshift.io/v1/users/~"
+            )
+            data = me.json()
+            log.debug("User info from OpenShift: {0}".format(data))
+            return {"username": "openshift_" + data.get("metadata").get("name")}
         else:
             return {}
 


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

<!--- Describe the change below, including rationale and design decisions -->

### Description

After successful authentication against the OpenShift built-in
OAuth provider, retrive the username.

Example OAuth Provider configuration, assuming that the Flask
application is running in the container on OpenShift:

```
OAUTH_PROVIDERS = [
    {
        "name": "openshift",
        "icon": "fa-circle-o",
        "token_key": "access_token",
        "remote_app": {
            "client_id": "system:serviceaccount:mynamespace:mysa",
            "client_secret": "<mysa serviceaccount token here>",
            "api_base_url": "https://openshift.default.svc.cluster.local:443",
            "client_kwargs": {"scope": "user:info"},
            "redirect_uri": "https://myapp-mynamespace.apps.<cluster_domain>",
            "access_token_url": "https://oauth-openshift.apps.<cluster_domain>/oauth/token",
            "authorize_url": "https://oauth-openshift.apps.<cluster_domain>/oauth/authorize",
            "token_endpoint_auth_method": "client_secret_post",
        },
    }
]
```

See also:
Using a service account as an OAuth client
https://docs.openshift.com/container-platform/4.5/authentication/using-service-accounts-as-oauth-client.html

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [x] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [x] Introduces new feature
- [ ] Removes existing feature
