### PR TITLE
fix: make servers be actual servers on swagger, full endpoint paths

### DIFF
--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -491,9 +491,7 @@ class BaseApi(object):
         self.resource_name = self.resource_name or self.__class__.__name__.lower()
 
         if self.route_base is None:
-            self.route_base = "/api/{}/{}".format(
-                self.version, self.resource_name.lower()
-            )
+            self.route_base = f"/api/{self.version}/{self.resource_name.lower()}"
         self.blueprint = Blueprint(self.endpoint, __name__, url_prefix=self.route_base)
         # Exempt API from CSRF protect
         if self.csrf_exempt:
@@ -591,7 +589,7 @@ class BaseApi(object):
         """
         RE_URL = re.compile(r"<(?:[^:<>]+:)?([^<>]+)>")
         path = RE_URL.sub(r"{\1}", path)
-        return f"/{self.resource_name}{path}"
+        return f"{self.route_base}{path}"
 
     def operation_helper(
         self, path=None, operations=None, methods=None, func=None, **kwargs

--- a/flask_appbuilder/api/manager.py
+++ b/flask_appbuilder/api/manager.py
@@ -1,7 +1,7 @@
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
 from apispec.ext.marshmallow.common import resolve_schema_cls
-from flask import current_app
+from flask import current_app, request
 from flask_appbuilder.api import BaseApi
 from flask_appbuilder.api import expose, protect, safe
 from flask_appbuilder.basemanager import BaseManager
@@ -66,13 +66,16 @@ class OpenApi(BaseApi):
 
     @staticmethod
     def _create_api_spec(version):
+        servers = current_app.config.get(
+            "FAB_OPENAPI_SERVERS", [{"url": request.host_url}]
+        )
         return APISpec(
             title=current_app.appbuilder.app_name,
             version=version,
             openapi_version="3.0.2",
             info=dict(description=current_app.appbuilder.app_name),
             plugins=[MarshmallowPlugin(schema_name_resolver=resolver)],
-            servers=[{"url": "/api/{}".format(version)}],
+            servers=servers,
         )
 
 

--- a/flask_appbuilder/templates/appbuilder/swagger/swagger.html
+++ b/flask_appbuilder/templates/appbuilder/swagger/swagger.html
@@ -2,14 +2,14 @@
 
 {% block head_css %}
 {{ super() }}
-<link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui.css">
+<link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4/swagger-ui.css">
 <link rel="shortcut icon" href="https://fastapi.tiangolo.com/img/favicon.png">
 {% endblock %}
 
 {% block content %}
 <div id="swagger-ui">
 </div>
-<script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4/swagger-ui-bundle.js"></script>
 <!-- `SwaggerUIBundle` is now available on the page -->
 <script>
 


### PR DESCRIPTION
### Description

Fix swagger servers to be actual servers that can be overridden by setting `FAB_OPENAPI_SERVERS`.
This change will make all endpoints on swagger be declared by their full relative path instead of just using `resource_name`.
 
Before:
<img width="1177" alt="Screenshot 2022-01-06 at 17 18 02" src="https://user-images.githubusercontent.com/4025227/148423396-9b38fdf1-aca4-4ada-8e38-728038b09ae2.png">

After:
<img width="1169" alt="Screenshot 2022-01-06 at 17 18 40" src="https://user-images.githubusercontent.com/4025227/148423473-7317f1cf-8090-45c4-b2f2-80fb1367c127.png">

REST API that use `route_base` will now work!

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
