### PR TITLE
fix: noop user update on Auth db, use set user model

### DIFF
--- a/flask_appbuilder/security/sqla/manager.py
+++ b/flask_appbuilder/security/sqla/manager.py
@@ -255,7 +255,7 @@ class SecurityManager(BaseSecurityManager):
 
     def noop_user_update(self, user: "User") -> None:
         stmt = (
-            update(User)
+            update(self.user_model)
             .where(self.user_model.id == user.id)
             .values(login_count=user.login_count)
         )


### PR DESCRIPTION
### Description

Noop on auth db fake update user is explicitly using the `User` model instead of `self.user_model` this causes issues with custom User models

### ADDITIONAL INFORMATION
- [ ] Has associated issue: #1822 
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
