### PR TITLE
chore: [Deprecation] Use Markup instead of HTMLString

### DIFF
--- a/flask_appbuilder/fieldwidgets.py
+++ b/flask_appbuilder/fieldwidgets.py
@@ -1,6 +1,7 @@
 from flask_babel import lazy_gettext as _
+from markupsafe import Markup
 from wtforms import widgets
-from wtforms.widgets import html_params, HTMLString
+from wtforms.widgets import html_params
 
 
 class DatePickerWidget(object):
@@ -24,7 +25,7 @@ class DatePickerWidget(object):
             field.data = ""
         template = self.data_template
 
-        return HTMLString(
+        return Markup(
             template % {"text": html_params(type="text", value=field.data, **kwargs)}
         )
 
@@ -50,7 +51,7 @@ class DateTimePickerWidget(object):
             field.data = ""
         template = self.data_template
 
-        return HTMLString(
+        return Markup(
             template % {"text": html_params(type="text", value=field.data, **kwargs)}
         )
 
@@ -103,7 +104,7 @@ class Select2AJAXWidget(object):
             field.data = ""
         template = self.data_template
 
-        return HTMLString(
+        return Markup(
             template % {"text": html_params(type="text", value=field.data, **kwargs)}
         )
 
@@ -132,7 +133,7 @@ class Select2SlaveAJAXWidget(object):
             field.data = ""
         template = self.data_template
 
-        return HTMLString(
+        return Markup(
             template % {"text": html_params(type="text", value=field.data, **kwargs)}
         )
 

--- a/flask_appbuilder/upload.py
+++ b/flask_appbuilder/upload.py
@@ -1,7 +1,8 @@
 from flask_babel import gettext
+from markupsafe import Markup
 from werkzeug.datastructures import FileStorage
 from wtforms import fields, ValidationError
-from wtforms.widgets import html_params, HTMLString
+from wtforms.widgets import html_params
 
 from .filemanager import FileManager, ImageManager
 
@@ -45,7 +46,7 @@ class BS3FileUploadFieldWidget(object):
 
         template = self.data_template if field.data else self.empty_template
 
-        return HTMLString(
+        return Markup(
             template
             % {
                 "text": html_params(type="text", value=field.data),
@@ -94,7 +95,7 @@ class BS3ImageUploadFieldWidget(object):
         else:
             template = self.empty_template
 
-        return HTMLString(template % args)
+        return Markup(template % args)
 
     def get_url(self, field):
         im = ImageManager()

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -6,6 +6,6 @@ cython==0.29.17
 mysqlclient==2.0.1
 psycopg2-binary==2.8.6
 pyodbc==4.0.30
-requests==2.25.0
+requests==2.26.0
 Authlib==0.15.4
 python-ldap==3.3.1


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

Bump up `requests` to 2.26.0
Move from HTMLString to Markup due deprecation warnings

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue:
> - https://github.com/dpgaspar/Flask-AppBuilder/issues/1721
> - https://github.com/dpgaspar/Flask-AppBuilder/issues/1692
