### PR TITLE
feat: Add groups to azure oauth2 provider role_keys

### DIFF
--- a/examples/oauth/config.py
+++ b/examples/oauth/config.py
@@ -77,7 +77,7 @@ OAUTH_PROVIDERS = [
             "client_secret": os.environ.get("AZURE_SECRET"),
             "api_base_url": "https://login.microsoftonline.com/{AZURE_TENANT_ID}/oauth2",
             "client_kwargs": {
-                "scope": "User.read name preferred_username email profile upn",
+                "scope": "User.read name preferred_username email profile upn groups openid",
                 "resource": os.environ.get("AZURE_APPLICATION_ID"),
             },
             "request_token_url": None,

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -616,6 +616,7 @@ class BaseSecurityManager(AbstractSecurityManager):
                 "last_name": me.get("family_name", ""),
                 "id": me["oid"],
                 "username": me["oid"],
+                "role_keys": me.get("groups", []),
             }
         # for OpenShift
         if provider == "openshift":


### PR DESCRIPTION

### Description

Add mapping from oauth groups to role_keys for azure.

It was only implemented for certain providers, like okta.

### ADDITIONAL INFORMATION

In order to export "groups", also need to add "openid".

The default in Azure is to use the Group IDs as keys.
