### PR TITLE
docs: adds missing config key FAB_OPENAPI_SERVERS

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -277,6 +277,10 @@ Use config.py to configure the following parameters. By default it will use SQLL
 | FAB_ADD_OPENAPI_VIEWS                  | Enables or disables registering all        |           |
 |                                        | OPENAPI views (boolean default:True)       |   No      |
 +----------------------------------------+--------------------------------------------+-----------+
+| FAB_OPENAPI_SERVERS                    | Used for setting OpenApi Swagger UI        |           |
+|                                        | servers if not set Swagger will use the    |           |
+|                                        | current request host URL                   |   No      |
++----------------------------------------+--------------------------------------------+-----------+
 | FAB_ROLES                              | Configure builtin roles see Security       |           |
 |                                        | chapter for further detail                 |   No      |
 +----------------------------------------+--------------------------------------------+-----------+


### PR DESCRIPTION
### Description

Adds a missing doc key `FAB_OPENAPI_SERVERS`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
