### PR TITLE
fix: Update forms.py

### DIFF
--- a/flask_appbuilder/forms.py
+++ b/flask_appbuilder/forms.py
@@ -188,13 +188,11 @@ class GeneralModelConverter(object):
     ):
         query_func = self._get_related_query_func(col_name, filter_rel_fields)
         get_pk_func = self._get_related_pk_func(col_name)
-        allow_blank = True
         form_props[col_name] = QuerySelectMultipleField(
             label,
             description=description,
             query_func=query_func,
             get_pk_func=get_pk_func,
-            allow_blank=allow_blank,
             validators=lst_validators,
             widget=Select2ManyWidget(),
         )


### PR DESCRIPTION
Removed `allow_blank` kwarg set to `True` by default  in `QuerySelectMultipleField` instantiation, due to the warning for that value in such class.

### Description

When using a multiple choice field due to an enumeration in a model a warning is raised by `QuerySelectMultipleField` complaining about the `True` value of the `allow_blank` kwarg.

This patch just removes the kwarg from the instantiation of a `QuerySelectMultipleField`.

### ADDITIONAL INFORMATION

This eliminates the warning reported in #1402 and seems not to change the behaviour of the field in the form.