### PR TITLE
fix: remove unnecessary CSS class/styling from dropdowns

### DIFF
--- a/examples/quickhowto2/app/static/angularAssets/abModelSearch.html
+++ b/examples/quickhowto2/app/static/angularAssets/abModelSearch.html
@@ -6,7 +6,7 @@
             </button>
             <ul class="dropdown-menu">
                 <li ng-repeat="(col, filters) in search_filters">
-                    <a href="javascript:void(0)" name={[col]} class="filter btn" ng-click="addFilter(col)">
+                    <a href="javascript:void(0)" name={[col]} class="filter" ng-click="addFilter(col)">
                     {[ label_columns[col] ]}</a>
                 </li>
 

--- a/examples/quickhowto2/app/templates/list_angulajs.html
+++ b/examples/quickhowto2/app/templates/list_angulajs.html
@@ -69,7 +69,7 @@ var label_columns = {{ label_columns | tojson | safe }};
             </button>
             <ul class="dropdown-menu">
                 <li ng-repeat="(col, filters) in search_filters">
-                    <a href="javascript:void(0)" name={[col]} class="filter btn" ng-click="addFilter(col)">
+                    <a href="javascript:void(0)" name={[col]} class="filter" ng-click="addFilter(col)">
                     {[ label_columns[col] ]}</a>
                 </li>
 
@@ -151,7 +151,7 @@ var label_columns = {{ label_columns | tojson | safe }};
             </button>
             <ul class="dropdown-menu">
                 <li ng-repeat="(col, filters) in search_filters">
-                    <a href="javascript:void(0)" name="{[col]}" class="filter btn" ng-click="addFilter(col)">
+                    <a href="javascript:void(0)" name="{[col]}" class="filter" ng-click="addFilter(col)">
                     {[ label_columns[col] ]}</a>
                 </li>
 

--- a/flask_appbuilder/static/appbuilder/css/ab.css
+++ b/flask_appbuilder/static/appbuilder/css/ab.css
@@ -20,7 +20,7 @@
 	background-color: #f5f5f5;
 	bottom:0;
 	left:0;
-	right:0;	
+	right:0;
 	width:100%;
 	margin:auto;
 }
@@ -45,8 +45,4 @@ th.action_checkboxes {
 
 .fa-black {
     color: black;
-}
-
-.btn.filter {
-    text-align: left;
 }

--- a/flask_appbuilder/templates/appbuilder/general/widgets/search.html
+++ b/flask_appbuilder/templates/appbuilder/general/widgets/search.html
@@ -9,7 +9,7 @@
         </button>
         <ul class="dropdown-menu">
             {% for col in include_cols %}
-            <li><a href="javascript:void(0)" name="{{col}}" class="filter btn" onclick="return false;">
+            <li><a href="javascript:void(0)" name="{{col}}" class="filter" onclick="return false;">
                 {{ label_columns[col] }}</a>
             </li>
             {% endfor %}
@@ -18,7 +18,7 @@
 
     <table class="table table-responsive table-hover filters">
         <tbody>
-        
+
         </tbody>
     </table>
 
@@ -35,5 +35,5 @@
                     {{ active_filters | tojson }}
                 );
 	})(jQuery);
-	
+
 </script>


### PR DESCRIPTION
Redo of #1491

This time leaving the `filter` class in place that is utilized by scripting, but still removing the undesired styling associated with it.

### Description

Adhering to [Bootstrap's Dropdown guidelines](https://getbootstrap.com/docs/3.3/components/#dropdowns), the anchors within dropdown elements should not have any styled CSS classes on them. This PR removes the `btn` classe added in FAB as they were yielding undesirable side effects (see [Airflow patch fix](https://github.com/apache/airflow/pull/11752)).

The `.btn.filter` styling that I removed in this PR appears to have been added by #493, but was likely only needed to begin with because of the presence of the `btn` class (which center aligned the text). 

| Before | After |
|---|---|
| <img width="272" alt="Image 2020-10-22 at 4 31 32 PM" src="https://user-images.githubusercontent.com/3267/96927116-956b2e00-1484-11eb-8836-267c1c6422eb.png">  |  <img width="230" alt="Image 2020-10-22 at 4 30 52 PM" src="https://user-images.githubusercontent.com/3267/96927121-9734f180-1484-11eb-88d7-0f3cba415573.png"> |

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
