### PR TITLE
fix: Only update user.last_login on successful authentication

### DIFF
--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -820,12 +820,17 @@ class BaseSecurityManager(AbstractSecurityManager):
 
     def update_user_auth_stat(self, user, success=True):
         """
-        Update authentication successful to user.
+        Update user authentication stats upon successful/unsuccessful
+        authentication attempts.
 
         :param user:
-            The authenticated user model
+            The identified (but possibly not successfully authenticated) user
+            model
         :param success:
-            Default to true, if false increments fail_login_count on user model
+        :type success: bool or None
+            Defaults to true, if true increments login_count, updates
+            last_login, and resets fail_login_count to 0, if false increments
+            fail_login_count on user model.
         """
         if not user.login_count:
             user.login_count = 0

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -833,10 +833,10 @@ class BaseSecurityManager(AbstractSecurityManager):
             user.fail_login_count = 0
         if success:
             user.login_count += 1
+            user.last_login = datetime.datetime.now()
             user.fail_login_count = 0
         else:
             user.fail_login_count += 1
-        user.last_login = datetime.datetime.now()
         self.update_user(user)
 
     def auth_user_db(self, username, password):

--- a/flask_appbuilder/tests/security/test_base_security_manager.py
+++ b/flask_appbuilder/tests/security/test_base_security_manager.py
@@ -1,0 +1,69 @@
+import datetime
+import unittest
+from unittest.mock import MagicMock, patch
+
+from flask_appbuilder.security.manager import BaseSecurityManager
+
+
+@patch.object(BaseSecurityManager, "update_user")
+@patch.object(BaseSecurityManager, "__init__", return_value=None)
+class BaseSecurityManagerUpdateUserAuthStatTestCase(unittest.TestCase):
+    def test_first_successful_auth(self, mock1, mock2):
+        bsm = BaseSecurityManager()
+
+        user_mock = MagicMock()
+        user_mock.login_count = None
+        user_mock.fail_login_count = None
+        user_mock.last_login = None
+
+        bsm.update_user_auth_stat(user_mock, success=True)
+
+        self.assertEqual(user_mock.login_count, 1)
+        self.assertEqual(user_mock.fail_login_count, 0)
+        self.assertEqual(type(user_mock.last_login), datetime.datetime)
+        self.assertTrue(bsm.update_user.called_once)
+
+    def test_first_unsuccessful_auth(self, mock1, mock2):
+        bsm = BaseSecurityManager()
+
+        user_mock = MagicMock()
+        user_mock.login_count = None
+        user_mock.fail_login_count = None
+        user_mock.last_login = None
+
+        bsm.update_user_auth_stat(user_mock, success=False)
+
+        self.assertEqual(user_mock.login_count, 0)
+        self.assertEqual(user_mock.fail_login_count, 1)
+        self.assertEqual(user_mock.last_login, None)
+        self.assertTrue(bsm.update_user.called_once)
+
+    def test_subsequent_successful_auth(self, mock1, mock2):
+        bsm = BaseSecurityManager()
+
+        user_mock = MagicMock()
+        user_mock.login_count = 5
+        user_mock.fail_login_count = 9
+        user_mock.last_login = None
+
+        bsm.update_user_auth_stat(user_mock, success=True)
+
+        self.assertEqual(user_mock.login_count, 6)
+        self.assertEqual(user_mock.fail_login_count, 0)
+        self.assertEqual(type(user_mock.last_login), datetime.datetime)
+        self.assertTrue(bsm.update_user.called_once)
+
+    def test_subsequent_unsuccessful_auth(self, mock1, mock2):
+        bsm = BaseSecurityManager()
+
+        user_mock = MagicMock()
+        user_mock.login_count = 5
+        user_mock.fail_login_count = 9
+        user_mock.last_login = None
+
+        bsm.update_user_auth_stat(user_mock, success=False)
+
+        self.assertEqual(user_mock.login_count, 5)
+        self.assertEqual(user_mock.fail_login_count, 10)
+        self.assertEqual(user_mock.last_login, None)
+        self.assertTrue(bsm.update_user.called_once)


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

<!--- Describe the change below, including rationale and design decisions -->

This PR moves one line around so the `user.last_login` field is only updated when the user has successfully authenticated.

Without this PR the `user.last_login` field is not very useful, as an attacker trying to brute force a login would continuously update the `last_login` field to the datetime of the latest _unsuccessful_ authentication attempt, instead of the datetime of the last successful authentication attempt. I believe that "login" usually refers to a successful authentication attempt, so this keeps the behavior of the code consistent with the semantics of the field name.

I don't have a thorough understanding of what all `user.last_login` could be/is used for, but I can imagine that, when it records the last datetime of successful authentication attempt, it can be combined with `user.fail_login_count` to generate an average "brute force rate" for each user between successful logins. Without this PR, it is impossible to collect that data because the `user.last_login` will almost always be set to the datetime of the latest brute force attempt.

I have expanded the docstring to have a more thorough description of the method, and I have added tests for each line and branch of the `BaseSecurityManager.update_user_auth_stat` method so it is now completely covered by tests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [x] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
