### PR TITLE
fix: improve performance for get role permissions

### DIFF
--- a/flask_appbuilder/security/sqla/manager.py
+++ b/flask_appbuilder/security/sqla/manager.py
@@ -4,6 +4,7 @@ import uuid
 
 from sqlalchemy import and_, func, literal
 from sqlalchemy.engine.reflection import Inspector
+from sqlalchemy.orm import contains_eager
 from sqlalchemy.orm.exc import MultipleResultsFound
 from werkzeug.security import generate_password_hash
 
@@ -369,6 +370,8 @@ class SecurityManager(BaseSecurityManager):
             .join(ViewMenu)
             .join(PermissionView.role)
             .filter(Role.id == role_id)
+            .options(contains_eager(PermissionView.permission))
+            .options(contains_eager(PermissionView.view_menu))
             .all()
         )
 


### PR DESCRIPTION
### Description

Uses eager loading for fetching role permissions. Improved performance. Previously when accessing `view_menu.name` would result on executing a new query (lazy loading)

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
