### PR TITLE
fix: Issue #1638 - replaced id_token by access_token for azure

### DIFF
--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -595,7 +595,7 @@ class BaseSecurityManager(AbstractSecurityManager):
         # active-directory-protocols-oauth-code
         if provider == "azure":
             log.debug("Azure response received : {0}".format(resp))
-            id_token = resp["id_token"]
+            id_token = resp["access_token"]
             log.debug(str(id_token))
             me = self._azure_jwt_token_parse(id_token)
             log.debug("Parse JWT token : {0}".format(me))

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -595,9 +595,9 @@ class BaseSecurityManager(AbstractSecurityManager):
         # active-directory-protocols-oauth-code
         if provider == "azure":
             log.debug("Azure response received : {0}".format(resp))
-            id_token = resp["access_token"]
-            log.debug(str(id_token))
-            me = self._azure_jwt_token_parse(id_token)
+            access_token = resp["access_token"]
+            log.debug(str(access_token))
+            me = self._azure_jwt_token_parse(access_token)
             log.debug("Parse JWT token : {0}".format(me))
             return {
                 "name": me.get("name", ""),

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -630,9 +630,9 @@ class BaseSecurityManager(AbstractSecurityManager):
         else:
             return {}
 
-    def _azure_parse_jwt(self, id_token):
+    def _azure_parse_jwt(self, access_token):
         jwt_token_parts = r"^([^\.\s]*)\.([^\.\s]+)\.([^\.\s]*)$"
-        matches = re.search(jwt_token_parts, id_token)
+        matches = re.search(jwt_token_parts, access_token)
         if not matches or len(matches.groups()) < 3:
             log.error("Unable to parse token.")
             return {}
@@ -642,8 +642,8 @@ class BaseSecurityManager(AbstractSecurityManager):
             "Sig": matches.group(3),
         }
 
-    def _azure_jwt_token_parse(self, id_token):
-        jwt_split_token = self._azure_parse_jwt(id_token)
+    def _azure_jwt_token_parse(self, access_token):
+        jwt_split_token = self._azure_parse_jwt(access_token)
         if not jwt_split_token:
             return
 
@@ -654,7 +654,7 @@ class BaseSecurityManager(AbstractSecurityManager):
         decoded_payload = base64.urlsafe_b64decode(payload_b64_string.encode("ascii"))
 
         if not decoded_payload:
-            log.error("Payload of id_token could not be base64 url decoded.")
+            log.error("Payload of access_token could not be base64 url decoded.")
             return
 
         jwt_decoded_payload = json.loads(decoded_payload.decode("utf-8"))


### PR DESCRIPTION
### Description

This fixes the issue descript in #1638 where the upn can't be located in id_token but actually is present in access_token.

### ADDITIONAL INFORMATION
- [x] Has associated issue: 1638
- [x] Is Auth, RBAC security related.
