### PR TITLE
fix(api): inner joins eager loading

### DIFF
--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -228,11 +228,11 @@ class SQLAInterface(BaseInterface):
                 ) or self.is_relation_one_to_many(root_relation):
                     print(f"Apply outer Load {root_relation}.{column}")
                     related_model = self.get_related_model(root_relation)
-                    query = query.options(Load(related_model).load_only(leaf_column))
+                    # query = query.options(Load(related_model).load_only(leaf_column))
 
-                    # query = query.options(
-                    #     Load(self.obj).joinedload(root_relation).load_only(leaf_column)
-                    # )
+                    query = query.options(
+                        Load(self.obj).joinedload(root_relation).load_only(leaf_column)
+                    )
                 else:
                     related_model = self.get_related_model(root_relation)
                     print(f"Apply outer Load2 {root_relation}.{column}")

--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -316,12 +316,12 @@ class SQLAInterface(BaseInterface):
 
     def query_count(
         self,
-        query: Query,
+        query: BaseQuery,
         filters: Optional[Filters] = None,
         select_columns: Optional[List[str]] = None,
     ):
         return self._apply_inner_all(
-            query, filters, select_columns=select_columns
+            query, filters, select_columns=select_columns, aliases_mapping={}
         ).count()
 
     def apply_all(


### PR DESCRIPTION
### Description

When using models with multiple M-O to the same table and M-M references also, results from the later M-O get "overlapped" by the first reference. This PR aliases all relations and improves eager loading, improving performance also.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
