### PR TITLE
fix: Missing `self` reference for my_custom

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -36,7 +36,7 @@ with a certain Model property::
         @renders('custom')
         def my_custom(self):
         # will render this columns as bold on ListWidget
-            return Markup('<b>' + custom + '</b>')
+            return Markup('<b>' + self.custom + '</b>')
 
 
 On your view reference your method as a column on list::

--- a/flask_appbuilder/models/decorators.py
+++ b/flask_appbuilder/models/decorators.py
@@ -11,7 +11,7 @@ def renders(col_name):
                 @renders('custom')
                 def my_custom(self):
                     # will render this columns as bold on ListWidget
-                    return Markup('<b>' + custom + '</b>')
+                    return Markup('<b>' + self.custom + '</b>')
 
             class MyModelView(ModelView):
                 datamodel = SQLAInterface(MyTable)


### PR DESCRIPTION


<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

* The code that describes the usage of the `@renders` decorator does not
  refer to `self` despite using a class variable. This commit fixes the
  problem.

Signed-off-by: mr.Shu <mr@shu.io>


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
