### PR TITLE
fix: Support remove some fields on method to_json

### DIFF
--- a/flask_appbuilder/models/sqla/__init__.py
+++ b/flask_appbuilder/models/sqla/__init__.py
@@ -121,10 +121,18 @@ class Model(object):
     """
 
     __table_args__ = {"extend_existing": True}
+    """
+        Remove fields when invoke to_json method.
+        For example: json_hidden_fields = ['name', 'foo', 'baz']
+    """
+    json_hidden_fields = None
 
     def to_json(self):
         result = dict()
         for key in self.__mapper__.c.keys():
+            if self.json_hidden_fields is not None and key in self.json_hidden_fields:
+                continue
+
             col = getattr(self, key)
             if isinstance(col, datetime.datetime) or isinstance(col, datetime.date):
                 col = col.isoformat()

--- a/flask_appbuilder/security/sqla/models.py
+++ b/flask_appbuilder/security/sqla/models.py
@@ -110,6 +110,8 @@ class User(Model):
     changed_on = Column(
         DateTime, default=lambda: datetime.datetime.now(), nullable=True
     )
+    
+    json_hidden_fields = ['password']
 
     @declared_attr
     def created_by_fk(self):
@@ -177,3 +179,5 @@ class RegisterUser(Model):
     email = Column(String(64), nullable=False)
     registration_date = Column(DateTime, default=datetime.datetime.now, nullable=True)
     registration_hash = Column(String(256))
+    
+    json_hidden_fields = ['password', 'registration_hash']


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

This MR, I implemented new logic which it allows model can define hidden fields when cast to json.

For example:

```python

class ExampleModel(Model):
  id = Column(...)
  secret_column = Column(...)

  json_hidden_fields = ['secret_column']


example = ExampleModel()
json = example.to_json() # should not include the column secret_column

```



### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue: https://github.com/dpgaspar/Flask-AppBuilder/issues/1908
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [x] Introduces new feature
- [ ] Removes existing feature
