### PR TITLE
fix(api): _info HTTP 500 when exists a defined invalid search field

### DIFF
--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -1211,6 +1211,9 @@ class ModelRestApi(BaseModelApi):
         search_filters = dict()
         dict_filters = self._filters.get_search_filters()
         for col in self.search_columns:
+            if col not in dict_filters:
+                # column not in search filters but defined has one
+                continue
             search_filters[col] = [
                 {"name": as_unicode(flt.name), "operator": flt.arg_name}
                 for flt in dict_filters[col]

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -220,6 +220,12 @@ class APITestCase(FABTestCase):
                     ~Model1.field_string.like(value + "%"), Model1.field_integer == 1
                 )
 
+        class Model2ApiInvalidSearchColumns(ModelRestApi):
+            datamodel = SQLAInterface(Model2)
+            search_columns = ["field_string", "group.field_string"]
+
+        self.appbuilder.add_api(Model2ApiInvalidSearchColumns)
+
         class Model1ApiSearchFilters(ModelRestApi):
             datamodel = SQLAInterface(Model1)
             search_filters = {"field_string": [CustomFilter]}
@@ -1563,6 +1569,20 @@ class APITestCase(FABTestCase):
 
         rv = self.auth_client_get(client, token, uri)
         self.assertEqual(rv.status_code, 400)
+
+    def test_get_info_with_invalid_search_column(self):
+        """
+        REST Api: Test get info with invalid search column
+        """
+        uri = f"api/v1/model2apiinvalidsearchcolumns/_info"
+
+        client = self.app.test_client()
+        token = self.login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
+        rv = self.auth_client_get(client, token, uri)
+        self.assertEqual(rv.status_code, 200)
+        data = json.loads(rv.data.decode("utf-8"))
+        self.assertIn("filters", data)
+        self.assertIn("field_string", data["filters"])
 
     def test_get_list_multiple_search_filters(self):
         """

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -1574,7 +1574,7 @@ class APITestCase(FABTestCase):
         """
         REST Api: Test get info with invalid search column
         """
-        uri = f"api/v1/model2apiinvalidsearchcolumns/_info"
+        uri = "api/v1/model2apiinvalidsearchcolumns/_info"
 
         client = self.app.test_client()
         token = self.login(client, USERNAME_ADMIN, PASSWORD_ADMIN)


### PR DESCRIPTION
### Description

When a developer defines an invalid search filter on `ModelRestApi` a warning is issued at bootstrap but `_info` metadata endpoint crashes with HTTP 500

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
