### PR TITLE
fix: openapi on and off config flag

### DIFF
--- a/examples/crud_rest_api/app/api.py
+++ b/examples/crud_rest_api/app/api.py
@@ -6,6 +6,7 @@ from sqlalchemy import or_
 
 from . import appbuilder, db
 from .models import Contact, ContactGroup, Gender, ModelOMParent
+from marshmallow import fields, Schema
 
 
 def fill_gender():
@@ -22,8 +23,14 @@ db.create_all()
 fill_gender()
 
 
+class GreetingsResponseSchema(Schema):
+    message = fields.String()
+
+
 class GreetingApi(BaseApi):
     resource_name = "greeting"
+    openapi_spec_component_schemas = (GreetingsResponseSchema,)
+
     openapi_spec_methods = {
         "greeting": {
             "get": {
@@ -44,9 +51,7 @@ class GreetingApi(BaseApi):
                 application/json:
                   schema:
                     type: object
-                    properties:
-                      message:
-                        type: string
+                    $ref: '#/components/schemas/GreetingsResponseSchema'
         """
         return self.response(200, message="Hello")
 

--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -3,7 +3,7 @@ import json
 import logging
 import re
 import traceback
-from typing import Callable, Dict, List, Optional, Set
+from typing import Callable, Dict, List, Optional, Set, Tuple, Type
 import urllib.parse
 
 from apispec import APISpec, yaml_utils
@@ -294,6 +294,22 @@ class BaseApi(object):
     """
     _apispec_parameter_schemas = None
 
+    openapi_spec_component_schemas: Tuple[Type[Schema], ...] = tuple()
+    """
+    A Tuple containing marshmallow schemas to be registered on the OpenAPI spec
+    has component schemas, these can be referenced by the endpoint's spec like:
+    `$ref: '#/components/schemas/MyCustomSchema'` Where MyCustomSchema is the
+    marshmallow schema class name.
+
+    To set your own OpenAPI schema component name, declare your schemas with:
+    __component_name__
+
+    class Schema1(Schema):
+        __component_name__ = "MyCustomSchema"
+        id = fields.Integer()
+        ...
+
+    """
     responses = {
         "400": {
             "description": "Bad request",
@@ -425,6 +441,8 @@ class BaseApi(object):
         self.apispec_parameter_schemas = self.apispec_parameter_schemas or dict()
         self._apispec_parameter_schemas = self._apispec_parameter_schemas or dict()
         self._apispec_parameter_schemas.update(self.apispec_parameter_schemas)
+        if self.openapi_spec_component_schemas is None:
+            self.openapi_spec_component_schemas = ()
 
         # Init class permission override attrs
         if not self.previous_class_permission_name and self.class_permission_name:
@@ -521,6 +539,17 @@ class BaseApi(object):
                 api_spec.components.schema(k, v)
             except DuplicateComponentNameError:
                 pass
+        for schema in self.openapi_spec_component_schemas:
+            try:
+                if hasattr(schema, "__component_name__"):
+                    component_name = schema.__component_name__
+                elif isinstance(schema, type):
+                    component_name = schema.__name__
+                else:
+                    component_name = schema.__class__.__name__
+                api_spec.components.schema(component_name, schema=schema)
+            except DuplicateComponentNameError:
+                pass
 
     def _register_urls(self) -> None:
         before_request_hooks = get_before_request_hooks(self)
@@ -569,7 +598,7 @@ class BaseApi(object):
     ):
         """May mutate operations.
         :param str path: Path to the resource
-        :param dict operations: A `dict` mapping HTTP methods to operation object. See
+        :param dict operations: A `dict` mapping HTTP methods to operation object.
         :param list methods: A list of methods registered for this path
         """
         for method in methods:

--- a/flask_appbuilder/api/manager.py
+++ b/flask_appbuilder/api/manager.py
@@ -95,7 +95,7 @@ class SwaggerView(BaseView):
 
 class OpenApiManager(BaseManager):
     def register_views(self):
-        if not self.appbuilder.app.config.get("FAB_ADD_SECURITY_VIEWS", True):
+        if not self.appbuilder.app.config.get("FAB_ADD_OPENAPI_VIEWS", True):
             return
         if self.appbuilder.get_app.config.get("FAB_API_SWAGGER_UI", False):
             self.appbuilder.add_api(OpenApi)

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -143,7 +143,7 @@ class APIDisableOpenApiViewTestCase(FABTestCase):
 
     def test_disabled_security_views(self):
         """
-        REST Api: Test disabled security views
+        REST Api: Test disabled OpenApi views
         """
         for rule in self.appbuilder.get_app.url_map.iter_rules():
             self.assertNotIn(rule.endpoint, self.openapi_fab_endpoint)

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -103,7 +103,7 @@ class APIDisableSecViewTestCase(FABTestCase):
         "LocaleView.index",
         "UtilView.back",
         "MenuApi.get_menu_data",
-        "OpenApi.get"
+        "OpenApi.get",
     ]
 
     def setUp(self):

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -104,6 +104,7 @@ class APIDisableSecViewTestCase(FABTestCase):
         "UtilView.back",
         "MenuApi.get_menu_data",
         "OpenApi.get",
+        "SwaggerView.show",
     ]
 
     def setUp(self):
@@ -123,6 +124,29 @@ class APIDisableSecViewTestCase(FABTestCase):
         """
         for rule in self.appbuilder.get_app.url_map.iter_rules():
             self.assertIn(rule.endpoint, self.base_fab_endpoint)
+
+
+class APIDisableOpenApiViewTestCase(FABTestCase):
+
+    openapi_fab_endpoint = ["OpenApi.get", "SwaggerView.show"]
+
+    def setUp(self):
+        from flask import Flask
+        from flask_appbuilder import AppBuilder
+
+        self.app = Flask(__name__)
+        self.app.config.from_object("flask_appbuilder.tests.config_api")
+        self.app.config["FAB_ADD_OPENAPI_VIEWS"] = False
+
+        self.db = SQLA(self.app)
+        self.appbuilder = AppBuilder(self.app, self.db.session)
+
+    def test_disabled_security_views(self):
+        """
+        REST Api: Test disabled security views
+        """
+        for rule in self.appbuilder.get_app.url_map.iter_rules():
+            self.assertNotIn(rule.endpoint, self.openapi_fab_endpoint)
 
 
 class APITestCase(FABTestCase):

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -103,6 +103,7 @@ class APIDisableSecViewTestCase(FABTestCase):
         "LocaleView.index",
         "UtilView.back",
         "MenuApi.get_menu_data",
+        "OpenApi.get"
     ]
 
     def setUp(self):
@@ -118,7 +119,7 @@ class APIDisableSecViewTestCase(FABTestCase):
 
     def test_disabled_security_views(self):
         """
-            REST Api: Test disabled security views
+        REST Api: Test disabled security views
         """
         for rule in self.appbuilder.get_app.url_map.iter_rules():
             self.assertIn(rule.endpoint, self.base_fab_endpoint)


### PR DESCRIPTION
### Description

The `FAB_ADD_OPENAPI_VIEWS` was not being evaluated anywhere on the code. The reference was to `FAB_ADD_SECURITY_VIEWS`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
