### PR TITLE
feat: Add support for OAuth user info from Gitlab

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -225,7 +225,7 @@ This needs a small explanation, you basically have five special keys:
 
 :name: the name of the provider:
     you can choose whatever you want, but FAB has builtin logic in `BaseSecurityManager.get_oauth_user_info()` for:
-    'azure', 'github', 'google', 'linkedin', 'okta', 'openshift', 'twitter'
+    'azure', 'github', 'google', 'linkedin', 'okta', 'openshift', 'twitter', 'gitlab'
 
 :icon: the font-awesome icon for this provider
 

--- a/examples/oauth/config.py
+++ b/examples/oauth/config.py
@@ -69,6 +69,20 @@ OAUTH_PROVIDERS = [
         },
     },
     {
+        "name": "gitlab",
+        "icon": "fa-gitlab",
+        "token_key": "access_token",
+        "remote_app": {
+            "client_id": os.environ.get("GITLAB_APPLICATION_ID"),
+            "client_secret": os.environ.get("GITLAB_SECRET"),
+            "api_base_url": "https://www.gitlab.com/api/v4/",
+            "client_kwargs": {"scope": "read_user email profile"},
+            "request_token_url": None,
+            "access_token_url": "https://gitlab.com/oauth/token",
+            "authorize_url": "https://gitlab.com/oauth/authorize",
+        },
+    },
+    {
         "name": "azure",
         "icon": "fa-windows",
         "token_key": "access_token",

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -558,6 +558,15 @@ class BaseSecurityManager(AbstractSecurityManager):
             data = me.json()
             log.debug("User info from Github: {0}".format(data))
             return {"username": "github_" + data.get("login")}
+        # for Gitlab
+        if provider == "gitlab":
+            me = self.appbuilder.sm.oauth_remotes[provider].get("user")
+            data = me.json()
+            log.debug("User info from Gitlab: {0}".format(data))
+            return {
+                "username": "gitlab_" + data.get("username"),
+                "email": data.get("email"),
+            }
         # for twitter
         if provider == "twitter":
             me = self.appbuilder.sm.oauth_remotes[provider].get("account/settings.json")


### PR DESCRIPTION
### Description

Adds support for parsing user info from Gitlab `/user` endpoint (see https://docs.gitlab.com/ee/api/users.html#list-current-user-for-normal-users) in OAuth


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [x] Introduces new feature
- [ ] Removes existing feature
