### PR TITLE
fix(MVC): discard excluded filters from query

### DIFF
--- a/flask_appbuilder/tests/test_urltools.py
+++ b/flask_appbuilder/tests/test_urltools.py
@@ -34,7 +34,7 @@ class FlaskTestCase(FABTestCase):
         ):
             filters = datamodel.get_filters(["field_string", "field_integer"])
             get_filter_args(filters)
-            assert filters.values == [["a"], ["2"]]
+            assert filters.values in ([["a"], ["2"]], [["2"], ["a"]])
 
     def test_get_filter_args_disallow(self):
         datamodel = SQLAInterface(Model1)

--- a/flask_appbuilder/tests/test_urltools.py
+++ b/flask_appbuilder/tests/test_urltools.py
@@ -1,0 +1,55 @@
+import os
+
+from flask import Flask
+from flask_appbuilder import AppBuilder, SQLA
+from flask_appbuilder.models.sqla.interface import SQLAInterface
+from flask_appbuilder.tests.sqla.models import Model1
+from flask_appbuilder.urltools import get_filter_args
+
+from .base import FABTestCase
+
+
+class FlaskTestCase(FABTestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.basedir = os.path.abspath(os.path.dirname(__file__))
+        self.app.config.from_object("flask_appbuilder.tests.config_api")
+
+        self.db = SQLA(self.app)
+        self.appbuilder = AppBuilder(self.app, self.db.session)
+
+    def test_get_filter_args_allow_one(self):
+        datamodel = SQLAInterface(Model1)
+        with self.appbuilder.get_app.test_request_context(
+            "/users/list?_flt_1_field_string=a"
+        ):
+            filters = datamodel.get_filters(["field_string", "field_integer"])
+            get_filter_args(filters)
+            assert filters.values == [["a"]]
+
+    def test_get_filter_args_allow_multiple(self):
+        datamodel = SQLAInterface(Model1)
+        with self.appbuilder.get_app.test_request_context(
+            "/users/list?_flt_1_field_string=a&_flt_1_field_integer=2"
+        ):
+            filters = datamodel.get_filters(["field_string", "field_integer"])
+            get_filter_args(filters)
+            assert filters.values == [["a"], ["2"]]
+
+    def test_get_filter_args_disallow(self):
+        datamodel = SQLAInterface(Model1)
+        with self.appbuilder.get_app.test_request_context(
+            "/users/list?_flt_1_field_float=1.0"
+        ):
+            filters = datamodel.get_filters(["field_string", "field_integer"])
+            get_filter_args(filters)
+            assert filters.values == []
+
+    def test_get_filter_args_invalid_index(self):
+        datamodel = SQLAInterface(Model1)
+        with self.appbuilder.get_app.test_request_context(
+            "/users/list?_flt_a_field_string=a"
+        ):
+            filters = datamodel.get_filters(["field_string", "field_integer"])
+            get_filter_args(filters)
+            assert filters.values == []

--- a/flask_appbuilder/urltools.py
+++ b/flask_appbuilder/urltools.py
@@ -1,6 +1,9 @@
+import logging
 import re
 
 from flask import request
+
+log = logging.getLogger(__name__)
 
 
 class Stack(object):
@@ -96,7 +99,16 @@ def get_filter_args(filters):
     request_args = set(request.args)
     for arg in request_args:
         re_match = re.findall(r"_flt_(\d)_(.*)", arg)
+        try:
+            filter_index = int(re_match[0][0])
+        except ValueError:
+            log.warning("Invalid filter index")
+            continue
+        filter_column = re_match[0][1]
+        if filter_column not in filters.get_search_filters().keys():
+            log.warning("Filter column not allowed")
+            continue
         if re_match:
             filters.add_filter_index(
-                re_match[0][1], int(re_match[0][0]), request.args.getlist(arg)
+                filter_column, filter_index, request.args.getlist(arg)
             )

--- a/flask_appbuilder/urltools.py
+++ b/flask_appbuilder/urltools.py
@@ -99,6 +99,8 @@ def get_filter_args(filters):
     request_args = set(request.args)
     for arg in request_args:
         re_match = re.findall(r"_flt_(\d)_(.*)", arg)
+        if not re_match:
+            continue
         try:
             filter_index = int(re_match[0][0])
         except ValueError:

--- a/flask_appbuilder/urltools.py
+++ b/flask_appbuilder/urltools.py
@@ -101,11 +101,7 @@ def get_filter_args(filters):
         re_match = re.findall(r"_flt_(\d)_(.*)", arg)
         if not re_match:
             continue
-        try:
-            filter_index = int(re_match[0][0])
-        except ValueError:
-            log.warning("Invalid filter index")
-            continue
+        filter_index = int(re_match[0][0])
         filter_column = re_match[0][1]
         if filter_column not in filters.get_search_filters().keys():
             log.warning("Filter column not allowed")


### PR DESCRIPTION
### Description

Fixes a bug when a `ModelView` has declared `search_columns` and `search_exclude_columns` was still possible to filter by these fields when calling explicitly the URL with the filter format on the query parameters.
 
cc: @thesuperzapper @z-arosio 

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
