### PR TITLE
release: 3.4.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,20 @@
 Flask-AppBuilder ChangeLog
 ==========================
 
+Improvements and Bug fixes on 3.4.1
+-----------------------------------
+
+- feat: Adding role_keys into Azure OAuth (#1744) [Michael Yee]
+- docs: Fix small documentation issues (#1755) [Dosenpfand]
+- fix: 1154 Add LOGOUT_REDIRECT_URL setting (#1749) [blag]
+- fix: optional unauthorized status codes (#1753) [Daniel Vaz Gaspar]
+- docs: Fix indentation of function content (#1752) [akettmann-e24]
+- fix: optionally return HTTP 403 instead of 401 when unauthorized (#1748) [Daniel Vaz Gaspar]
+- chore: Redirect to prev url on login (#1747) [Geido]
+- docs: add aws cognito setup code examples (#1746) [Pin Jin]
+- fix: Added sr-only class to icon only links (#1727) [Thomas Stivers]
+- chore: [Deprecation] Use Markup instead of HTMLString (#1729) [Andrey Polegoshko]
+
 Improvements and Bug fixes on 3.4.0
 -----------------------------------
 

--- a/flask_appbuilder/__init__.py
+++ b/flask_appbuilder/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Daniel Vaz Gaspar"
-__version__ = "3.4.0"
+__version__ = "3.4.1"
 
 from .actions import action  # noqa: F401
 from .api import ModelRestApi  # noqa: F401


### PR DESCRIPTION
### Description

Release 3.4.1:

```
- feat: Adding role_keys into Azure OAuth (#1744) [Michael Yee]
- docs: Fix small documentation issues (#1755) [Dosenpfand]
- fix: 1154 Add LOGOUT_REDIRECT_URL setting (#1749) [blag]
- fix: optional unauthorized status codes (#1753) [Daniel Vaz Gaspar]
- docs: Fix indentation of function content (#1752) [akettmann-e24]
- fix: optionally return HTTP 403 instead of 401 when unauthorized (#1748) [Daniel Vaz Gaspar]
- chore: Redirect to prev url on login (#1747) [Geido]
- docs: add aws cognito setup code examples (#1746) [Pin Jin]
- fix: Added sr-only class to icon only links (#1727) [Thomas Stivers]
- chore: [Deprecation] Use Markup instead of HTMLString (#1729) [Andrey Polegoshko]
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
