### PR TITLE
fix(api): register responses with apispec using components.response()

### DIFF
--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -533,7 +533,10 @@ class BaseApi(AbstractViewApi):
 
     def add_apispec_components(self, api_spec: APISpec) -> None:
         for k, v in self.responses.items():
-            api_spec.components._responses[k] = v
+            try:
+                api_spec.components.response(k, v)
+            except DuplicateComponentNameError:
+                pass
         for k, v in self._apispec_parameter_schemas.items():
             try:
                 api_spec.components.schema(k, v)


### PR DESCRIPTION
responses should be registered with apispec using components.response();
not by directly modifying the _reponses dict, which is internal to the
ApiSpec.Components class.

Also, handle duplicate response registrations gracefully.