### PR TITLE
fix: custom security class import, bad cast

### DIFF
--- a/flask_appbuilder/base.py
+++ b/flask_appbuilder/base.py
@@ -196,7 +196,7 @@ class AppBuilder:
         if _security_manager_class_name is not None:
             security_manager_class = dynamic_class_import(_security_manager_class_name)
             self.security_manager_class = cast(
-                Type[BaseSecurityManager], security_manager_class
+                Type["BaseSecurityManager"], security_manager_class
             )
         if self.security_manager_class is None:
             from flask_appbuilder.security.sqla.manager import SecurityManager


### PR DESCRIPTION
### Description

when using a custom `SecurityManager` FAB raises:

```
    Type[BaseSecurityManager], security_manager_class
NameError: name 'BaseSecurityManager' is not defined
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
