### PR TITLE
docs: fix, swagger path in readme

### DIFF
--- a/examples/base_api/README.rst
+++ b/examples/base_api/README.rst
@@ -8,4 +8,4 @@ Run it::
     $ export FLASK_APP=app/__init__.py
     $ flask run
 
-For Swagger view go to: http://localhost:5000/swaggerview/v1
+For Swagger view go to: http://localhost:5000/swagger/v1

--- a/examples/crud_rest_api/README.rst
+++ b/examples/crud_rest_api/README.rst
@@ -13,4 +13,4 @@ Run it::
     $ flask fab create-admin
     $ flask run
 
-For Swagger view go to: http://localhost:5000/swaggerview/v1
+For Swagger view go to: http://localhost:5000/swagger/v1

--- a/examples/react-rest-api/README.rst
+++ b/examples/react-rest-api/README.rst
@@ -13,4 +13,4 @@ Run it::
     $ flask fab create-admin
     $ flask run
 
-For Swagger view go to: http://localhost:5000/swaggerview/v1
+For Swagger view go to: http://localhost:5000/swagger/v1


### PR DESCRIPTION
The specified swagger path in the readme (http://localhost:5000/swaggerview/v1) does not work. Instead http://localhost:5000/swagger/v1 works.

<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

<!--- Describe the change below, including rationale and design decisions -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
