### PR TITLE
Flexible fields mapping for AAD user info and FAB user

### DIFF
--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -615,15 +615,24 @@ class BaseSecurityManager(AbstractSecurityManager):
             log.debug(str(id_token))
             me = self._azure_jwt_token_parse(id_token)
             log.debug("Parse JWT token : {0}".format(me))
-            return {
-                "name": me.get("name", ""),
-                "email": me["upn"],
-                "first_name": me.get("given_name", ""),
-                "last_name": me.get("family_name", ""),
-                "id": me["oid"],
-                "username": me["oid"],
-                "role_keys": me.get("roles", []),
-            }
+            user_info_map = self.oauth_remotes[provider].client_kwargs.get("user_info_mapping")
+
+            user_info_data = {}
+            if user_info_map:
+                for user_info_field, aad_user_info_field in user_info_map.items():
+                    user_info_data[user_info_field] = me.get(aad_user_info_field[0], aad_user_info_field[1])
+            else:
+                user_info_data = {
+                    "name": me.get("name", ""),
+                    "email": me["upn"],
+                    "first_name": me.get("given_name", ""),
+                    "last_name": me.get("family_name", ""),
+                    "id": me["oid"],
+                    "username": me["oid"],
+                    "role_keys": me.get("roles", []),
+                }
+
+            return user_info_data
         # for OpenShift
         if provider == "openshift":
             me = self.appbuilder.sm.oauth_remotes[provider].get(


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

<!--- Describe the change below, including rationale and design decisions -->
Currently in security module for AAD OAuth, if get user info from AAD, the module will return a fixed values which map user info from AAD to fab user as below:
```
return {
    "name": me.get("name", ""),
    "email": me["upn"],
    "first_name": me.get("given_name", ""),
    "last_name": me.get("family_name", ""),
    "id": me["oid"],
    "username": me["oid"],
    "role_keys": me.get("roles", []),
}
```
But I found some of fields from AAD may be missed like "upn" can't retrieve from AAD, and the fixed mapping doesn't meet my requirements, like "email" should map to me["email"] in my scenario. 
This PR is to enable the fields mapping can be set in config.py for more flexible configuration.

The new mapping structure is blow:
```
"user_info_mapping": {
    "name": ("name", ""),
    "email": ("email", ""),
    "first_name": ("given_name", ""),
    "last_name": ("family_name", ""),
    "id": ("oid", ""),
    "username": ("preferred_username", ""),
    "role_keys": ("roles", []),
}
```
The field mapping shall look like this
`"<FAB user info field>": ("<user info field from AAD>", <default value if no this field from AAD>)`.

The fields mapping will be put into this path: OAUTH_PROVIDERS > {provider: azure} > "remote_app" > "client_kwargs"
```
OAUTH_PROVIDERS = [
{
        "name": "azure",
        "icon": "fa-windows",
        "token_key": "access_token",
        "remote_app": {
            "client_id": "AZURE_APPLICATION_ID",
            "client_secret": "AZURE_SECRET",
            "api_base_url": "https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2",
            "client_kwargs": {
                "scope": "User.read name preferred_username email profile upn",
                "resource": "AZURE_APPLICATION_ID",
                "user_info_mapping": {
                    "name": ("name", ""),
                    "email": ("email", ""),
                    "first_name": ("given_name", ""),
                    "last_name": ("family_name", ""),
                    "id": ("oid", ""),
                    "username": ("preferred_username", ""),
                    "role_keys": ("roles", []),
                }
            },
            "request_token_url": None,
            "access_token_url": "https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token",
            "authorize_url": "https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/authorize",
        },
    },
]
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #1868" if you are fixing an existing issue -->
- [x] Has associated issue: #1868
- [ ] Is CRUD MVC related.
- [x] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
