### PR TITLE
chore: Use assertEqual instead of assertEquals for Python 3.11 compatibility

### DIFF
--- a/flask_appbuilder/tests/security/test_auth_ldap.py
+++ b/flask_appbuilder/tests/security/test_auth_ldap.py
@@ -77,7 +77,7 @@ class LDAPSearchTestCase(unittest.TestCase):
     def assertOnlyDefaultUsers(self):
         users = self.appbuilder.sm.get_all_users()
         user_names = [user.username for user in users]
-        self.assertEquals(user_names, [USERNAME_ADMIN, USERNAME_READONLY])
+        self.assertEqual(user_names, [USERNAME_ADMIN, USERNAME_READONLY])
 
     # ----------------
     # LDAP Directory
@@ -342,7 +342,7 @@ class LDAPSearchTestCase(unittest.TestCase):
         self.assertOnlyDefaultUsers()
 
         # validate - expected LDAP methods were called
-        self.assertEquals(self.ldapobj.methods_called(with_args=True), [])
+        self.assertEqual(self.ldapobj.methods_called(with_args=True), [])
 
     def test__inactive_user(self):
         """
@@ -376,7 +376,7 @@ class LDAPSearchTestCase(unittest.TestCase):
         self.assertIsNone(user)
 
         # validate - expected LDAP methods were called
-        self.assertEquals(self.ldapobj.methods_called(with_args=True), [])
+        self.assertEqual(self.ldapobj.methods_called(with_args=True), [])
 
     def test__multi_group_user_mapping_to_same_role(self):
         """

--- a/flask_appbuilder/tests/security/test_auth_oauth.py
+++ b/flask_appbuilder/tests/security/test_auth_oauth.py
@@ -51,7 +51,7 @@ class OAuthRegistrationRoleTestCase(unittest.TestCase):
     def assertOnlyDefaultUsers(self):
         users = self.appbuilder.sm.get_all_users()
         user_names = [user.username for user in users]
-        self.assertEquals(user_names, [USERNAME_ADMIN, USERNAME_READONLY])
+        self.assertEqual(user_names, [USERNAME_ADMIN, USERNAME_READONLY])
 
     # ----------------
     # Userinfo Objects

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -1324,7 +1324,7 @@ class APITestCase(FABTestCase):
         arguments = {"page_size": page_size, "page": 1}
         uri = f"api/v1/model1api/?{API_URI_RIS_KEY}={prison.dumps(arguments)}"
         rv = self.auth_client_get(client, token, uri)
-        self.assertEquals(rv.status_code, 200)
+        self.assertEqual(rv.status_code, 200)
 
     def test_get_list_max_page_size(self):
         """


### PR DESCRIPTION
### Description

The deprecated unittest aliases were removed in python/cpython#28268 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
