### PR TITLE
fix: relax AzureAD mandatory fields

### DIFF
--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -606,7 +606,6 @@ class BaseSecurityManager(AbstractSecurityManager):
                 "last_name": me.get("family_name", ""),
                 "id": me["oid"],
                 "username": me["oid"],
-                "roles": me.get("roles", []),
             }
         # for OpenShift
         if provider == "openshift":

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -603,7 +603,7 @@ class BaseSecurityManager(AbstractSecurityManager):
                 "name": me.get("name", ""),
                 "email": me["upn"],
                 "first_name": me.get("given_name", ""),
-                "last_name": me("family_name", ""),
+                "last_name": me.get("family_name", ""),
                 "id": me["oid"],
                 "username": me["oid"],
             }

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -600,10 +600,10 @@ class BaseSecurityManager(AbstractSecurityManager):
             me = self._azure_jwt_token_parse(id_token)
             log.debug("Parse JWT token : {0}".format(me))
             return {
-                "name": me["name"],
+                "name": me.get("name", ""),
                 "email": me["upn"],
-                "first_name": me["given_name"],
-                "last_name": me["family_name"],
+                "first_name": me.get("given_name", ""),
+                "last_name": me("family_name", ""),
                 "id": me["oid"],
                 "username": me["oid"],
             }

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -606,6 +606,7 @@ class BaseSecurityManager(AbstractSecurityManager):
                 "last_name": me.get("family_name", ""),
                 "id": me["oid"],
                 "username": me["oid"],
+                "roles": me.get("roles", []),
             }
         # for OpenShift
         if provider == "openshift":


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

<!--- Describe the change below, including rationale and design decisions -->
When `given_name` field does not exist in AzureAD, users can't login.
I explicitly claimed `given_name` field in AzureAD, however, `given_name` field does not exist because it is empty.
Therefore, the changes are to relax mandatory fields in AzureAD.

Fix the issue: #1612

> 2021-04-13 04:53:27,972:ERROR:flask_appbuilder.security.views:Error returning OAuth user info: 'given_name'

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [x] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
