### PR TITLE
fix: CI broken by pyodbc vs unixodbc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y python-dev libldap2-dev libsasl2-dev libssl-dev freetds-bin unixodbc-dev=2.3.7 tdsodbc
+          sudo apt-get install -y python-dev libldap2-dev libsasl2-dev libssl-dev freetds-bin unixodbc-dev tdsodbc
           pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-dev.txt

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -5,7 +5,7 @@ Pillow~=9.1
 cython==0.29.17
 mysqlclient==2.0.1
 psycopg2-binary==2.8.6
-pyodbc==4.0.30
+pyodbc==4.0.35
 requests==2.26.0
 Authlib==0.15.4
 python-ldap==3.3.1


### PR DESCRIPTION
### Description

Hopefully permanently fixes CI error:

```
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DPYODBC_VERSION=4.0.30 -I/opt/hostedtoolcache/Python/3.8.16/x64/include/python3.8 -c src/buffer.cpp -o build/temp.linux-x86_64-3.8/src/buffer.o -Wno-write-strings
      In file included from /usr/include/sql.h:19:0,
                       from src/pyodbc.h:56,
                       from src/buffer.cpp:12:
      /usr/include/sqltypes.h:56:10: fatal error: unixodbc.h: No such file or directory
       #include "unixodbc.h"
                ^~~~~~~~~~~~
      compilation terminated.
      error: command 'gcc' failed with exit status 1
      [end of output]
```

related with: https://github.com/dpgaspar/Flask-AppBuilder/pull/1992
and: https://github.com/microsoft/linux-package-repositories/issues/36


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
