### PR TITLE
docs: fixing base route property name in rest_api.rst

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -43,7 +43,7 @@ So we can make a request to our method using::
 
     $ curl http://localhost:8080/api/v1/exampleapi/greeting
 
-To override the base route class blueprint, override the ``base_route`` property,
+To override the base route class blueprint, override the ``route_base`` property,
 so on our previous example::
 
     from flask_appbuilder.api import BaseApi, expose
@@ -52,7 +52,7 @@ so on our previous example::
 
     class ExampleApi(BaseApi):
 
-        base_route = '/newapi/v2/nice'
+        route_base = '/newapi/v2/nice'
 
         @expose('/greeting')
         def greeting(self):


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

The right name is `route_base` refer to [the source code](https://github.com/dpgaspar/Flask-AppBuilder/blob/master/flask_appbuilder/api/__init__.py#L224)

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
