### PR TITLE
fix: Custom IndexView and Menu

### DIFF
--- a/flask_appbuilder/base.py
+++ b/flask_appbuilder/base.py
@@ -20,6 +20,7 @@ from .const import (
 from .filters import TemplateFilters
 from .menu import Menu, MenuApiManager
 from .views import IndexView, UtilView
+from .baseviews import BaseView
 
 if TYPE_CHECKING:
     from flask_appbuilder.basemanager import BaseManager
@@ -27,7 +28,6 @@ if TYPE_CHECKING:
     from flask_appbuilder.security.manager import BaseSecurityManager
 
 log = logging.getLogger(__name__)
-
 
 DynamicImportType = Union[
     Type["BaseManager"], Type["BaseView"], Type["BaseSecurityManager"], Type[Menu]
@@ -174,7 +174,7 @@ class AppBuilder:
         _index_view = app.config.get("FAB_INDEX_VIEW", None)
         if _index_view is not None:
             view = dynamic_class_import(_index_view)
-            if isinstance(view, BaseView):
+            if issubclass(view, BaseView):
                 self.indexview = view
         else:
             self.indexview = self.indexview or IndexView()
@@ -183,7 +183,7 @@ class AppBuilder:
         # Setup Menu
         if _menu is not None:
             menu = dynamic_class_import(_menu)
-            if isinstance(menu, Menu):
+            if issubclass(menu, Menu):
                 self.menu = menu
         else:
             self.menu = self.menu or Menu()
@@ -291,9 +291,9 @@ class AppBuilder:
     @property
     def version(self) -> str:
         """
-            Get the current F.A.B. version
+        Get the current F.A.B. version
 
-            :return: String with the current F.A.B. version
+        :return: String with the current F.A.B. version
         """
         return __version__
 
@@ -313,7 +313,7 @@ class AppBuilder:
 
     def _add_admin_views(self) -> None:
         """
-            Registers indexview, utilview (back function), babel views and Security views.
+        Registers indexview, utilview (back function), babel views and Security views.
         """
         if self.indexview:
             self.indexview = self._check_and_init(self.indexview)

--- a/flask_appbuilder/base.py
+++ b/flask_appbuilder/base.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm.session import Session as SessionBase
 from . import __version__
 from .api.manager import OpenApiManager
 from .babel.manager import BabelManager
+from .baseviews import BaseView
 from .const import (
     LOGMSG_ERR_FAB_ADD_PERMISSION_MENU,
     LOGMSG_ERR_FAB_ADD_PERMISSION_VIEW,
@@ -20,11 +21,10 @@ from .const import (
 from .filters import TemplateFilters
 from .menu import Menu, MenuApiManager
 from .views import IndexView, UtilView
-from .baseviews import BaseView
 
 if TYPE_CHECKING:
     from flask_appbuilder.basemanager import BaseManager
-    from flask_appbuilder.baseviews import BaseView, AbstractViewApi
+    from flask_appbuilder.baseviews import AbstractViewApi
     from flask_appbuilder.security.manager import BaseSecurityManager
 
 log = logging.getLogger(__name__)

--- a/flask_appbuilder/base.py
+++ b/flask_appbuilder/base.py
@@ -174,8 +174,8 @@ class AppBuilder:
         _index_view = app.config.get("FAB_INDEX_VIEW", None)
         if _index_view is not None:
             view = dynamic_class_import(_index_view)
-            if issubclass(view, BaseView):
-                self.indexview = view
+            if view is not None and issubclass(view, BaseView):
+                self.indexview = view()
         else:
             self.indexview = self.indexview or IndexView()
         _menu = app.config.get("FAB_MENU", None)
@@ -183,8 +183,8 @@ class AppBuilder:
         # Setup Menu
         if _menu is not None:
             menu = dynamic_class_import(_menu)
-            if issubclass(menu, Menu):
-                self.menu = menu
+            if menu is not None and issubclass(menu, Menu):
+                self.menu = menu()
         else:
             self.menu = self.menu or Menu()
 

--- a/flask_appbuilder/tests/templates/custom_index.html
+++ b/flask_appbuilder/tests/templates/custom_index.html
@@ -1,0 +1,1 @@
+This is a custom index view.

--- a/flask_appbuilder/tests/test_custom_indexview.py
+++ b/flask_appbuilder/tests/test_custom_indexview.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 
 class CustomIndexView(IndexView):
-    index_template = 'templates/custom_index.html'
+    index_template = "templates/custom_index.html"
 
 
 class FlaskTestCase(FABTestCase):
@@ -17,10 +17,12 @@ class FlaskTestCase(FABTestCase):
         from flask import Flask
         from flask_appbuilder import AppBuilder
 
-        self.app = Flask(__name__, template_folder='.')
+        self.app = Flask(__name__, template_folder=".")
         self.basedir = os.path.abspath(os.path.dirname(__file__))
         self.app.config.from_object("flask_appbuilder.tests.config_api")
-        self.app.config["FAB_INDEX_VIEW"] = 'flask_appbuilder.tests.test_custom_indexview.CustomIndexView'
+        self.app.config[
+            "FAB_INDEX_VIEW"
+        ] = "flask_appbuilder.tests.test_custom_indexview.CustomIndexView"
 
         self.db = SQLA(self.app)
         self.appbuilder = AppBuilder(self.app, self.db.session)
@@ -33,7 +35,7 @@ class FlaskTestCase(FABTestCase):
 
     def test_custom_indexview(self):
         """
-            Test custom index view.
+        Test custom index view.
         """
         uri = "/"
         client = self.app.test_client()

--- a/flask_appbuilder/tests/test_custom_indexview.py
+++ b/flask_appbuilder/tests/test_custom_indexview.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-from flask_appbuilder import SQLA, IndexView
+from flask_appbuilder import IndexView, SQLA
 
 from .base import FABTestCase
 

--- a/flask_appbuilder/tests/test_custom_indexview.py
+++ b/flask_appbuilder/tests/test_custom_indexview.py
@@ -1,0 +1,44 @@
+import logging
+import os
+
+from flask_appbuilder import SQLA, IndexView
+
+from .base import FABTestCase
+
+log = logging.getLogger(__name__)
+
+
+class CustomIndexView(IndexView):
+    index_template = 'templates/custom_index.html'
+
+
+class FlaskTestCase(FABTestCase):
+    def setUp(self):
+        from flask import Flask
+        from flask_appbuilder import AppBuilder
+
+        self.app = Flask(__name__, template_folder='.')
+        self.basedir = os.path.abspath(os.path.dirname(__file__))
+        self.app.config.from_object("flask_appbuilder.tests.config_api")
+        self.app.config["FAB_INDEX_VIEW"] = 'flask_appbuilder.tests.test_custom_indexview.CustomIndexView'
+
+        self.db = SQLA(self.app)
+        self.appbuilder = AppBuilder(self.app, self.db.session)
+
+    def tearDown(self):
+        self.appbuilder = None
+        self.app = None
+        self.db = None
+        log.debug("TEAR DOWN")
+
+    def test_custom_indexview(self):
+        """
+            Test custom index view.
+        """
+        uri = "/"
+        client = self.app.test_client()
+        rv = client.get(uri)
+
+        self.assertEqual(rv.status_code, 200)
+        data = rv.data.decode("utf-8")
+        self.assertIn("This is a custom index view.", data)


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

Currently custom `IndexView` and `Menu` (via `FAB_INDEX_VIEW` and `FAB_MENU` respectively) are not working: 

```
  File "/venv/lib/python3.10/site-packages/flask_appbuilder/base.py", line 177, in init_app
    if isinstance(view, BaseView):
NameError: name 'BaseView' is not defined
```

This PR fixes it by:
1. Importing `BaseView`
2. Checking classes instead of instances

<!--- Describe the change below, including rationale and design decisions -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
