### PR TITLE
Fix "actions" on ModelViews with composite primary keys

### DIFF
--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -917,7 +917,6 @@ class SQLAInterface(BaseInterface):
             _filters = filters.copy()
         else:
             _filters = Filters(self.filter_converter_class, self)
-            _filters.add_filter(pk, self.FilterEqual, id)
 
         if self.is_pk_composite():
             for _pk, _id in zip(pk, id):

--- a/flask_appbuilder/tests/test_mvc.py
+++ b/flask_appbuilder/tests/test_mvc.py
@@ -4,6 +4,7 @@ import logging
 from typing import Set
 
 from flask import Flask, redirect, request, session
+from flask_appbuilder.actions import action
 from flask_appbuilder import AppBuilder, SQLA
 from flask_appbuilder.charts.views import (
     ChartView,
@@ -388,6 +389,12 @@ class MVCTestCase(BaseMVCTestCase):
             list_columns = ["pk1", "pk2", "field_string"]
             add_columns = ["pk1", "pk2", "field_string"]
             edit_columns = ["pk1", "pk2", "field_string"]
+
+            @action("muldelete", "Delete", "Delete all Really?", "fa-rocket", single=False)
+            def muldelete(self, items):
+                self.datamodel.delete_all(items)
+                self.update_redirect()
+                return redirect(self.get_redirect())
 
         class Model1CompactView(CompactCRUDMixin, ModelView):
             datamodel = SQLAInterface(Model1)
@@ -827,6 +834,21 @@ class MVCTestCase(BaseMVCTestCase):
         rv = client.get("/model3view/delete/" + quote(pk), follow_redirects=True)
         self.assertEqual(rv.status_code, 200)
         model = self.db.session.query(Model3).filter_by(pk1=2).one_or_none()
+        self.assertEqual(model, None)
+
+        # Add it back, then delete via muldelete
+        self.appbuilder.get_session.add(Model3(pk1=1, pk2=datetime.datetime(2017, 1, 1), field_string="baz"))
+        self.appbuilder.get_session.commit()
+        rv = client.post(
+            "/model3view/action_post",
+            data=dict(
+                action="muldelete",
+                rowid=[json.dumps(["1", {"_type": "datetime", "value": "2017-01-01T00:00:00.000000"}])],
+            ),
+            follow_redirects=True,
+        )
+        self.assertEqual(rv.status_code, 200)
+        model = self.db.session.query(Model3).filter_by(pk1=1).one_or_none()
         self.assertEqual(model, None)
 
     def test_model_crud_add_with_enum(self):


### PR DESCRIPTION
The refactor in #1398 changes the `get()` function, and mistakenly
always applied the PK filter, even in the case of composite keys.

(The else block of `if self.is_pk_composite` applied it again, so it was
actually applying the same filter twice, which didn't break anything,
but was not needed)

I had a bit of trouble running the tests locally, but by ignoring some bits that weren't working for me I was able to validate that the block I added behaves as expected.


<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

Discovered in Airflow, https://github.com/apache/airflow/issues/11513

The stack trace we got was:

```
  File "/home/airflow/.local/lib/python3.6/site-packages/flask/app.py", line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/airflow/.local/lib/python3.6/site-packages/flask/app.py", line 1952, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/airflow/.local/lib/python3.6/site-packages/flask/app.py", line 1821, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/airflow/.local/lib/python3.6/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/home/airflow/.local/lib/python3.6/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/airflow/.local/lib/python3.6/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/airflow/.local/lib/python3.6/site-packages/flask_appbuilder/views.py", line 686, in action_post
    self.datamodel.get(self._deserialize_pk_if_composite(pk)) for pk in pks
  File "/home/airflow/.local/lib/python3.6/site-packages/flask_appbuilder/views.py", line 686, in <listcomp>
    self.datamodel.get(self._deserialize_pk_if_composite(pk)) for pk in pks
  File "/home/airflow/.local/lib/python3.6/site-packages/flask_appbuilder/models/sqla/interface.py", line 870, in get
    query, _filters, select_columns=select_columns
  File "/home/airflow/.local/lib/python3.6/site-packages/flask_appbuilder/models/sqla/interface.py", line 324, in apply_all
    select_columns,
  File "/home/airflow/.local/lib/python3.6/site-packages/flask_appbuilder/models/sqla/interface.py", line 272, in _apply_inner_all
    query = self.apply_filters(query, inner_filters)
  File "/home/airflow/.local/lib/python3.6/site-packages/flask_appbuilder/models/sqla/interface.py", line 162, in apply_filters
    return filters.apply_all(query)
  File "/home/airflow/.local/lib/python3.6/site-packages/flask_appbuilder/models/filters.py", line 295, in apply_all
    query = flt.apply(query, value)
  File "/home/airflow/.local/lib/python3.6/site-packages/flask_appbuilder/models/sqla/filters.py", line 137, in apply
    query, field = get_field_setup_query(query, self.model, self.column_name)
  File "/home/airflow/.local/lib/python3.6/site-packages/flask_appbuilder/models/sqla/filters.py", line 40, in get_field_setup_query
    if not hasattr(model, column_name):
TypeError: hasattr(): attribute name must be string
```

### ADDITIONAL INFORMATION

This was noticed in Apache Airflow 2.0.0a1 where we use the "multi-select + action" on a table with composite PKs 

<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
