### PR TITLE
fix: required roles on user form not showing error msg

### DIFF
--- a/flask_appbuilder/fieldwidgets.py
+++ b/flask_appbuilder/fieldwidgets.py
@@ -144,7 +144,7 @@ class Select2Widget(widgets.Select):
     def __init__(self, extra_classes=None, style=None):
         self.extra_classes = extra_classes
         self.style = style or u"width:250px"
-        return super(Select2Widget, self).__init__()
+        super(Select2Widget, self).__init__()
 
     def __call__(self, field, **kwargs):
         kwargs["class"] = u"my_select2 form-control"
@@ -163,7 +163,7 @@ class Select2ManyWidget(widgets.Select):
     def __init__(self, extra_classes=None, style=None):
         self.extra_classes = extra_classes
         self.style = style or u"width:250px"
-        return super(Select2ManyWidget, self).__init__()
+        super(Select2ManyWidget, self).__init__()
 
     def __call__(self, field, **kwargs):
         kwargs["class"] = u"my_select2 form-control"

--- a/flask_appbuilder/security/forms.py
+++ b/flask_appbuilder/security/forms.py
@@ -8,6 +8,19 @@ from ..forms import DynamicForm
 from ..validators import PasswordComplexityValidator
 
 
+class SelectDataRequired(DataRequired):
+    """
+    Select required flag on the input field will not work well on Chrome
+    Console error:
+        An invalid form control with name='roles' is not focusable.
+
+    This makes a simple override to the DataRequired to be used specifically with
+    select fields
+    """
+
+    field_flags = ()
+
+
 class LoginForm_oid(DynamicForm):
     openid = StringField(lazy_gettext("OpenID"), validators=[DataRequired()])
     username = StringField(lazy_gettext("User Name"))

--- a/flask_appbuilder/security/views.py
+++ b/flask_appbuilder/security/views.py
@@ -19,6 +19,7 @@ from .forms import (
     LoginForm_db,
     LoginForm_oid,
     ResetPasswordForm,
+    SelectDataRequired,
     UserInfoEdit,
 )
 from .._compat import as_unicode
@@ -328,7 +329,7 @@ class UserDBModelView(UserModelView):
         "conf_password",
     ]
 
-    validators_columns = {"roles": [validators.DataRequired()]}
+    validators_columns = {"roles": [SelectDataRequired()]}
 
     @expose("/show/<pk>", methods=["GET"])
     @has_access


### PR DESCRIPTION
### Description

Small fix for https://github.com/dpgaspar/Flask-AppBuilder/pull/1758, where the error message (shown by the browser) is not show to the user, not adding a new user without any information.

The console log shows: 
```
An invalid form control with name='roles' is not focusable.
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
