### PR TITLE
Fix: Improve UX by moving drop-down caret within clickable target

### DIFF
--- a/flask_appbuilder/templates/appbuilder/general/lib.html
+++ b/flask_appbuilder/templates/appbuilder/general/lib.html
@@ -279,7 +279,7 @@
         <div class="panel-heading">
             <h4 class="panel-title">
                 <a class="accordion-toggle" data-toggle="collapse" data-parent="#{{id}}"
-                   href="#{{id}}_href">{{label}}</a><span class="caret"></span>
+                   href="#{{id}}_href">{{label}}<span class="caret"></span></a>
             </h4>
         </div>
         {% if open %}


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

Small UX improvement. Moves the caret next to "Search" within the clickable target so the accordion toggles when it is clicked as well.

| Before | After |
|---|---|
| ![Screen Recording 2020-10-22 at 05 13 25 PM](https://user-images.githubusercontent.com/3267/96930712-24c71000-148a-11eb-9204-db8c58b35f64.gif)  | ![Screen Recording 2020-10-22 at 05 12 47 PM](https://user-images.githubusercontent.com/3267/96930718-27296a00-148a-11eb-89b6-82bd368068b0.gif)  |

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
