### PR TITLE
test: Add test for `export-roles --indent`'s argument “duck casting” to int

### DIFF
--- a/flask_appbuilder/cli.py
+++ b/flask_appbuilder/cli.py
@@ -28,6 +28,21 @@ def echo_header(title):
     click.echo(click.style("-" * len(title), fg="green"))
 
 
+def cast_int_like_to_int(cli_arg: Union[None, str, int]) -> Union[None, str, int]:
+    """Cast int-like objects to int if possible
+
+    If the arg cannot be cast to an integer, return the unmodified object instead."""
+    try:
+        cli_arg_int = int(cli_arg)
+        return cli_arg_int
+    except TypeError:
+        # Don't cast if None
+        return cli_arg
+    except ValueError:
+        # Don't cast non-int-like strings
+        return cli_arg
+
+
 @click.group()
 def fab():
     """ FAB flask group commands"""
@@ -155,17 +170,9 @@ def export_roles(
     path: Optional[str] = None, indent: Optional[Union[int, str]] = None
 ) -> None:
     """Exports roles with permissions and view menus to JSON file"""
-    # Cast negative numbers to int (as they're passed as str from CLI)
-    try:
-        indent = int(indent)
-    except TypeError:
-        # Don't cast None
-        pass
-    except ValueError:
-        # Don't cast non-int-like strings
-        pass
-
-    current_app.appbuilder.sm.export_roles(path=path, indent=indent)
+    # Cast negative numbers to int (as they are passed as str from CLI)
+    cast_indent = cast_int_like_to_int(indent)
+    current_app.appbuilder.sm.export_roles(path=path, indent=cast_indent)
 
 
 @fab.command("import-roles")

--- a/flask_appbuilder/tests/test_fab_cli.py
+++ b/flask_appbuilder/tests/test_fab_cli.py
@@ -17,6 +17,7 @@ from flask_appbuilder.cli import (
     list_users,
     list_views,
     reset_password,
+    cast_int_like_to_int,
 )
 
 from .base import FABTestCase
@@ -78,6 +79,22 @@ class FlaskTestCase(FABTestCase):
             result = runner.invoke(list_views, [])
             self.assertIn("List of registered views", result.output)
             self.assertIn(" Route:/api/v1/security", result.output)
+
+    def test_cast_int_like_to_int(self):
+        scenarii = {
+            -1: -1,
+            0: 0,
+            1: 1,
+            "-1": -1,
+            "0": 0,
+            "1": 1,
+            "+1": 1,
+            "foo": "foo",
+            None: None,
+        }
+
+        for input, expected_output in scenarii.items():
+            self.assertEqual(cast_int_like_to_int(input), expected_output)
 
 
 class SQLAlchemyImportExportTestCase(FABTestCase):


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

#1724 introduced the `--indent` argument to `fab export-roles`. This (optional) argument accepts `int` and `str` args — and notably *negative* integers.

However, `fab export-roles --indent=-1` would naturally return `-1`… as a `str`, and not a negative `int`. That's why we [“duck cast” the arg](https://github.com/EBoisseauSierra/Flask-AppBuilder/blob/ba7da50cb40aa41c07b7642494ff18ce0e390eb6/flask_appbuilder/cli.py#L159-L166) to an integer… if possible.

This piece of logic remained however untested. So for the sake of the exercise, this PR:

* extracts the duck casting logic into an ad hoc method,
* create tests for this method.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
