### PR TITLE
fix: Un-pin SQLAlchemy related deps now they have updated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,6 @@ setup(
         "Flask-Babel>=1, <2",
         "Flask-Login>=0.3, <0.5",
         "Flask-OpenID>=1.2.5, <2",
-        # SQLAlchemy 1.4.0 breaks flask-sqlalchemy and sqlalchemy-utils
-        "SQLAlchemy<1.4.0",
         "Flask-SQLAlchemy>=2.4, <3",
         "Flask-WTF>=0.14.2, <0.15.0",
         "Flask-JWT-Extended>=3.18, <4",


### PR DESCRIPTION
Flask-SQLAlchemy 2.5 and sqlalchemy-utils 0.37.0 have now been released
and work with SQLA 1.4.

I haven't updated the explicit deps there, as the new pip resolver
should handle this case fine, and we don't need any of the new
functionality.

Relates/continues https://github.com/dpgaspar/Flask-AppBuilder/pull/1592

/cc @dpgaspar 
