### PR TITLE
fix: MVC order by related column use alias

### DIFF
--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -161,11 +161,12 @@ class SQLAInterface(BaseInterface):
                 if not self.is_model_already_joined(
                     query, self.get_related_model(root_relation)
                 ):
-                    query = self._query_join_relation(query, root_relation)
-                else:
-                    column_leaf = get_column_leaf(order_column)
-                    _alias = self.get_alias_mapping(root_relation, aliases_mapping)
-                    _order_column = getattr(_alias, column_leaf)
+                    query = self._query_join_relation(
+                        query, root_relation, aliases_mapping=aliases_mapping
+                    )
+                column_leaf = get_column_leaf(order_column)
+                _alias = self.get_alias_mapping(root_relation, aliases_mapping)
+                _order_column = getattr(_alias, column_leaf)
             if order_direction == "asc":
                 query = query.order_by(asc(_order_column))
             else:

--- a/flask_appbuilder/tests/test_mvc.py
+++ b/flask_appbuilder/tests/test_mvc.py
@@ -366,6 +366,8 @@ class MVCTestCase(BaseMVCTestCase):
                 "group": [["field_string", FilterEqual, "test0"]]
             }
 
+            order_columns = ["field_string", "group.field_string"]
+
         class Model22View(ModelView):
             datamodel = SQLAInterface(Model2)
             list_columns = [
@@ -1094,9 +1096,22 @@ class MVCTestCase(BaseMVCTestCase):
         data = rv.data.decode("utf-8")
         self.assertIn(f"test{MODEL1_DATA_SIZE-1}", data)
 
+    def test_model_list_order_related(self):
+        """
+        Test Model order related field on lists
+        """
+        client = self.app.test_client()
+        self.browser_login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
+
+        rv = client.get(
+            "/model2view/list?_oc_Model2View=group.field_string&_od_Model2View=asc",
+            follow_redirects=True,
+        )
+        self.assertEqual(rv.status_code, 200)
+
     def test_model_add_unique_validation(self):
         """
-            Test Model add unique field validation
+        Test Model add unique field validation
         """
         client = self.app.test_client()
         self.browser_login(client, USERNAME_ADMIN, PASSWORD_ADMIN)


### PR DESCRIPTION
### Description

fix MVC order by related fields (use aliased join)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
