### PR TITLE
docs: add FAB_ADD_SECURITY_API config option

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -261,6 +261,8 @@ Use config.py to configure the following parameters. By default it will use SQLL
 |                                        | roles, permissions, view_menus.            |   No      |
 |                                        | Further details on /swagger/v1             |           |
 |                                        | All endpoints are under /api/v1/sercurity/ |           |
+|                                        | [Note]: This feature is still in beta      |           |
+|                                        | breaking changes are likely to occur       |           |
 +----------------------------------------+--------------------------------------------+-----------+
 | FAB_ADD_SECURITY_VIEWS                 | Enables or disables registering all        |           |
 |                                        | security views (boolean default:True)      |   No      |

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -257,6 +257,11 @@ Use config.py to configure the following parameters. By default it will use SQLL
 | FAB_SECURITY_MANAGER_CLASS             | Declare a new custom SecurityManager       |           |
 |                                        | class                                      |   No      |
 +----------------------------------------+--------------------------------------------+-----------+
+| FAB_ADD_SECURITY_API                   | [Beta] Adds a CRUD REST API for users,     |           |
+|                                        | roles, permissions, view_menus.            |   No      |
+|                                        | Further details on /swagger/v1             |           |
+|                                        | All endpoints are under /api/v1/sercurity/ |           |
++----------------------------------------+--------------------------------------------+-----------+
 | FAB_ADD_SECURITY_VIEWS                 | Enables or disables registering all        |           |
 |                                        | security views (boolean default:True)      |   No      |
 +----------------------------------------+--------------------------------------------+-----------+


### PR DESCRIPTION
### Description

Add `FAB_ADD_SECURITY_API` config option to the docs, for the new CRUD REST API for the security models, still on Beta phase.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
