### PR TITLE
fix: add_view menu_cond

### DIFF
--- a/flask_appbuilder/filters.py
+++ b/flask_appbuilder/filters.py
@@ -1,5 +1,5 @@
 from flask import current_app, request, url_for
-
+import sys
 from .const import PERMISSION_PREFIX
 
 
@@ -133,7 +133,9 @@ class TemplateFilters(object):
 
     @app_template_filter("is_menu_visible")
     def is_menu_visible(self, item):
-        return self.security_manager.has_access("menu_access", item.name)
+        if item.cond is None or item.cond():
+            return self.security_manager.has_access("menu_access", item.name)
+        return False
 
     @staticmethod
     def find_views_by_name(view_name):

--- a/flask_appbuilder/filters.py
+++ b/flask_appbuilder/filters.py
@@ -1,5 +1,5 @@
 from flask import current_app, request, url_for
-import sys
+
 from .const import PERMISSION_PREFIX
 
 


### PR DESCRIPTION
### Description

menu_cond parameter of appbuilder.add_view is described as being a callable or None, that will hide the menu item if returns false. But setting this as per docs doesn't hide the menu item.

Apologies for lack of test case. It looks like current ones fail if an item is artificially hidden, but doesn't fail if an item is not hidden.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
