### PR TITLE
fix: REST API one-to-one relationship

### DIFF
--- a/examples/crud_rest_api/testdata.py
+++ b/examples/crud_rest_api/testdata.py
@@ -3,7 +3,7 @@ import logging
 import random
 
 from app import db
-from app.models import Contact, ContactGroup, Gender, ModelOMParent, ModelOMChild
+from app.models import Contact, ContactGroup, Gender, ModelOMParent, ModelOMChild, Child
 
 log = logging.getLogger(__name__)
 
@@ -82,6 +82,7 @@ for i in range(1, 1000):
     c.personal_celphone = random.randrange(1111111, 9999999)
     c.contact_group = groups[random.randrange(0, 3)]
     c.gender = genders[random.randrange(0, 2)]
+    c.child = Child(name=get_random_name(names_list, random.randrange(2, 6)))
     year = random.choice(range(1900, 2012))
     month = random.choice(range(1, 12))
     day = random.choice(range(1, 28))

--- a/examples/crud_rest_api/testdata.py
+++ b/examples/crud_rest_api/testdata.py
@@ -3,7 +3,7 @@ import logging
 import random
 
 from app import db
-from app.models import Contact, ContactGroup, Gender, ModelOMParent, ModelOMChild, Child
+from app.models import Contact, ContactGroup, Gender, ModelOMParent, ModelOMChild
 
 log = logging.getLogger(__name__)
 
@@ -82,7 +82,6 @@ for i in range(1, 1000):
     c.personal_celphone = random.randrange(1111111, 9999999)
     c.contact_group = groups[random.randrange(0, 3)]
     c.gender = genders[random.randrange(0, 2)]
-    c.child = Child(name=get_random_name(names_list, random.randrange(2, 6)))
     year = random.choice(range(1900, 2012))
     month = random.choice(range(1, 12))
     day = random.choice(range(1, 28))

--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -607,7 +607,10 @@ class SQLAInterface(BaseInterface):
     def is_relation_one_to_one(self, col_name: str) -> bool:
         try:
             if self.is_relation(col_name):
-                return self.list_properties[col_name].direction.name == "ONETOONE"
+                relation = self.list_properties[col_name]
+                return self.list_properties[col_name].direction.name == "ONETOONE" or (
+                    relation.direction.name == "ONETOMANY" and relation.uselist is False
+                )
             return False
         except KeyError:
             return False
@@ -615,7 +618,8 @@ class SQLAInterface(BaseInterface):
     def is_relation_one_to_many(self, col_name: str) -> bool:
         try:
             if self.is_relation(col_name):
-                return self.list_properties[col_name].direction.name == "ONETOMANY"
+                relation = self.list_properties[col_name]
+                return relation.direction.name == "ONETOMANY" and relation.uselist
             return False
         except KeyError:
             return False

--- a/flask_appbuilder/tests/sqla/models.py
+++ b/flask_appbuilder/tests/sqla/models.py
@@ -183,6 +183,20 @@ class ModelOMChild(Model):
         foreign_keys=[parent_id],
     )
 
+
+class ModelOOParent(Model):
+    __tablename__ = "model_oo_parent"
+    id = Column(Integer, primary_key=True)
+    field_string = Column(String(50), unique=True, nullable=False)
+    child = relationship("ModelOOChild", back_populates="parent", uselist=False)
+
+
+class ModelOOChild(Model):
+    id = Column(Integer, primary_key=True)
+    field_string = Column(String(50), unique=True, nullable=False)
+    parent_id = Column(Integer, ForeignKey("model_oo_parent.id"))
+    parent = relationship("ModelOOParent", back_populates="child")
+
     """ ---------------------------------
             TEST HELPER FUNCTIONS
         ---------------------------------
@@ -338,3 +352,10 @@ def insert_data(session, count):
             model.parent = model_om_parents[i]
             session.add(model)
             session.commit()
+
+    for i in range(count):
+        model = ModelOOParent()
+        model.field_string = f"text{i}"
+        model.child = ModelOOChild(field_string=f"text{i}.child")
+        session.add(model)
+        session.commit()

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -58,12 +58,12 @@ from .sqla.models import (
     ModelMMParentRequired,
     ModelOMChild,
     ModelOMParent,
+    ModelOOParent,
     ModelWithEnums,
     ModelWithProperty,
     TmpEnum,
     validate_name,
 )
-
 
 log = logging.getLogger(__name__)
 
@@ -318,6 +318,11 @@ class APITestCase(FABTestCase):
         self.modeldottedmmapi = ModelDottedMMApi
         self.appbuilder.add_api(ModelDottedMMApi)
 
+        class ModelMMRequiredApi(ModelRestApi):
+            datamodel = SQLAInterface(ModelMMParentRequired)
+
+        self.appbuilder.add_api(ModelMMRequiredApi)
+
         class ModelOMParentApi(ModelRestApi):
             datamodel = SQLAInterface(ModelOMParent)
 
@@ -330,10 +335,17 @@ class APITestCase(FABTestCase):
 
         self.appbuilder.add_api(ModelDottedOMParentApi)
 
-        class ModelMMRequiredApi(ModelRestApi):
-            datamodel = SQLAInterface(ModelMMParentRequired)
+        class ModelOOParentApi(ModelRestApi):
+            datamodel = SQLAInterface(ModelOOParent)
 
-        self.appbuilder.add_api(ModelMMRequiredApi)
+        self.appbuilder.add_api(ModelOOParentApi)
+
+        class ModelDottedOOParentApi(ModelRestApi):
+            datamodel = SQLAInterface(ModelOOParent)
+            list_columns = ["field_string", "child.field_string"]
+            show_columns = ["field_string", "child.field_string"]
+
+        self.appbuilder.add_api(ModelDottedOOParentApi)
 
         class Model1CustomValidationApi(ModelRestApi):
             datamodel = SQLAInterface(Model1)
@@ -1023,6 +1035,43 @@ class APITestCase(FABTestCase):
         }
         self.assertEqual(data[API_RESULT_RES_KEY], expected_result)
 
+    def test_get_item_oo_field(self):
+        """
+        REST Api: Test get item with O-O related field
+        """
+        client = self.app.test_client()
+        token = self.login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
+
+        # We can't get a base filtered item
+        pk = 1
+        rv = self.auth_client_get(client, token, f"api/v1/modelooparentapi/{pk}")
+        data = json.loads(rv.data.decode("utf-8"))
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(
+            data[API_RESULT_RES_KEY],
+            {
+                "field_string": "text0",
+                "child": {"field_string": "text0.child", "id": 1},
+            },
+        )
+
+    def test_get_item_dotted_oo_field(self):
+        """
+        REST Api: Test get item with dotted O-O related field
+        """
+        client = self.app.test_client()
+        token = self.login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
+
+        # We can't get a base filtered item
+        pk = 1
+        rv = self.auth_client_get(client, token, f"api/v1/modeldottedooparentapi/{pk}")
+        data = json.loads(rv.data.decode("utf-8"))
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(
+            data[API_RESULT_RES_KEY],
+            {"field_string": "text0", "child": {"field_string": "text0.child"}},
+        )
+
     def test_get_item_om_field(self):
         """
         REST Api: Test get item with O-M related field
@@ -1115,6 +1164,36 @@ class APITestCase(FABTestCase):
             {"field_string": f"text0.{i}"} for i in range(1, MODELOMCHILD_DATA_SIZE)
         ]
         self.assertEqual(data[API_RESULT_RES_KEY][0]["children"], expected_rel_field)
+
+    def test_get_list_oo_field(self):
+        """
+        REST Api: Test get list with O-O related field
+        """
+        client = self.app.test_client()
+        token = self.login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
+
+        rv = self.auth_client_get(client, token, "api/v1/modelooparentapi/")
+        data = json.loads(rv.data.decode("utf-8"))
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(data["count"], MODEL1_DATA_SIZE)
+        self.assertEqual(len(data[API_RESULT_RES_KEY]), self.model1api.page_size)
+        expected_rel_field = {"field_string": "text0.child", "id": 1}
+        self.assertEqual(data[API_RESULT_RES_KEY][0]["child"], expected_rel_field)
+
+    def test_get_list_dotted_oo_field(self):
+        """
+        REST Api: Test get list with dotted O-O related field
+        """
+        client = self.app.test_client()
+        token = self.login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
+
+        rv = self.auth_client_get(client, token, "api/v1/modeldottedooparentapi/")
+        data = json.loads(rv.data.decode("utf-8"))
+        self.assertEqual(rv.status_code, 200)
+        self.assertEqual(data["count"], MODEL1_DATA_SIZE)
+        self.assertEqual(len(data[API_RESULT_RES_KEY]), self.model1api.page_size)
+        expected_rel_field = {"field_string": "text0.child"}
+        self.assertEqual(data[API_RESULT_RES_KEY][0]["child"], expected_rel_field)
 
     def test_get_list_dotted_mm_field(self):
         """


### PR DESCRIPTION
### Description

Fixes `ModelRestApi` one to one relation when it's defined like:

```python
class Child(Model):
    id = Column(Integer, primary_key=True)
    name = Column(String(50), unique=True, nullable=False)
    parent_id = Column(Integer, ForeignKey("contact.id"))
    parent = relationship("Parent", back_populates="child")

class Parent(Model):
    id = Column(Integer, primary_key=True)
    name = Column(String(150), unique=True, nullable=False)
    child = relationship("Child", back_populates="parent", uselist=False)
```

@hughhhh 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
