### PR TITLE
release: 3.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,23 @@
 Flask-AppBuilder ChangeLog
 ==========================
 
+Improvements and Bug fixes on 3.1.1
+-----------------------------------
+
+fix: MVC order by related column use alias (#1504) [Daniel Vaz Gaspar]
+fix: remove unnecessary CSS class/styling from dropdowns (#1503) [Ryan Hamilton]
+deps: constraint pre 1 packages following semver (#1502) [Daniel Vaz Gaspar]
+fix: MVC order by on relation (#1500) [Daniel Vaz Gaspar]
+docs: add github actions badge (#1501) [Daniel Vaz Gaspar]
+fix: remove unnecessary classes from dropdowns (#1491) [Ryan Hamilton]
+ci: migrate from travis to github actions (#1497) [Daniel Vaz Gaspar]
+fix: lint (#1498) [Daniel Vaz Gaspar]
+fix: Improve UX by moving drop-down caret within clickable target (#1492) [Ryan Hamilton]
+style: use a clearer visual representation for "delete" actions (#1495) [Ryan Hamilton]
+fix: "actions" on ModelViews with composite primary keys (#1493) [Ash Berlin-Taylor]
+docs: migrate examples/quickhowto3 to version 3.x.x (#1488) [luizduma]
+fix: REST API inner joins eager loading (#1486) [Daniel Vaz Gaspar]
+
 Improvements and Bug fixes on 3.1.0
 -----------------------------------
 

--- a/flask_appbuilder/__init__.py
+++ b/flask_appbuilder/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Daniel Vaz Gaspar"
-__version__ = "3.1.0"
+__version__ = "3.1.1"
 
 from .actions import action  # noqa: F401
 from .api import ModelRestApi  # noqa: F401


### PR DESCRIPTION
### Description

Release 3.1.1

```
Improvements and Bug fixes on 3.1.1
-----------------------------------

fix: MVC order by related column use alias (#1504) [Daniel Vaz Gaspar]
fix: remove unnecessary CSS class/styling from dropdowns (#1503) [Ryan Hamilton]
deps: constraint pre 1 packages following semver (#1502) [Daniel Vaz Gaspar]
fix: MVC order by on relation (#1500) [Daniel Vaz Gaspar]
docs: add github actions badge (#1501) [Daniel Vaz Gaspar]
fix: remove unnecessary classes from dropdowns (#1491) [Ryan Hamilton]
ci: migrate from travis to github actions (#1497) [Daniel Vaz Gaspar]
fix: lint (#1498) [Daniel Vaz Gaspar]
fix: Improve UX by moving drop-down caret within clickable target (#1492) [Ryan Hamilton]
style: use a clearer visual representation for "delete" actions (#1495) [Ryan Hamilton]
fix: "actions" on ModelViews with composite primary keys (#1493) [Ash Berlin-Taylor]
docs: migrate examples/quickhowto3 to version 3.x.x (#1488) [luizduma]
fix: REST API inner joins eager loading (#1486) [Daniel Vaz Gaspar]
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
