### PR TITLE
docs: Update doc i18 to flask_babel

### DIFF
--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -22,8 +22,7 @@ F.A.B. has support for 14 languages (planning for some more):
 
 This means that all messages, builtin on the framework are translated to these languages.
 
-You can add your own translations for your application, using Flask-BabelPkg, this is a fork from Flask-Babel,
-created because it was not possible to separate package translations from the application translations.
+You can add your own translations for your application, using Flask-Babel.
 
 You can add your own translations, and your own language support.
 Take a look at `Flask-Babel <http://pythonhosted.org/Flask-Babel>`_ for setup an babel initial configuration.
@@ -62,7 +61,7 @@ so you want to add translations for the menus "List Groups" and "List Contacts".
 
 ::
 
-    from flask.ext.babelpkg import lazy_gettext as _
+    from flask_babel import lazy_gettext as _
 
     class GroupModelView(ModelView):
         datamodel = SQLAInterface(ContactGroup)
@@ -128,5 +127,5 @@ If you want to, or if you're using a version prior to 1.3.0 you can use::
            'pt': {'flag':'pt', 'name':'Portuguese'}
         }
 
-And thats it!
+And that's it!
 

--- a/docs/versionmigration.rst
+++ b/docs/versionmigration.rst
@@ -11,7 +11,7 @@ One:
 
 There was a security issue when using the default builtin information getter for the providers
 (see github: Prevent masquerade attacks through oauth providers #472)
-This fix will prepend the provider to the user id. So you're usernames will look like 'google_<USER_ID>'
+This fix will prepend the provider to the user id. So your usernames will look like 'google_<USER_ID>'
 
 Two:
 
@@ -58,7 +58,7 @@ Migrating to 1.8.0
 ------------------
 
 On this release flask-appbuilder supports python 3.5, and returned to flask-babel original package
-(stopped using the fork flask-babelpkg for multiple tranlation directories).
+(stopped using the fork flask-babelpkg for multiple translation directories).
 
 You can and should, uninstall flask-babelpkg from your package list and change all your imports from::
 
@@ -147,7 +147,7 @@ to::
 Migrating from 1.1.X to 1.2.X
 ------------------------------
 
-There is a breaking feature, change your filters import like this:
+There is a breaking feature, change your filters imports like this:
 
 from::
 
@@ -307,7 +307,7 @@ This new version has some breaking features. You don't have to change any code, 
 Migrating from 0.5.X to 0.6.X
 -----------------------------
 
-This new version has some breaking features, that i hope will be easily changeable on your code.
+This new version has some breaking features, that I hope will be easily changeable on your code.
 
 If you feel lost please post an issue on github: https://github.com/dpgaspar/Flask-AppBuilder/issues?state=open
 
@@ -390,6 +390,6 @@ To this::
 	baseapp.add_view(PersonGeneralView(), "List Contacts","/persons/list","earphone","Contacts")
 	baseapp.add_view(PersonChartView(), "Contacts Chart","/persons/chart","earphone","Contacts")
 
-Small change you just have to instantiate your classes.
+Small change, you just have to instantiate your classes.
 
 


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description
The doc in master regarding i18 still reference the not used anymore by `flask_appbuilder` fork `flask_babelpkg` for multiple translations.
This PR fixes that by:
- Updating the i18 doc from references to flask_bablepkg fork as is not used anymore as stated in the version migration
- minor typos encountered along the way of updating i18 doc from `flask_bablepkg` to `flask_babel`

