### PR TITLE
fix: oauth #1511

### DIFF
--- a/flask_appbuilder/security/views.py
+++ b/flask_appbuilder/security/views.py
@@ -668,7 +668,9 @@ class AuthOAuthView(AuthView):
                         redirect_uri=url_for(
                             ".oauth_authorized", provider=provider, _external=True
                         ),
-                        state=state.decode("ascii"),
+                        state=state.decode("ascii")
+                        if isinstance(state, bytes)
+                        else state,
                     )
             except Exception as e:
                 log.error("Error on OAuth authorize: {0}".format(e))

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         "marshmallow-sqlalchemy>=0.22.0, <0.24.0",
         "python-dateutil>=2.3, <3",
         "prison>=0.1.3, <1.0.0",
-        "PyJWT>=1.7.1",
+        "PyJWT>=1.7.1, <2.0.0",
         "sqlalchemy-utils>=0.32.21, <1",
     ],
     extras_require={"jmespath": ["jmespath>=0.9.5"]},


### PR DESCRIPTION
### Description

```
ERROR:flask_appbuilder.security.views:Error on OAuth authorize: 'str' object has no attribute 'decode'
```

Fixes #1511

### ADDITIONAL INFORMATION
- [ ] Has associated issue: #1511
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
