### PR TITLE
fix: Ignore LDAP search referrals

### DIFF
--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -878,10 +878,17 @@ class BaseSecurityManager(AbstractSecurityManager):
                 filter_str, request_fields, self.auth_ldap_search
             )
         )
-        search_result = con.search_s(
+        raw_search_result = con.search_s(
             self.auth_ldap_search, ldap.SCOPE_SUBTREE, filter_str, request_fields
         )
-        log.debug("LDAP search returned: {0}".format(search_result))
+        log.debug("LDAP search returned: {0}".format(raw_search_result))
+
+        # Remove any search referrals from results
+        search_result = [
+            (dn, attrs)
+            for dn, attrs in raw_search_result
+            if dn is not None and isinstance(attrs, dict)
+        ]
 
         # only continue if 0 or 1 results were returned
         if len(search_result) > 1:


### PR DESCRIPTION


<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

<!--- Describe the change below, including rationale and design decisions -->

LDAP referrals are completely broken anyway, and we've already set
`ldap.OPT_REFERRALS` to 0, so there is no reason to care about these.

Thus the presence of referrals alone should not cause authentication of
a user to fail due to multiple results being returned.

Fixes issue #1581.

If this change is not desired, and rather a documentation update to
indicate that setting up LDAP against Microsoft AD requires a
organizational unit to be specified in the LDAP search base, and I
happy to make that update.  I can add the necessary tests once I get
feedback if we want to move forward with this.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [x] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
