### PR TITLE
fix(js): select2 readonly not working

### DIFF
--- a/flask_appbuilder/static/appbuilder/js/ab.js
+++ b/flask_appbuilder/static/appbuilder/js/ab.js
@@ -51,9 +51,9 @@ $(function() {
     $('.appbuilder_date').datetimepicker({
         pickTime: false });
     $(".my_select2").select2({placeholder: "Select a State", allowClear: true});
+    $(".my_select2.readonly").select2("readonly", true);
     loadSelectData();
     loadSelectDataSlave();
-    $(".my_select2.readonly").attr("readonly", "readonly");
     $("a").tooltip({container:'.row', 'placement': 'bottom'});
 });
 


### PR DESCRIPTION
### Description

Select2 readonly extra class was no longer working after select2 version bump

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
