### PR TITLE
fix(api): OpenAPI spec of nested components without auto generated names

### DIFF
--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -1026,42 +1026,60 @@ class ModelRestApi(BaseModelApi):
         self._init_model_schemas()
         return super(ModelRestApi, self).create_blueprint(appbuilder, *args, **kwargs)
 
+    @property
+    def list_model_schema_name(self) -> str:
+        return f"{self.__class__.__name__}.get_list"
+
+    @property
+    def show_model_schema_name(self) -> str:
+        return f"{self.__class__.__name__}.get"
+
+    @property
+    def add_model_schema_name(self) -> str:
+        return f"{self.__class__.__name__}.post"
+
+    @property
+    def edit_model_schema_name(self) -> str:
+        return f"{self.__class__.__name__}.put"
+
     def add_apispec_components(self, api_spec):
         super(ModelRestApi, self).add_apispec_components(api_spec)
         api_spec.components.schema(
-            "{}.{}".format(self.__class__.__name__, "get_list"),
-            schema=self.list_model_schema,
+            self.list_model_schema_name, schema=self.list_model_schema
         )
         api_spec.components.schema(
-            "{}.{}".format(self.__class__.__name__, "post"),
-            schema=self.add_model_schema,
+            self.add_model_schema_name, schema=self.add_model_schema
         )
         api_spec.components.schema(
-            "{}.{}".format(self.__class__.__name__, "put"),
-            schema=self.edit_model_schema,
+            self.edit_model_schema_name, schema=self.edit_model_schema
         )
         api_spec.components.schema(
-            "{}.{}".format(self.__class__.__name__, "get"),
-            schema=self.show_model_schema,
+            self.show_model_schema_name, schema=self.show_model_schema
         )
 
     def _init_model_schemas(self):
         # Create Marshmalow schemas if one is not specified
         if self.list_model_schema is None:
             self.list_model_schema = self.model2schemaconverter.convert(
-                self.list_columns
+                self.list_columns, parent_schema_name=self.list_model_schema_name
             )
         if self.add_model_schema is None:
             self.add_model_schema = self.model2schemaconverter.convert(
-                self.add_columns, nested=False, enum_dump_by_name=True
+                self.add_columns,
+                nested=False,
+                enum_dump_by_name=True,
+                parent_schema_name=self.add_model_schema_name,
             )
         if self.edit_model_schema is None:
             self.edit_model_schema = self.model2schemaconverter.convert(
-                self.edit_columns, nested=False, enum_dump_by_name=True
+                self.edit_columns,
+                nested=False,
+                enum_dump_by_name=True,
+                parent_schema_name=self.edit_model_schema_name,
             )
         if self.show_model_schema is None:
             self.show_model_schema = self.model2schemaconverter.convert(
-                self.show_columns
+                self.show_columns, parent_schema_name=self.show_model_schema_name
             )
 
     def _init_titles(self):

--- a/flask_appbuilder/api/convert.py
+++ b/flask_appbuilder/api/convert.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Type
 
 from flask_appbuilder.models.sqla import Model
 from flask_appbuilder.models.sqla.interface import SQLAInterface
@@ -85,7 +85,9 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
         for k, v in schema._declared_fields.items():
             print(k, v)
 
-    def _meta_schema_factory(self, columns: List[str], model: Model, class_mixin):
+    def _meta_schema_factory(
+        self, columns: List[str], model: Model, class_mixin, parent_schema=None
+    ):
         """
         Creates ModelSchema marshmallow-sqlalchemy
 
@@ -208,7 +210,13 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
                 field.validators.append(self.validators_columns[column.data])
             return field
 
-    def convert(self, columns, model=None, nested=True, enum_dump_by_name=False):
+    def convert(
+        self,
+        columns: List[str],
+        model: Type[Model] = None,
+        nested: bool = True,
+        enum_dump_by_name: bool = False,
+    ):
         """
             Creates a Marshmallow ModelSchema class
 

--- a/flask_appbuilder/api/convert.py
+++ b/flask_appbuilder/api/convert.py
@@ -152,21 +152,21 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
             field = fields.Nested(nested_schema, many=many, required=required)
             field.unique = datamodel.is_unique(column.data)
             return field
-        # Handle bug on marshmallow-sqlalchemy #163
-        elif datamodel.is_relation(column.data):
-            if datamodel.is_relation_many_to_many(
-                column.data
-            ) or datamodel.is_relation_one_to_many(column.data):
-                if datamodel.get_info(column.data).get("required", False):
-                    required = True
-                else:
-                    required = False
+        # Handle bug on marshmallow-sqlalchemy
+        # https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/163
+        if datamodel.is_relation_many_to_many(
+            column.data
+        ) or datamodel.is_relation_one_to_many(column.data):
+            if datamodel.get_info(column.data).get("required", False):
+                required = True
             else:
-                required = not datamodel.is_nullable(column.data)
-            field = field_for(datamodel.obj, column.data)
-            field.required = required
-            field.unique = datamodel.is_unique(column.data)
-            return field
+                required = False
+        else:
+            required = not datamodel.is_nullable(column.data)
+        field = field_for(datamodel.obj, column.data)
+        field.required = required
+        field.unique = datamodel.is_unique(column.data)
+        return field
 
     def _column2field(
         self,
@@ -185,7 +185,7 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
         """
         # Handle relations
         if datamodel.is_relation(column.data):
-            self._column2relation(datamodel, column, nested=nested)
+            return self._column2relation(datamodel, column, nested=nested)
         # Handle Enums
         elif datamodel.is_enum(column.data):
             return self._column2enum(

--- a/flask_appbuilder/api/manager.py
+++ b/flask_appbuilder/api/manager.py
@@ -14,7 +14,9 @@ def resolver(schema):
     name = schema_cls.__name__
     if name == "MetaSchema":
         if hasattr(schema_cls, "Meta"):
-            return schema_cls.Meta.model.__name__
+            return (
+                f"{schema_cls.Meta.parent_schema_name}.{schema_cls.Meta.model.__name__}"
+            )
     if name.endswith("Schema"):
         return name[:-6] or name
     return name

--- a/flask_appbuilder/api/manager.py
+++ b/flask_appbuilder/api/manager.py
@@ -1,11 +1,23 @@
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
+from apispec.ext.marshmallow.common import resolve_schema_cls
 from flask import current_app
 from flask_appbuilder.api import BaseApi
 from flask_appbuilder.api import expose, protect, safe
 from flask_appbuilder.basemanager import BaseManager
 from flask_appbuilder.baseviews import BaseView
 from flask_appbuilder.security.decorators import has_access
+
+
+def resolver(schema):
+    schema_cls = resolve_schema_cls(schema)
+    name = schema_cls.__name__
+    if name == "MetaSchema":
+        if hasattr(schema_cls, "Meta"):
+            return schema_cls.Meta.model.__name__
+    if name.endswith("Schema"):
+        return name[:-6] or name
+    return name
 
 
 class OpenApi(BaseApi):
@@ -57,7 +69,7 @@ class OpenApi(BaseApi):
             version=version,
             openapi_version="3.0.2",
             info=dict(description=current_app.appbuilder.app_name),
-            plugins=[MarshmallowPlugin()],
+            plugins=[MarshmallowPlugin(schema_name_resolver=resolver)],
             servers=[{"url": "/api/{}".format(version)}],
         )
 

--- a/flask_appbuilder/tests/config_api.py
+++ b/flask_appbuilder/tests/config_api.py
@@ -1,6 +1,12 @@
 import os
 
-SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
+basedir = os.path.abspath(os.path.dirname(__file__))
+
+SQLALCHEMY_DATABASE_URI = os.environ.get(
+    "SQLALCHEMY_DATABASE_URI"
+) or "sqlite:///" + os.path.join(basedir, "app.db")
+
+
 SECRET_KEY = "thisismyscretkey"
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 WTF_CSRF_ENABLED = False


### PR DESCRIPTION
### Description
Fixes the name collision on OpenAPI spec for auto generated nested schemas. Previously schema names were getting named "Meta1", "Meta2" etc.. this PR prefixes the schema name with the schema parent name and sufixes with the model name.

#### Before:
<img width="241" alt="Screenshot 2021-01-11 at 18 09 16" src="https://user-images.githubusercontent.com/4025227/104220970-26c0bf80-5438-11eb-97a9-828d726ac639.png">

#### After:
<img width="397" alt="Screenshot 2021-01-11 at 18 20 19" src="https://user-images.githubusercontent.com/4025227/104222476-42c56080-543a-11eb-8faf-1ebdd3097783.png">

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
