### PR TITLE
fix: Replace deprecated attachment_filename

### DIFF
--- a/flask_appbuilder/views.py
+++ b/flask_appbuilder/views.py
@@ -640,7 +640,7 @@ class ModelView(RestCRUDView):
     def download(self, filename):
         return send_file(
             op.join(self.appbuilder.app.config["UPLOAD_FOLDER"], filename),
-            attachment_filename=uuid_originalname(filename),
+            download_name=uuid_originalname(filename),
             as_attachment=True,
         )
 


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description
<!--- Describe the change below, including rationale and design decisions -->
Replace attachment_filename with download_name, as it has been removed from flask. Fixes #1947 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue:
- [X] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
