### PR TITLE
feat: Adding role_keys into Azure OAuth

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -231,7 +231,7 @@ This needs a small explanation, you basically have five special keys:
 
 You can give FlaskAppBuilder roles based on Oauth groups::
 
-    # note, this is only natively supported in `okta` currently,
+    # note, this is only natively supported in `azure` and `okta` currently,
     # however, if you customize userinfo retrieval to include 'role_keys', this will work for other providers
 
     # a mapping from the values of `userinfo["role_keys"]` to a list of FAB roles

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -616,7 +616,7 @@ class BaseSecurityManager(AbstractSecurityManager):
                 "last_name": me.get("family_name", ""),
                 "id": me["oid"],
                 "username": me["oid"],
-                "role_keys": data.get("groups", []),
+                "role_keys": data.get("roles", []),
             }
         # for OpenShift
         if provider == "openshift":

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -616,6 +616,7 @@ class BaseSecurityManager(AbstractSecurityManager):
                 "last_name": me.get("family_name", ""),
                 "id": me["oid"],
                 "username": me["oid"],
+                "role_keys": data.get("groups", []),
             }
         # for OpenShift
         if provider == "openshift":


### PR DESCRIPTION
### Description

AUTH_ROLES_MAPPING is not currently not support using the Azure provider.

This branch will mimicking what has been done for Okta and add the single line of code: "role_keys": data.get("groups", []) in the return dictionary for the provider Azure

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [x] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
