### PR TITLE
chore: Use lazy rather than joined (eager) loading

### DIFF
--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -305,7 +305,7 @@ class SQLAInterface(BaseInterface):
                     root_relation
                 ) or self.is_relation_one_to_many(root_relation):
                     query = query.options(
-                        Load(self.obj).joinedload(root_relation).load_only(leaf_column)
+                        Load(self.obj).lazyload(root_relation).load_only(leaf_column)
                     )
                 else:
                     related_model = self.get_related_model(root_relation)


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

https://github.com/dpgaspar/Flask-AppBuilder/pull/1361 introduced [Joined Eager Loading](https://docs.sqlalchemy.org/en/14/orm/loading_relationships.html#joined-eager-loading) for joining one-to-many or many-to-many model relationships, however per the SQLAlchemy example this results in a slew of `LEFT OUTER JOIN`s which will rapidly result into a expansive interim result set—from a multiplicative combinatorial sense—when a model has multiple high cardinality relationships. Furthermore the result set—which is repetitive in nature—requires further overhead my SQLAlchemy to [de-duplicate](https://docs.sqlalchemy.org/en/14/orm/loading_relationships.html#joined-eager-loading-and-result-set-batching) the rows against the actual model record.

Given that the FAB response is an addition of relationships rather than a multiplication of relationships it seems like [Lazy Loading](https://docs.sqlalchemy.org/en/14/orm/loading_relationships.html#lazy-loading) is more desirable. Granted this results in one query per relationship, but the interim result sets are typically much smaller non-repetitive in nature (especially for high cardinality relationships) and thus more performant.

For example in Superset at Airbnb we have a virtual dataset which is comprised of a thousands of metrics and columns. Previously a query to obtain the dataset with the associated metric and column IDs would time out whereas with lazy loading the query takes << 5 seconds.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
