### PR TITLE
feat: SQLAlchemy 1.4 support

### DIFF
--- a/flask_appbuilder/cli.py
+++ b/flask_appbuilder/cli.py
@@ -142,7 +142,7 @@ def create_db():
     """
     from flask_appbuilder.models.sqla import Model
 
-    engine = current_app.appbuilder.get_session.get_bind(mapper=None, clause=None)
+    engine = current_app.appbuilder.get_session.get_bind()
     Model.metadata.create_all(engine)
     click.echo(click.style("DB objects created", fg="green"))
 

--- a/flask_appbuilder/console.py
+++ b/flask_appbuilder/console.py
@@ -197,7 +197,7 @@ def create_db(app, appbuilder):
     from flask_appbuilder.models.sqla import Base
 
     _appbuilder = import_application(app, appbuilder)
-    engine = _appbuilder.get_session.get_bind(mapper=None, clause=None)
+    engine = _appbuilder.get_session.get_bind()
     Base.metadata.create_all(engine)
     click.echo(click.style("DB objects created", fg="green"))
 

--- a/flask_appbuilder/security/sqla/manager.py
+++ b/flask_appbuilder/security/sqla/manager.py
@@ -88,7 +88,7 @@ class SecurityManager(BaseSecurityManager):
 
     def create_db(self):
         try:
-            engine = self.get_session.get_bind(mapper=None, clause=None)
+            engine = self.get_session.get_bind()
             inspector = Inspector.from_engine(engine)
             if "ab_user" not in inspector.get_table_names():
                 log.info(c.LOGMSG_INF_SEC_NO_DB)

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -450,7 +450,7 @@ class APITestCase(FABTestCase):
 
     def tearDown(self):
         self.appbuilder.get_session.close()
-        engine = self.db.session.get_bind(mapper=None, clause=None)
+        engine = self.db.session.get_bind()
         engine.dispose()
 
     def test_babel(self):

--- a/flask_appbuilder/tests/test_mvc.py
+++ b/flask_appbuilder/tests/test_mvc.py
@@ -654,7 +654,7 @@ class MVCTestCase(BaseMVCTestCase):
         """
         from sqlalchemy.engine.reflection import Inspector
 
-        engine = self.db.session.get_bind(mapper=None, clause=None)
+        engine = self.db.session.get_bind()
         inspector = Inspector.from_engine(engine)
         # Check if tables exist
         self.assertIn("model1", inspector.get_table_names())

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 apispec[yaml]==3.3.2
     # via Flask-AppBuilder (setup.py)
-attrs==21.2.0
+attrs==21.4.0
     # via jsonschema
 babel==2.9.1
     # via flask-babel
@@ -43,10 +43,14 @@ flask-sqlalchemy==2.5.1
     # via Flask-AppBuilder (setup.py)
 flask-wtf==0.14.3
     # via Flask-AppBuilder (setup.py)
-idna==3.2
+greenlet==1.1.2
+    # via sqlalchemy
+idna==3.3
     # via email-validator
-importlib-metadata==4.8.1
-    # via jsonschema
+importlib-metadata==4.10.0
+    # via
+    #   jsonschema
+    #   sqlalchemy
 itsdangerous==1.1.0
     # via
     #   flask
@@ -61,7 +65,7 @@ markupsafe==2.0.1
     # via
     #   jinja2
     #   wtforms
-marshmallow==3.13.0
+marshmallow==3.14.1
     # via
     #   Flask-AppBuilder (setup.py)
     #   marshmallow-enum
@@ -82,11 +86,11 @@ python-dateutil==2.8.2
     # via Flask-AppBuilder (setup.py)
 python3-openid==3.2.0
     # via flask-openid
-pytz==2021.1
+pytz==2021.3
     # via
     #   babel
     #   flask-babel
-pyyaml==5.4.1
+pyyaml==6.0
     # via apispec
 six==1.16.0
     # via
@@ -95,15 +99,14 @@ six==1.16.0
     #   prison
     #   python-dateutil
     #   sqlalchemy-utils
-sqlalchemy==1.3.24
+sqlalchemy==1.4.29
     # via
-    #   Flask-AppBuilder (setup.py)
     #   flask-sqlalchemy
     #   marshmallow-sqlalchemy
     #   sqlalchemy-utils
-sqlalchemy-utils==0.37.8
+sqlalchemy-utils==0.38.2
     # via Flask-AppBuilder (setup.py)
-typing-extensions==3.10.0.2
+typing-extensions==4.0.1
     # via importlib-metadata
 werkzeug==1.0.1
     # via
@@ -113,7 +116,7 @@ wtforms==2.3.3
     # via
     #   Flask-AppBuilder (setup.py)
     #   flask-wtf
-zipp==3.5.0
+zipp==3.7.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,6 @@ setup(
         "Flask-Babel>=1, <3",
         "Flask-Login>=0.3, <0.5",
         "Flask-OpenID>=1.2.5, <2",
-        # SQLAlchemy 1.4.0 breaks flask-sqlalchemy and sqlalchemy-utils
-        "SQLAlchemy<1.4.0",
         "Flask-SQLAlchemy>=2.4, <3",
         "Flask-WTF>=0.14.2, <0.15.0",
         "Flask-JWT-Extended>=3.18, <4",


### PR DESCRIPTION
### Description

An alternative way to fix #1710. Flask-SQLAlchemy 2 broke the `clause=None` parameter, but since `mapper=None, clause=None` is simply the default since SQLAlchemy 0.7.2 (released more than ten years ago), we can simply fix the problem by not passing those parameters at all.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #1710
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
