### PR TITLE
chore: Use implicit default loading rather than explicit joined eager loading

### DIFF
--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -305,7 +305,7 @@ class SQLAInterface(BaseInterface):
                     root_relation
                 ) or self.is_relation_one_to_many(root_relation):
                     query = query.options(
-                        Load(self.obj).joinedload(root_relation).load_only(leaf_column)
+                        Load(self.obj).defaultload(root_relation).load_only(leaf_column)
                     )
                 else:
                     related_model = self.get_related_model(root_relation)


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

A rehash of https://github.com/dpgaspar/Flask-AppBuilder/pull/1959 but, per https://github.com/dpgaspar/Flask-AppBuilder/pull/1959#issuecomment-1347645811, rather than explicitly defining the form of the relationship loading rely instead on the implicit definition of the specific model relationships (which defaults to lazy per [here](https://docs.sqlalchemy.org/en/14/orm/relationship_api.html#sqlalchemy.orm.relationship.params.lazy)). This helps to ensure that the optimal loading technic is used for each specific implementation/use case.

See [Relationship Loading Techniques](https://docs.sqlalchemy.org/en/14/orm/loading_relationships.html#relationship-loading-techniques) for the various relationship loading techniques which are supported by SQLAlchemy which fall into one of three categories: lazy, eager, or none. Lazy implies delayed loading and results in [N +1](https://docs.sqlalchemy.org/en/14/glossary.html#term-N-plus-one-problem) queries, whereas eager loading "eagerly" loads items alongside the parent—either using a separate `SELECT` statement or using `JOIN` clause (which can lead to a multiplicative issue when the parent has multiple relationships).

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
