### PR TITLE
fix: fix a wrong 'next' URL in javascript

### DIFF
--- a/flask_appbuilder/templates/appbuilder/general/security/login_oauth.html
+++ b/flask_appbuilder/templates/appbuilder/general/security/login_oauth.html
@@ -6,7 +6,7 @@
 <script type="text/javascript">
     var baseLoginUrl = "{{appbuilder.get_url_for_login}}";
     var baseRegisterUrl = "{{appbuilder.get_url_for_login}}";
-    var next = "?next={{request.args.get('next', '')}}"
+    var next = "?next=" + encodeURIComponent("{{request.args.get('next', '') | safe}}");
 
     function signin(provider) {
         window.location.href = baseLoginUrl + provider + next;


### PR DESCRIPTION
### Description

Due to Jinja autoescaping, when we render the `next` url in html the `&` become escaped to `&amp;`
This result in a wrong URL parameters.

For example
`?next=https://www.abc.com?id=1&name=a` will be rendered as `?next=https://www.abc.com?id=1&amp;name=a` in HTML page.

The fix is to hint Jinja not to escape the URL and also encode the URL.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
