### PR TITLE
fix: Handle authorize_access_token exception

### DIFF
--- a/flask_appbuilder/security/views.py
+++ b/flask_appbuilder/security/views.py
@@ -656,7 +656,12 @@ class AuthOAuthView(AuthView):
             flash(u"Provider not supported.", "warning")
             log.warning("OAuth authorized got an unknown provider %s", provider)
             return redirect(self.appbuilder.get_url_for_login)
-        resp = self.appbuilder.sm.oauth_remotes[provider].authorize_access_token()
+        try:
+            resp = self.appbuilder.sm.oauth_remotes[provider].authorize_access_token()
+        except Exception as e:
+            log.error("Error authorizing OAuth access token: {0}".format(e))
+            flash(u"The request to sign in was denied.", "error")
+            return redirect(self.appbuilder.get_url_for_login)
         if resp is None:
             flash(u"You denied the request to sign in.", "warning")
             return redirect(self.appbuilder.get_url_for_login)


### PR DESCRIPTION
### Description

Currently the call to `authorize_access_token` in `oauth_authorized` is not wrapped in exception handling. As a result when an error occurs in the OAuth flow, a 500 response is generated and the user sees an error page. This may lead to a bad user experience, because the user is not able to fix the problem in any way on their own.

This PR adds an error handling, so that any error will be caught and the user is redirected to the login page with the appropriate flash error message.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [x] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
