### PR TITLE
fix(mvc): action confirmation on single show view

### DIFF
--- a/flask_appbuilder/templates/appbuilder/general/lib.html
+++ b/flask_appbuilder/templates/appbuilder/general/lib.html
@@ -22,7 +22,11 @@
             </form>
 
             <a href="javascript:void(0)" class="btn btn-sm btn-primary"
+               {% if action.confirmation %}
                onclick="var a = new AdminActions(); return a.execute_single('{{path}}','{{action.confirmation}}');">
+               {% else %}
+               onclick="var a = new AdminActions(); return a.execute_single('{{path}}',false);">
+               {% endif %}
                 <i class="fa {{action.icon}}"></i>
                     {{_(action.text)}}
                 </a>


### PR DESCRIPTION
### Description
Fixes: #1529 

Action confirmation set to None is not respected when using single on a show view 

### ADDITIONAL INFORMATION
- [X] Has associated issue: #1529 
- [X] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
