### PR TITLE
feat: Add support for before_request hooks

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,7 +12,7 @@ AppBuilder
 
     .. autoclass:: AppBuilder
         :members:
-        
+
         .. automethod:: __init__
 
 flask_appbuilder.security.decorators
@@ -30,6 +30,12 @@ flask_appbuilder.models.decorators
 .. automodule:: flask_appbuilder.models.decorators
 
     .. autofunction:: renders
+
+flask_appbuilder.hooks
+======================
+.. automodule:: flask_appbuilder.hooks
+
+    .. autofunction:: before_request
 
 flask_appbuilder.api
 ==============================

--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -19,6 +19,7 @@ from ._compat import as_unicode
 from .actions import ActionItem
 from .const import PERMISSION_PREFIX
 from .forms import GeneralModelConverter
+from .hooks import get_before_request_hooks, wrap_route_handler_with_hooks
 from .urltools import (
     get_filter_args,
     get_order_args,
@@ -247,6 +248,7 @@ class BaseView(object):
         return self.blueprint
 
     def _register_urls(self):
+        before_request_hooks = get_before_request_hooks(self)
         for attr_name in dir(self):
             if (
                 self.include_route_methods is not None
@@ -265,7 +267,12 @@ class BaseView(object):
                     log.info(
                         f"Registering route {self.blueprint.url_prefix}{url} {methods}"
                     )
-                    self.blueprint.add_url_rule(url, attr_name, attr, methods=methods)
+                    route_handler = wrap_route_handler_with_hooks(
+                        attr_name, attr, before_request_hooks
+                    )
+                    self.blueprint.add_url_rule(
+                        url, attr_name, route_handler, methods=methods
+                    )
 
     def render_template(self, template, **kwargs):
         """

--- a/flask_appbuilder/hooks.py
+++ b/flask_appbuilder/hooks.py
@@ -1,28 +1,40 @@
 def before_request(*args, **kwargs):
     """
-        Use this decorator to add a before_request lifecycle
-        hook to be executed before each handler in the view.
-        If invoked with the `only` kwarg, the hook will only
-        be invoked for the given list of handler methods.
+        Use this decorator to enqueue methods to be invoked
+        before each handler in the view. If method returns
+        a value other than :code:`None`, then that value
+        will be returned to the client. If invoked with the
+        :code:`only` kwarg, the hook will only be invoked for
+        the given list of handler methods.
 
-        Examples:
+        Examples::
 
-            @before_request
-            def ensure_feature_is_enabled(self):
-                if self.feature_is_disabled:
-                    return self.response_404()
-                return None
+            class MyFeature(ModelView)
 
-            @before_request(only=["create", "update", "delete"])
-            def ensure_write_mode_enabled(self):
-                if self.read_only:
-                    return self.response_400()
-                return None
+                @before_request
+                def ensure_feature_is_enabled(self):
+                    if self.feature_is_disabled:
+                        return self.response_404()
+                    return None
 
-        :param only:
-            Only kwarg scopes this hook to run only for
-            the given list of handler methods. If absent,
-            the hook will be invoked before all handlers.
+                # etc...
+
+
+            class MyView(ModelRestAPI):
+
+                @before_request(only=["create", "update", "delete"])
+                def ensure_write_mode_enabled(self):
+                    if self.read_only:
+                        return self.response_400()
+                    return None
+
+                # etc...
+
+
+        :param kwargs:
+            The :code:`only` kwarg scopes the method being decorated
+            to run only for the given list of handler methods. If
+            abset, the method will be invoked before all handlers.
     """
     only = kwargs.get("only", None)
 

--- a/flask_appbuilder/hooks.py
+++ b/flask_appbuilder/hooks.py
@@ -1,11 +1,17 @@
-def before_request(*args, **kwargs):
+from typing import Any, Callable, Dict, List
+
+
+def before_request(
+    hook: Callable[[], Any] = None, only: List[str] = None
+) -> Callable[..., Any]:
     """
-        Use this decorator to enqueue methods to be invoked
-        before each handler in the view. If method returns
-        a value other than :code:`None`, then that value
-        will be returned to the client. If invoked with the
-        :code:`only` kwarg, the hook will only be invoked for
-        the given list of handler methods.
+        This decorator provides a way to hook into the request
+        lifecycle by enqueueing methods to be invoked before
+        each handler in the view. If the method returns a value
+        other than :code:`None`, then that value will be returned
+        to the client. If invoked with the :code:`only` kwarg,
+        the hook will only be invoked for the given list of
+        handler methods.
 
         Examples::
 
@@ -30,23 +36,31 @@ def before_request(*args, **kwargs):
 
                 # etc...
 
-
-        :param kwargs:
-            The :code:`only` kwarg scopes the method being decorated
-            to run only for the given list of handler methods. If
-            abset, the method will be invoked before all handlers.
+        :param hook:
+            A callable to be invoked before handlers in the class. If the
+            hook returns :code:`None`, then the request proceeds and the
+            handler is invoked. If it returns something other than :code:`None`,
+            then execution halts and that value is returned to the client.
+        :param only:
+            An optional list of the names of handler methods. If present,
+            :code:`hook` will only be invoked before the handlers specified
+            in the list. If absent, :code:`hook` will be invoked for before
+            all handlers in the class.
     """
-    only = kwargs.get("only", None)
 
-    def wrap(f):
-        f._before_request_hook = True
-        f._before_request_only = only
-        return f
+    def wrap(hook: Callable[[], Any]) -> Callable[[], Any]:
+        hook._before_request_hook = True
+        hook._before_request_only = only
+        return hook
 
-    return wrap(args[0]) if len(args) == 1 else wrap
+    return wrap if hook is None else wrap(hook)
 
 
-def wrap_route_handler_with_hooks(handler_name, handler, before_request_hooks):
+def wrap_route_handler_with_hooks(
+    handler_name: str,
+    handler: Callable[..., Any],
+    before_request_hooks: List[Callable[[], Any]],
+) -> Callable[..., Any]:
     applicable_hooks = []
     for hook in before_request_hooks:
         only = hook._before_request_only
@@ -57,7 +71,7 @@ def wrap_route_handler_with_hooks(handler_name, handler, before_request_hooks):
     if not applicable_hooks:
         return handler
 
-    def wrapped_handler(*args, **kwargs):
+    def wrapped_handler(*args: List[Any], **kwargs: Dict[str, Any]) -> Any:
         for hook in applicable_hooks:
             result = hook()
             if result is not None:
@@ -67,7 +81,7 @@ def wrap_route_handler_with_hooks(handler_name, handler, before_request_hooks):
     return wrapped_handler
 
 
-def get_before_request_hooks(view_or_api_instance):
+def get_before_request_hooks(view_or_api_instance: Any) -> List[Callable[[], Any]]:
     before_request_hooks = []
     for attr_name in dir(view_or_api_instance):
         attr = getattr(view_or_api_instance, attr_name)

--- a/flask_appbuilder/hooks.py
+++ b/flask_appbuilder/hooks.py
@@ -1,0 +1,64 @@
+def before_request(*args, **kwargs):
+    """
+        Use this decorator to add a before_request lifecycle
+        hook to be executed before each handler in the view.
+        If invoked with the `only` kwarg, the hook will only
+        be invoked for the given list of handler methods.
+
+        Examples:
+
+            @before_request
+            def ensure_feature_is_enabled(self):
+                if self.feature_is_disabled:
+                    return self.response_404()
+                return None
+
+            @before_request(only=["create", "update", "delete"])
+            def ensure_write_mode_enabled(self):
+                if self.read_only:
+                    return self.response_400()
+                return None
+
+        :param only:
+            Only kwarg scopes this hook to run only for
+            the given list of handler methods. If absent,
+            the hook will be invoked before all handlers.
+    """
+    only = kwargs.get("only", None)
+
+    def wrap(f):
+        f._before_request_hook = True
+        f._before_request_only = only
+        return f
+
+    return wrap(args[0]) if len(args) == 1 else wrap
+
+
+def wrap_route_handler_with_hooks(handler_name, handler, before_request_hooks):
+    applicable_hooks = []
+    for hook in before_request_hooks:
+        only = hook._before_request_only
+        applicable_hook = only is None or handler_name in only
+        if applicable_hook:
+            applicable_hooks.append(hook)
+
+    if not applicable_hooks:
+        return handler
+
+    def wrapped_handler(*args, **kwargs):
+        for hook in applicable_hooks:
+            result = hook()
+            if result is not None:
+                return result
+        return handler(*args, **kwargs)
+
+    return wrapped_handler
+
+
+def get_before_request_hooks(view_or_api_instance):
+    before_request_hooks = []
+    for attr_name in dir(view_or_api_instance):
+        attr = getattr(view_or_api_instance, attr_name)
+        if hasattr(attr, "_before_request_hook") and attr._before_request_hook is True:
+            before_request_hooks.append(attr)
+    return before_request_hooks

--- a/flask_appbuilder/tests/test_mvc.py
+++ b/flask_appbuilder/tests/test_mvc.py
@@ -1771,10 +1771,7 @@ class MVCTestCase(BaseMVCTestCase):
         )
         self.assertEqual(rv.status_code, 404)
 
-        rv = client.get(
-            "/modelbeforerequest/delete/1",
-            follow_redirects=True,
-        )
+        rv = client.get("/modelbeforerequest/delete/1", follow_redirects=True)
         self.assertEqual(rv.status_code, 404)
 
         # Basic condition is true, so some requests should succeed,
@@ -1798,10 +1795,7 @@ class MVCTestCase(BaseMVCTestCase):
         )
         self.assertEqual(rv.status_code, 404)
 
-        rv = client.get(
-            "/modelbeforerequest/delete/1",
-            follow_redirects=True,
-        )
+        rv = client.get("/modelbeforerequest/delete/1", follow_redirects=True)
         self.assertEqual(rv.status_code, 404)
 
         # Now /list/ and others are available, but
@@ -1825,10 +1819,7 @@ class MVCTestCase(BaseMVCTestCase):
         )
         self.assertEqual(rv.status_code, 404)
 
-        rv = client.get(
-            "/modelbeforerequest/delete/1",
-            follow_redirects=True,
-        )
+        rv = client.get("/modelbeforerequest/delete/1", follow_redirects=True)
         self.assertEqual(rv.status_code, 404)
 
         # Everything is available
@@ -1852,8 +1843,5 @@ class MVCTestCase(BaseMVCTestCase):
         )
         self.assertEqual(rv.status_code, 200)
 
-        rv = client.get(
-            "/modelbeforerequest/delete/1",
-            follow_redirects=True,
-        )
+        rv = client.get("/modelbeforerequest/delete/1", follow_redirects=True)
         self.assertEqual(rv.status_code, 200)

--- a/flask_appbuilder/tests/test_mvc.py
+++ b/flask_appbuilder/tests/test_mvc.py
@@ -617,7 +617,7 @@ class MVCTestCase(BaseMVCTestCase):
         """
             Test views creation and registration
         """
-        self.assertEqual(len(self.appbuilder.baseviews), 36)
+        self.assertEqual(len(self.appbuilder.baseviews), 37)
 
     def test_back(self):
         """


### PR DESCRIPTION
### Description

This PR adds support for a `before_request` hook that can be used in FAB's view and API classes to execute some code just before the route handler is invoked. It has the same semantics as Flask's `before_request`, but it is scoped only to the routes within a given FAB class and can be scoped even further to a subset of handlers within the class.

### Examples

```python
@before_request
def ensure_feature_is_enabled(self):
    if self.feature_is_disabled:
        return self.response_404()
    return None
```
```python
@before_request(only=["create", "update", "delete"])
def ensure_write_mode_enabled(self):
    if self.read_only:
        return self.response_400()
    return None
```

### Motivation

_It seems like we could implement the conditional logic directly in route handlers. Why do we need a new pattern?_

In many cases, implementing the conditional logic in the handler itself is preferred. To justify this change, consider the following scenario:

> You've implemented many classes that inherit from `ModelView` or `ModelRestAPI` and have relied on FAB to implement the endpoint logic for you. Some of these classes you only want enabled if some dynamic condition is true at _request time_ (e.g., feature flags, A/B testing). Since you have not implemented the handlers yourself, you have nowhere to put the conditional logic... that is, unless you manually override/implement each one.
>
>In other classes, you have a large number of endpoints that you have implemented. Some need to be gated by a condition. The `before_request` hook provides a way to DRY up your condition handling that is consistent with classes whose handlers are implemented by FAB.

While technically possible to workaround these issues, the hook provides an elegant pattern for developers that enables consistency across classes, a way to keep some endpoint logic DRY and decoupled from handlers, and prevents the need to override/implement FAB's automatic route handling in some cases.

### FAB Menus/Separators

_FAB supports constructing UI menu items and separators, which is registered with its view. If the `before_request` hook  in a view is able to dynamically enabled/disable a route, wouldn't we want the same for the menu item?_

I would imagine that in most (all?) cases, if a route was disabled the menu item should be unavailable too. However, I believe that exposing one pattern that handles both Flask endpoints/responses and UI component availability is hard to do elegantly.

Therefore, I propose treating the request handling and menu item separately. This PR implements the request piece, and a subsequent PR I plan to open will implement an option for executing a callable to determine if menu item is available.
