### PR TITLE
refactor: remove unnecessary strict option from schemas

### DIFF
--- a/flask_appbuilder/api/convert.py
+++ b/flask_appbuilder/api/convert.py
@@ -96,7 +96,6 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
                 class Meta:
                     model = _model
                     fields = columns
-                    strict = True
                     load_instance = True
                     sqla_session = self.datamodel.session
 
@@ -105,7 +104,6 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
             class MetaSchema(SQLAlchemyAutoSchema, class_mixin):
                 class Meta:
                     model = _model
-                    strict = True
                     load_instance = True
                     sqla_session = self.datamodel.session
 


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

<!--- Describe the change below, including rationale and design decisions -->
Now that FAB supports marshmallow>=3, there is no need for the `strict` option.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
