### PR TITLE
docs: add responsible disclosure text to security

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -1,6 +1,12 @@
 Security
 ========
 
+Responsible disclosure
+----------------------
+
+We want to keep Flask-AppBuilder safe for everyone. If you've discovered a security vulnerability
+please report to danielvazgaspar@gmail.com.
+
 Supported Authentication Types
 ------------------------------
 


### PR DESCRIPTION
### Description

Adds a responsible disclosure text to docs and to github security policy

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
