### PR TITLE
feat(security): get user permissions API

### DIFF
--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -1394,7 +1394,7 @@ class BaseSecurityManager(AbstractSecurityManager):
         # If it's not a builtin role check against database store roles
         return self.exist_permission_on_roles(view_name, permission_name, db_role_ids)
 
-    def get_current_user_roles(self) -> List[...]:
+    def get_current_user_roles(self) -> List[object]:
         """
         Get current user roles, if user is not authenticated returns the public role
         """
@@ -1785,7 +1785,7 @@ class BaseSecurityManager(AbstractSecurityManager):
         """
         raise NotImplementedError
 
-    def get_role_permissions(self, role_id: int) -> List[...]:
+    def get_role_permissions(self, role_id: int) -> List[object]:
         """
         Get all DB permissions from a role id
         """

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -3,7 +3,7 @@ import datetime
 import json
 import logging
 import re
-from typing import Dict, List, Set
+from typing import Dict, List, Set, Tuple
 
 from flask import g, session, url_for
 from flask_babel import lazy_gettext as _
@@ -1394,6 +1394,31 @@ class BaseSecurityManager(AbstractSecurityManager):
         # If it's not a builtin role check against database store roles
         return self.exist_permission_on_roles(view_name, permission_name, db_role_ids)
 
+    def get_current_user_roles(self) -> List[...]:
+        """
+        Get current user roles, if user is not authenticated returns the public role
+        """
+        user = self.current_user
+        if not user.is_authenticated:
+            return [self.get_public_role()]
+        return user.roles
+
+    def get_current_user_permissions(self) -> Set[Tuple[str, str]]:
+        """
+        Get all permissions from the current user
+        """
+        roles = self.get_current_user_roles()
+        result = set()
+        for role in roles:
+            if role.name in self.builtin_roles:
+                for permission in self.builtin_roles[role.name]:
+                    result.add((permission[0], permission[1]))
+            else:
+
+                for permission in self.get_role_permissions(role.id):
+                    result.add((permission.view_menu.name, permission.permission.name))
+            return result
+
     def _get_user_permission_view_menus(
         self, user: object, permission_name: str, view_menus_name: List[str]
     ) -> Set[str]:
@@ -1432,7 +1457,7 @@ class BaseSecurityManager(AbstractSecurityManager):
 
     def has_access(self, permission_name, view_name):
         """
-            Check if current user or public has access to view or menu
+        Check if current user or public has access to view or menu
         """
         if current_user.is_authenticated:
             return self._has_view_access(g.user, permission_name, view_name)
@@ -1457,13 +1482,13 @@ class BaseSecurityManager(AbstractSecurityManager):
 
     def add_permissions_view(self, base_permissions, view_menu):
         """
-            Adds a permission on a view menu to the backend
+        Adds a permission on a view menu to the backend
 
-            :param base_permissions:
-                list of permissions from view (all exposed methods):
-                 'can_add','can_edit' etc...
-            :param view_menu:
-                name of the view or menu to add
+        :param base_permissions:
+            list of permissions from view (all exposed methods):
+             'can_add','can_edit' etc...
+        :param view_menu:
+            name of the view or menu to add
         """
         view_menu_db = self.add_view_menu(view_menu)
         perm_views = self.find_permissions_view_menu(view_menu_db)
@@ -1505,10 +1530,10 @@ class BaseSecurityManager(AbstractSecurityManager):
 
     def add_permissions_menu(self, view_menu_name):
         """
-            Adds menu_access to menu on permission_view_menu
+        Adds menu_access to menu on permission_view_menu
 
-            :param view_menu_name:
-                The menu name
+        :param view_menu_name:
+            The menu name
         """
         self.add_view_menu(view_menu_name)
         pv = self.find_permission_view_menu("menu_access", view_menu_name)
@@ -1520,10 +1545,10 @@ class BaseSecurityManager(AbstractSecurityManager):
 
     def security_cleanup(self, baseviews, menus):
         """
-            Will cleanup all unused permissions from the database
+        Will cleanup all unused permissions from the database
 
-            :param baseviews: A list of BaseViews class
-            :param menus: Menu class
+        :param baseviews: A list of BaseViews class
+        :param menus: Menu class
         """
         viewsmenus = self.get_all_view_menu()
         roles = self.get_all_roles()
@@ -1595,9 +1620,9 @@ class BaseSecurityManager(AbstractSecurityManager):
     @staticmethod
     def _update_del_transitions(state_transitions: Dict, baseviews: List) -> None:
         """
-            Mutates state_transitions, loop baseviews and prunes all
-            views and permissions that are not to delete because references
-            exist.
+        Mutates state_transitions, loop baseviews and prunes all
+        views and permissions that are not to delete because references
+        exist.
 
         :param baseview:
         :param state_transitions:
@@ -1613,14 +1638,14 @@ class BaseSecurityManager(AbstractSecurityManager):
 
     def create_state_transitions(self, baseviews: List, menus: List) -> Dict:
         """
-            Creates a Dict with all the necessary vm/permission transitions
+        Creates a Dict with all the necessary vm/permission transitions
 
-            Dict: {
-                    "add": {(<VM>, <PERM>): ((<VM>, PERM), ... )}
-                    "del_role_pvm": ((<VM>, <PERM>), ...)
-                    "del_views": (<VM>, ... )
-                    "del_perms": (<PERM>, ... )
-                  }
+        Dict: {
+                "add": {(<VM>, <PERM>): ((<VM>, PERM), ... )}
+                "del_role_pvm": ((<VM>, <PERM>), ...)
+                "del_views": (<VM>, ... )
+                "del_perms": (<PERM>, ... )
+              }
 
         :param baseviews: List with all the registered BaseView, BaseApi
         :param menus: List with all the menu entries
@@ -1669,10 +1694,10 @@ class BaseSecurityManager(AbstractSecurityManager):
 
     def security_converge(self, baseviews: List, menus: List, dry=False) -> Dict:
         """
-            Converges overridden permissions on all registered views/api
-            will compute all necessary operations from `class_permissions_name`,
-            `previous_class_permission_name`, method_permission_name`,
-            `previous_method_permission_name` class attributes.
+        Converges overridden permissions on all registered views/api
+        will compute all necessary operations from `class_permissions_name`,
+        `previous_class_permission_name`, method_permission_name`,
+        `previous_method_permission_name` class attributes.
 
         :param baseviews: List of registered views/apis
         :param menus: List of menu items
@@ -1756,7 +1781,13 @@ class BaseSecurityManager(AbstractSecurityManager):
 
     def get_all_users(self):
         """
-            Generic function that returns all exsiting users
+            Generic function that returns all existing users
+        """
+        raise NotImplementedError
+
+    def get_role_permissions(self, role_id: int) -> List[...]:
+        """
+        Get all DB permissions from a role id
         """
         raise NotImplementedError
 

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -1394,30 +1394,28 @@ class BaseSecurityManager(AbstractSecurityManager):
         # If it's not a builtin role check against database store roles
         return self.exist_permission_on_roles(view_name, permission_name, db_role_ids)
 
-    def get_current_user_roles(self) -> List[object]:
+    def get_user_roles(self, user) -> List[object]:
         """
         Get current user roles, if user is not authenticated returns the public role
         """
-        user = self.current_user
         if not user.is_authenticated:
             return [self.get_public_role()]
         return user.roles
 
-    def get_current_user_permissions(self) -> Set[Tuple[str, str]]:
+    def get_user_permissions(self, user) -> Set[Tuple[str, str]]:
         """
         Get all permissions from the current user
         """
-        roles = self.get_current_user_roles()
+        roles = self.get_user_roles(user)
         result = set()
         for role in roles:
             if role.name in self.builtin_roles:
                 for permission in self.builtin_roles[role.name]:
                     result.add((permission[0], permission[1]))
             else:
-
                 for permission in self.get_role_permissions(role.id):
                     result.add((permission.view_menu.name, permission.permission.name))
-            return result
+        return result
 
     def _get_user_permission_view_menus(
         self, user: object, permission_name: str, view_menus_name: List[str]

--- a/flask_appbuilder/security/sqla/manager.py
+++ b/flask_appbuilder/security/sqla/manager.py
@@ -359,7 +359,7 @@ class SecurityManager(BaseSecurityManager):
             )
         ).all()
 
-    def get_role_permissions(self, role_id: int) -> List[PermissionView]:
+    def get_db_role_permissions(self, role_id: int) -> List[PermissionView]:
         """
         Get all DB permissions from a role (one single query)
         """

--- a/flask_appbuilder/security/sqla/manager.py
+++ b/flask_appbuilder/security/sqla/manager.py
@@ -364,10 +364,11 @@ class SecurityManager(BaseSecurityManager):
         Get all DB permissions from a role (one single query)
         """
         return (
-            self.appbuilder.get_session.query(self.role_model)
-            .join(self.permission_model)
-            .join(self.viewmenu_model)
-            .filter(self.role_model.id == role_id)
+            self.appbuilder.get_session.query(PermissionView)
+            .join(Permission)
+            .join(ViewMenu)
+            .join(PermissionView.role)
+            .filter(Role.id == role_id)
             .all()
         )
 

--- a/flask_appbuilder/security/sqla/manager.py
+++ b/flask_appbuilder/security/sqla/manager.py
@@ -359,6 +359,39 @@ class SecurityManager(BaseSecurityManager):
             )
         ).all()
 
+    def get_role_permissions(self, role_id: int) -> List[PermissionView]:
+        """
+        Get all DB permissions from a role (one single query)
+        """
+        return (
+            self.appbuilder.get_session.query(self.role_model)
+            .join(self.permission_model)
+            .join(self.viewmenu_model)
+            .filter(self.role_model.id == role_id)
+            .all()
+        )
+
+    def get_role_permission_view_menus(self, permission_name: str, role_ids: List[int]):
+        return (
+            self.appbuilder.get_session.query(self.permissionview_model)
+            .join(
+                assoc_permissionview_role,
+                and_(
+                    (
+                        self.permissionview_model.id
+                        == assoc_permissionview_role.c.permission_view_id
+                    )
+                ),
+            )
+            .join(self.role_model)
+            .join(self.permission_model)
+            .join(self.viewmenu_model)
+            .filter(
+                self.permission_model.name == permission_name,
+                self.role_model.id.in_(role_ids),
+            )
+        ).all()
+
     def add_permission(self, name):
         """
             Adds a permission to the backend, model permission

--- a/flask_appbuilder/security/sqla/manager.py
+++ b/flask_appbuilder/security/sqla/manager.py
@@ -371,27 +371,6 @@ class SecurityManager(BaseSecurityManager):
             .all()
         )
 
-    def get_role_permission_view_menus(self, permission_name: str, role_ids: List[int]):
-        return (
-            self.appbuilder.get_session.query(self.permissionview_model)
-            .join(
-                assoc_permissionview_role,
-                and_(
-                    (
-                        self.permissionview_model.id
-                        == assoc_permissionview_role.c.permission_view_id
-                    )
-                ),
-            )
-            .join(self.role_model)
-            .join(self.permission_model)
-            .join(self.viewmenu_model)
-            .filter(
-                self.permission_model.name == permission_name,
-                self.role_model.id.in_(role_ids),
-            )
-        ).all()
-
     def add_permission(self, name):
         """
             Adds a permission to the backend, model permission

--- a/flask_appbuilder/tests/base.py
+++ b/flask_appbuilder/tests/base.py
@@ -83,8 +83,13 @@ class FABTestCase(unittest.TestCase):
         first_name="admin",
         last_name="user",
         email="admin@fab.org",
+        role_names=None,
     ):
-        role_admin = appbuilder.sm.find_role(role_name)
-        appbuilder.sm.add_user(
-            username, first_name, last_name, email, role_admin, password
+        roles = (
+            [appbuilder.sm.find_role(role_name) for role_name in role_names]
+            if role_names
+            else [appbuilder.sm.find_role(role_name)]
+        )
+        return appbuilder.sm.add_user(
+            username, first_name, last_name, email, roles, password
         )

--- a/flask_appbuilder/tests/config_security.py
+++ b/flask_appbuilder/tests/config_security.py
@@ -1,0 +1,17 @@
+import os
+
+basedir = os.path.abspath(os.path.dirname(__file__))
+
+SQLALCHEMY_DATABASE_URI = os.environ.get(
+    "SQLALCHEMY_DATABASE_URI"
+) or "sqlite:///" + os.path.join(basedir, "app.db")
+
+
+SECRET_KEY = "thisismyscretkey"
+SQLALCHEMY_TRACK_MODIFICATIONS = False
+WTF_CSRF_ENABLED = False
+FAB_API_SWAGGER_UI = True
+FAB_ROLES = {
+    "FAB_ROLE1": [["Model1View", "can_list"], ["Model2View", "can_list"]],
+    "FAB_ROLE2": [["Model3View", "can_list"], ["Model4View", "can_list"]],
+}

--- a/flask_appbuilder/tests/test_security_permissions.py
+++ b/flask_appbuilder/tests/test_security_permissions.py
@@ -1,0 +1,127 @@
+from flask_appbuilder import SQLA
+from flask_appbuilder.tests.base import FABTestCase
+from flask_login import AnonymousUserMixin
+
+
+class SecurityPermissionsTestCase(FABTestCase):
+    def setUp(self):
+        from flask import Flask
+        from flask_appbuilder import AppBuilder
+
+        self.app = Flask(__name__)
+        self.app.config.from_object("flask_appbuilder.tests.config_security")
+        self.app.config["FAB_ADD_SECURITY_VIEWS"] = False
+
+        self.db = SQLA(self.app)
+        self.appbuilder = AppBuilder(self.app, self.db.session)
+
+        self._db_role_1 = self.appbuilder.sm.add_role("DB_ROLE1")
+        self._pvm1 = self.appbuilder.sm.add_permission_view_menu(
+            "can_show", "ModelDBView"
+        )
+        self._pvm2 = self.appbuilder.sm.add_permission_view_menu(
+            "can_delete", "ModelDBView"
+        )
+        self.appbuilder.sm.add_permission_role(self._db_role_1, self._pvm1)
+        self.appbuilder.sm.add_permission_role(self._db_role_1, self._pvm2)
+
+        # Insert test data
+        self._user01 = self.create_user(
+            self.appbuilder,
+            "user1",
+            "password1",
+            "",
+            first_name="user01",
+            last_name="user",
+            email="user01@fab.org",
+            role_names=["FAB_ROLE1", "DB_ROLE1"],
+        )
+
+        self._user02 = self.create_user(
+            self.appbuilder,
+            "user2",
+            "password1",
+            "",
+            first_name="user02",
+            last_name="user",
+            email="user02@fab.org",
+            role_names=["DB_ROLE1"],
+        )
+
+        self._user03 = self.create_user(
+            self.appbuilder,
+            "user3",
+            "password1",
+            "",
+            first_name="user03",
+            last_name="user",
+            email="user03@fab.org",
+            role_names=["FAB_ROLE2"],
+        )
+
+        self._user04 = self.create_user(
+            self.appbuilder,
+            "user4",
+            "password1",
+            "",
+            first_name="user04",
+            last_name="user",
+            email="user04@fab.org",
+            role_names=["FAB_ROLE1", "FAB_ROLE2"],
+        )
+
+    def tearDown(self):
+        self.appbuilder.get_session.delete(self._user01)
+        self.appbuilder.get_session.delete(self._user02)
+        self.appbuilder.get_session.delete(self._user03)
+        self.appbuilder.get_session.delete(self._user04)
+        self.appbuilder.get_session.delete(self._pvm1)
+        self.appbuilder.get_session.delete(self._pvm2)
+        self.appbuilder.get_session.delete(self._db_role_1)
+        self.appbuilder.get_session.commit()
+
+    def test_get_user_permissions_mixed(self):
+        """
+        Security Permissions: Get user permissions mixes role types
+        """
+        assert {
+            ("Model1View", "can_list"),
+            ("Model2View", "can_list"),
+            ("ModelDBView", "can_show"),
+            ("ModelDBView", "can_delete"),
+        } == self.appbuilder.sm.get_user_permissions(self._user01)
+
+    def test_get_user_permissions_db(self):
+        """
+        Security Permissions: Get user permissions DB role type
+        """
+        assert {
+            ("ModelDBView", "can_delete"),
+            ("ModelDBView", "can_show"),
+        } == self.appbuilder.sm.get_user_permissions(self._user02)
+
+    def test_get_user_permissions_builtin(self):
+        """
+        Security Permissions: Get user permissions builtin role type
+        """
+        assert {
+            ("Model3View", "can_list"),
+            ("Model4View", "can_list"),
+        } == self.appbuilder.sm.get_user_permissions(self._user03)
+
+    def test_get_user_permissions_builtin_multiple(self):
+        """
+        Security Permissions: Get user permissions multiple builtin role type
+        """
+        assert {
+            ("Model2View", "can_list"),
+            ("Model1View", "can_list"),
+            ("Model3View", "can_list"),
+            ("Model4View", "can_list"),
+        } == self.appbuilder.sm.get_user_permissions(self._user04)
+
+    def test_get_anonymous_permissions(self):
+        """
+        Security Permissions: Get anonymous user permissions
+        """
+        assert set() == self.appbuilder.sm.get_user_permissions(AnonymousUserMixin())

--- a/flask_appbuilder/tests/test_security_permissions.py
+++ b/flask_appbuilder/tests/test_security_permissions.py
@@ -87,8 +87,8 @@ class SecurityPermissionsTestCase(FABTestCase):
         assert {
             ("can_list", "Model1View"),
             ("can_list", "Model2View"),
-            ( "can_show", "ModelDBView"),
-            ( "can_delete", "ModelDBView"),
+            ("can_show", "ModelDBView"),
+            ("can_delete", "ModelDBView"),
         } == self.appbuilder.sm.get_user_permissions(self._user01)
 
     def test_get_user_permissions_db(self):
@@ -125,3 +125,23 @@ class SecurityPermissionsTestCase(FABTestCase):
         Security Permissions: Get anonymous user permissions
         """
         assert set() == self.appbuilder.sm.get_user_permissions(AnonymousUserMixin())
+
+    def test_get_role_permissions_builtin(self):
+        """
+        Security Permissions: Get role permissions builtin
+        """
+        role = self.appbuilder.sm.find_role("FAB_ROLE1")
+        assert {
+            ("can_list", "Model2View"),
+            ("can_list", "Model1View"),
+        } == self.appbuilder.sm.get_role_permissions(role)
+
+    def test_get_role_permissions_db(self):
+        """
+        Security Permissions: Get role permissions db
+        """
+        role = self.appbuilder.sm.find_role("DB_ROLE1")
+        assert {
+           ("can_show", "ModelDBView"),
+           ("can_delete", "ModelDBView"),
+       } == self.appbuilder.sm.get_role_permissions(role)

--- a/flask_appbuilder/tests/test_security_permissions.py
+++ b/flask_appbuilder/tests/test_security_permissions.py
@@ -85,10 +85,10 @@ class SecurityPermissionsTestCase(FABTestCase):
         Security Permissions: Get user permissions mixes role types
         """
         assert {
-            ("Model1View", "can_list"),
-            ("Model2View", "can_list"),
-            ("ModelDBView", "can_show"),
-            ("ModelDBView", "can_delete"),
+            ("can_list", "Model1View"),
+            ("can_list", "Model2View"),
+            ( "can_show", "ModelDBView"),
+            ( "can_delete", "ModelDBView"),
         } == self.appbuilder.sm.get_user_permissions(self._user01)
 
     def test_get_user_permissions_db(self):
@@ -96,8 +96,8 @@ class SecurityPermissionsTestCase(FABTestCase):
         Security Permissions: Get user permissions DB role type
         """
         assert {
-            ("ModelDBView", "can_delete"),
-            ("ModelDBView", "can_show"),
+            ("can_delete", "ModelDBView"),
+            ("can_show", "ModelDBView"),
         } == self.appbuilder.sm.get_user_permissions(self._user02)
 
     def test_get_user_permissions_builtin(self):
@@ -105,8 +105,8 @@ class SecurityPermissionsTestCase(FABTestCase):
         Security Permissions: Get user permissions builtin role type
         """
         assert {
-            ("Model3View", "can_list"),
-            ("Model4View", "can_list"),
+            ("can_list", "Model3View"),
+            ("can_list", "Model4View"),
         } == self.appbuilder.sm.get_user_permissions(self._user03)
 
     def test_get_user_permissions_builtin_multiple(self):
@@ -114,10 +114,10 @@ class SecurityPermissionsTestCase(FABTestCase):
         Security Permissions: Get user permissions multiple builtin role type
         """
         assert {
-            ("Model2View", "can_list"),
-            ("Model1View", "can_list"),
-            ("Model3View", "can_list"),
-            ("Model4View", "can_list"),
+            ("can_list", "Model2View"),
+            ("can_list", "Model1View"),
+            ("can_list", "Model3View"),
+            ("can_list", "Model4View"),
         } == self.appbuilder.sm.get_user_permissions(self._user04)
 
     def test_get_anonymous_permissions(self):

--- a/flask_appbuilder/tests/test_security_permissions.py
+++ b/flask_appbuilder/tests/test_security_permissions.py
@@ -142,6 +142,6 @@ class SecurityPermissionsTestCase(FABTestCase):
         """
         role = self.appbuilder.sm.find_role("DB_ROLE1")
         assert {
-           ("can_show", "ModelDBView"),
-           ("can_delete", "ModelDBView"),
-       } == self.appbuilder.sm.get_role_permissions(role)
+            ("can_show", "ModelDBView"),
+            ("can_delete", "ModelDBView"),
+        } == self.appbuilder.sm.get_role_permissions(role)


### PR DESCRIPTION
### Description

Add a new security manager API method to fetch a user permissions, these permissions can be a mix between builtin roles and DB roles. The actual permission fetching from the DB is efficient (single query), avoids the N+1 issue.

`get_user_permissions`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
