### PR TITLE
release: 4.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Flask-AppBuilder ChangeLog
 ==========================
 
+Improvements and Bug fixes on 4.1.1
+-----------------------------------
+
+- fix: custom security class import, bad cast (#1851) [Daniel Vaz Gaspar]
+- fix: Set certificates before reconnecting to LDAP (#1846) [Sebastian Bernauer]
+
 Improvements and Bug fixes on 4.1.0
 -----------------------------------
 

--- a/flask_appbuilder/__init__.py
+++ b/flask_appbuilder/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Daniel Vaz Gaspar"
-__version__ = "4.1.0"
+__version__ = "4.1.1"
 
 from .actions import action  # noqa: F401
 from .api import ModelRestApi  # noqa: F401


### PR DESCRIPTION
### Description

Patch release 4.1.1

```
- fix: custom security class import, bad cast (#1851) [Daniel Vaz Gaspar]
- fix: Set certificates before reconnecting to LDAP (#1846) [Sebastian Bernauer]
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
