### PR TITLE
release: 4.1.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,19 @@
 Flask-AppBuilder ChangeLog
 ==========================
 
+Improvements and Bug fixes on 4.1.4
+-----------------------------------
+
+- chore: Redirect to prev url on login for AuthRemoteUserView (#1901) [Alexander Ryndin]
+- chore: Bump upper bounds on wtforms and flask-wtf (#1904) [Tomáš Drtina]
+- fix(mvc): related model view setting default related field value (#1898) [Daniel Vaz Gaspar]
+- fix: DateTimePicker rendering in forms (#1698) [Federico Padua]
+- test(fab_cli): tag tests that need internet so they can be skipped (#1880) [jnahmias]
+- fix: fix a wrong 'next' URL in javascript (#1897) [Sansarun Sukawongviwat]
+- chore: allow authlib > 1 updated docs (#1891) [Daniel Vaz Gaspar]
+- docs: fix oauth example config (#1890) [Daniel Vaz Gaspar]
+- docs: fix oauth example config (#1889) [Daniel Vaz Gaspar]
+
 Improvements and Bug fixes on 4.1.3
 -----------------------------------
 

--- a/flask_appbuilder/__init__.py
+++ b/flask_appbuilder/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Daniel Vaz Gaspar"
-__version__ = "4.1.3"
+__version__ = "4.1.4"
 
 from .actions import action  # noqa: F401
 from .api import ModelRestApi  # noqa: F401


### PR DESCRIPTION
### Description

Release: 4.1.4

Change log:
```
- chore: Redirect to prev url on login for AuthRemoteUserView (#1901) [Alexander Ryndin]
- chore: Bump upper bounds on wtforms and flask-wtf (#1904) [Tomáš Drtina]
- fix(mvc): related model view setting default related field value (#1898) [Daniel Vaz Gaspar]
- fix: DateTimePicker rendering in forms (#1698) [Federico Padua]
- test(fab_cli): tag tests that need internet so they can be skipped (#1880) [jnahmias]
- fix: fix a wrong 'next' URL in javascript (#1897) [Sansarun Sukawongviwat]
- chore: allow authlib > 1 updated docs (#1891) [Daniel Vaz Gaspar]
- docs: fix oauth example config (#1890) [Daniel Vaz Gaspar]
- docs: fix oauth example config (#1889) [Daniel Vaz Gaspar]
```

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
