### PR TITLE
fix: remove pinned sqlalchemy and sqlalchemy-utils

### DIFF
--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -13,7 +13,6 @@ from sqlalchemy.orm.session import Session as SessionBase
 from sqlalchemy.orm.util import AliasedClass
 from sqlalchemy.sql.elements import BinaryExpression
 from sqlalchemy.sql.sqltypes import TypeEngine
-from sqlalchemy_utils.types.uuid import UUIDType
 
 
 from . import filters, Model
@@ -485,10 +484,7 @@ class SQLAInterface(BaseInterface):
 
     def is_string(self, col_name: str) -> bool:
         try:
-            return (
-                _is_sqla_type(self.list_columns[col_name].type, sa.types.String)
-                or self.list_columns[col_name].type.__class__ == UUIDType
-            )
+            return _is_sqla_type(self.list_columns[col_name].type, sa.types.String)
         except KeyError:
             return False
 

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,6 @@ setup(
         "Flask-Babel>=1, <2",
         "Flask-Login>=0.3, <0.5",
         "Flask-OpenID>=1.2.5, <2",
-        # SQLAlchemy 1.4.0 breaks flask-sqlalchemy and sqlalchemy-utils
-        "SQLAlchemy<1.4.0",
         "Flask-SQLAlchemy>=2.4, <3",
         "Flask-WTF>=0.14.2, <0.15.0",
         "Flask-JWT-Extended>=3.18, <4",
@@ -65,7 +63,6 @@ setup(
         "python-dateutil>=2.3, <3",
         "prison>=0.1.3, <1.0.0",
         "PyJWT>=1.7.1, <2.0.0",
-        "sqlalchemy-utils>=0.32.21, <1",
     ],
     extras_require={"jmespath": ["jmespath>=0.9.5"]},
     tests_require=["nose>=1.0", "mockldap>=0.3.0"],


### PR DESCRIPTION
### Description

Flask-SQLAlchemy released a new version that already supports SQLAlchemy 1.4: https://github.com/pallets/flask-sqlalchemy/blob/master/CHANGES.rst#version-250

Removing sqlalchemy-utils since it's not really used on FAB and it's not compatible for now:
https://github.com/kvesteri/sqlalchemy-utils/issues/505

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
