### PR TITLE
feat: Add support get oauth user info from userinfo_endpoint with authlib

### DIFF
--- a/examples/oauth/config.py
+++ b/examples/oauth/config.py
@@ -40,6 +40,16 @@ CSRF_ENABLED = True
 # AUTH_REMOTE_USER : Is for using REMOTE_USER from web server
 AUTH_TYPE = AUTH_OAUTH
 
+
+def normalize_userinfo(client, data):
+    return {
+        'sub': str(data['id']),
+        'name': data['username'],
+        'username': data['username'],
+        'email': data.get('email'),
+        'first_name': data['name'],
+    }
+
 OAUTH_PROVIDERS = [
     {
         "name": "twitter",
@@ -104,6 +114,21 @@ OAUTH_PROVIDERS = [
             ),
         },
     },
+    {
+        'name': 'gitlab',
+        'icon': 'fa-gitlab',
+        'token_key': 'access_token',
+        'remote_app': {
+            "client_id": os.environ.get("GITLAB_KEY"),
+            "client_secret": os.environ.get("GITLAB_SECRET"),
+            'api_base_url': 'https://gitlab.com/api/v4/',
+            'access_token_url': 'https://gitlab.com/oauth/token',
+            'authorize_url': 'https://gitlab.com/oauth/authorize',
+            'userinfo_endpoint': 'user',
+            'userinfo_compliance_fix': normalize_userinfo,
+            'client_kwargs': {'scope': 'email read_user'},
+        }
+    }
 ]
 
 # Uncomment to setup Full admin role name

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -552,6 +552,20 @@ class BaseSecurityManager(AbstractSecurityManager):
             Since there are different OAuth API's with different ways to
             retrieve user info
         """
+        remote = self.oauth_remotes[provider]
+        metadata = remote.load_server_metadata()
+        # from `userinfo_endpoint`
+        # https://docs.authlib.org/en/latest/client/frameworks.html?highlight=userinfo#userinfo-endpoint
+        if "userinfo_endpoint" in metadata:
+            userinfo = remote.userinfo()
+            log.debug("User info from {}: {}".format(provider, userinfo))
+            return {
+                "username": userinfo["username"],
+                "email": userinfo.get("email"),
+                "first_name": userinfo.get("first_name"),
+                "last_name": userinfo.get("last_name"),
+            }
+
         # for GITHUB
         if provider == "github" or provider == "githublocal":
             me = self.appbuilder.sm.oauth_remotes[provider].get("user")


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description
Adding oauth providers manually is very tedious and unfriendly, since migrated from Flask-OAuthlib to Authlib that support `userinfo_endpoint`, we can get user info more easily from different provider.


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [x] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
