### PR TITLE
fix: encode next url

### DIFF
--- a/flask_appbuilder/templates/appbuilder/general/security/login_oauth.html
+++ b/flask_appbuilder/templates/appbuilder/general/security/login_oauth.html
@@ -7,7 +7,7 @@
 
     var baseLoginUrl = "{{appbuilder.get_url_for_login}}";
     var baseRegisterUrl = "{{appbuilder.get_url_for_login}}";
-    var next = "?next={{request.args.get('next', '')}}"
+    var next = "?next={{request.args.get('next', '') | urlencode}}"
 
     var currentSelection = "";
 


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

next args should be encode.

if url has `&` will be render to `&amp;`
```
?next=http://airflow/log?execution_date=2021-01-27T05%3A40%3A00%2B00%3A00&amp;task_id=demo_task&amp;dag_id=demo_dag
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
