### PR TITLE
fix: check if locale exists before loading it

### DIFF
--- a/flask_appbuilder/babel/views.py
+++ b/flask_appbuilder/babel/views.py
@@ -1,4 +1,4 @@
-from flask import redirect, session
+from flask import abort, redirect, session
 from flask_babel import refresh
 
 from ..baseviews import BaseView, expose
@@ -11,6 +11,8 @@ class LocaleView(BaseView):
 
     @expose("/<string:locale>")
     def index(self, locale):
+        if locale not in self.appbuilder.bm.languages:
+            abort(404, description="Locale not supported.")
         session["locale"] = locale
         refresh()
         self.update_redirect()


### PR DESCRIPTION
Fixes: https://github.com/dpgaspar/Flask-AppBuilder/issues/1459


<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

<!--- Describe the change below, including rationale and design decisions -->
Previously, FAB did not check if a locale is supported before attempting to load it. Now the check is performed and a 404 is given if the locale is not supported.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #1459 
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
