### PR TITLE
fix: disable rate limit by default

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -392,9 +392,9 @@ to get an idea of a simple use for this.
 Authentication: Rate limiting
 -----------------------------
 
-To prevent brute-forcing of credentials, FlaskApplicationBuilder applies rate limits to AuthViews in 4.2.0, so that
-only 2 POST requests can be made every 5 seconds. This can be disabled by setting ``AUTH_RATE_LIMITED`` to
-``False`` or can be changed by adjusting ``AUTH_RATE_LIMIT`` to, for example, ``1 per 10 seconds``. Take a look
+To prevent brute-forcing of credentials, you can apply rate limits to AuthViews in 4.2.0, so that
+only 10 POST requests can be made every 20 seconds. This can be enabled by setting ``AUTH_RATE_LIMITED`` to
+``True`` or can be changed by adjusting ``AUTH_RATE_LIMIT`` to, for example, ``1 per 10 seconds``. Take a look
 at the `documentation <https://flask-limiter.readthedocs.io/en/stable/>`_ of Flask-Limiter for more options and
 examples.
 

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -393,8 +393,9 @@ Authentication: Rate limiting
 -----------------------------
 
 To prevent brute-forcing of credentials, you can apply rate limits to AuthViews in 4.2.0, so that
-only 10 POST requests can be made every 20 seconds. This can be enabled by setting ``AUTH_RATE_LIMITED`` to
-``True`` or can be changed by adjusting ``AUTH_RATE_LIMIT`` to, for example, ``1 per 10 seconds``. Take a look
+only 10 POST requests can be made every 20 seconds. This can be enabled by setting
+``AUTH_RATE_LIMITED`` and ``RATELIMIT_ENABLED`` to ``True``.
+The rate can be changed by adjusting ``AUTH_RATE_LIMIT`` to, for example, ``1 per 10 seconds``. Take a look
 at the `documentation <https://flask-limiter.readthedocs.io/en/stable/>`_ of Flask-Limiter for more options and
 examples.
 

--- a/flask_appbuilder/base.py
+++ b/flask_appbuilder/base.py
@@ -162,6 +162,7 @@ class AppBuilder:
         app.config.setdefault("APP_ICON", "")
         app.config.setdefault("LANGUAGES", {"en": {"flag": "gb", "name": "English"}})
         app.config.setdefault("ADDON_MANAGERS", [])
+        app.config.setdefault("RATELIMIT_ENABLED", False)
         app.config.setdefault("FAB_API_MAX_PAGE_SIZE", 100)
         app.config.setdefault("FAB_BASE_TEMPLATE", self.base_template)
         app.config.setdefault("FAB_STATIC_FOLDER", self.static_folder)
@@ -171,9 +172,7 @@ class AppBuilder:
 
         self.base_template = app.config.get("FAB_BASE_TEMPLATE", self.base_template)
         self.static_folder = app.config.get("FAB_STATIC_FOLDER", self.static_folder)
-        self.static_url_path = app.config.get(
-            "FAB_STATIC_URL_PATH", self.static_url_path
-        )
+        self.static_url_path = app.config.get("FAB_STATIC_URL_PATH", self.static_url_path)
         _index_view = app.config.get("FAB_INDEX_VIEW", None)
         if _index_view:
             self.indexview = dynamic_class_import(_index_view)  # type: ignore
@@ -192,9 +191,7 @@ class AppBuilder:
 
         if self.update_perms:  # default is True, if False takes precedence from config
             self.update_perms = app.config.get("FAB_UPDATE_PERMS", True)
-        _security_manager_class_name = app.config.get(
-            "FAB_SECURITY_MANAGER_CLASS", None
-        )
+        _security_manager_class_name = app.config.get("FAB_SECURITY_MANAGER_CLASS", None)
         if _security_manager_class_name is not None:
             security_manager_class = dynamic_class_import(_security_manager_class_name)
             self.security_manager_class = cast(
@@ -633,9 +630,7 @@ class AppBuilder:
     def get_url_for_index(self) -> str:
         if self._indexview is None:
             return ""
-        return url_for(
-            "%s.%s" % (self._indexview.endpoint, self._indexview.default_view)
-        )
+        return url_for("%s.%s" % (self._indexview.endpoint, self._indexview.default_view))
 
     @property
     def get_url_for_userinfo(self) -> str:

--- a/flask_appbuilder/base.py
+++ b/flask_appbuilder/base.py
@@ -172,7 +172,9 @@ class AppBuilder:
 
         self.base_template = app.config.get("FAB_BASE_TEMPLATE", self.base_template)
         self.static_folder = app.config.get("FAB_STATIC_FOLDER", self.static_folder)
-        self.static_url_path = app.config.get("FAB_STATIC_URL_PATH", self.static_url_path)
+        self.static_url_path = app.config.get(
+            "FAB_STATIC_URL_PATH", self.static_url_path
+        )
         _index_view = app.config.get("FAB_INDEX_VIEW", None)
         if _index_view:
             self.indexview = dynamic_class_import(_index_view)  # type: ignore
@@ -191,7 +193,9 @@ class AppBuilder:
 
         if self.update_perms:  # default is True, if False takes precedence from config
             self.update_perms = app.config.get("FAB_UPDATE_PERMS", True)
-        _security_manager_class_name = app.config.get("FAB_SECURITY_MANAGER_CLASS", None)
+        _security_manager_class_name = app.config.get(
+            "FAB_SECURITY_MANAGER_CLASS", None
+        )
         if _security_manager_class_name is not None:
             security_manager_class = dynamic_class_import(_security_manager_class_name)
             self.security_manager_class = cast(
@@ -630,7 +634,9 @@ class AppBuilder:
     def get_url_for_index(self) -> str:
         if self._indexview is None:
             return ""
-        return url_for("%s.%s" % (self._indexview.endpoint, self._indexview.default_view))
+        return url_for(
+            "%s.%s" % (self._indexview.endpoint, self._indexview.default_view)
+        )
 
     @property
     def get_url_for_userinfo(self) -> str:

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -258,7 +258,7 @@ class BaseSecurityManager(AbstractSecurityManager):
             app.config.setdefault("AUTH_LDAP_EMAIL_FIELD", "mail")
 
         # Rate limiting
-        app.config.setdefault("AUTH_RATE_LIMITED", True)
+        app.config.setdefault("AUTH_RATE_LIMITED", False)
         app.config.setdefault("AUTH_RATE_LIMIT", "10 per 20 second")
 
         if self.auth_type == AUTH_OID:

--- a/flask_appbuilder/tests/config_api.py
+++ b/flask_appbuilder/tests/config_api.py
@@ -18,5 +18,3 @@ FAB_ROLES = {
         [".*", "can_show"],
     ]
 }
-
-RATELIMIT_ENABLED = False

--- a/flask_appbuilder/tests/config_oauth.py
+++ b/flask_appbuilder/tests/config_oauth.py
@@ -34,5 +34,3 @@ AUTH_USER_REGISTRATION = True
 
 # The default user self registration role for all users
 AUTH_USER_REGISTRATION_ROLE = "Admin"
-
-RATELIMIT_ENABLED = False

--- a/flask_appbuilder/tests/config_security.py
+++ b/flask_appbuilder/tests/config_security.py
@@ -15,4 +15,3 @@ FAB_ROLES = {
     "FAB_ROLE1": [["Model1View", "can_list"], ["Model2View", "can_list"]],
     "FAB_ROLE2": [["Model3View", "can_list"], ["Model4View", "can_list"]],
 }
-RATELIMIT_ENABLED = False

--- a/flask_appbuilder/tests/config_security_api.py
+++ b/flask_appbuilder/tests/config_security_api.py
@@ -20,4 +20,3 @@ FAB_ROLES = {
         [".*", "can_show"],
     ]
 }
-RATELIMIT_ENABLED = False

--- a/flask_appbuilder/tests/security/test_rate_limiter.py
+++ b/flask_appbuilder/tests/security/test_rate_limiter.py
@@ -17,6 +17,7 @@ class LimiterTestCase(FABTestCase):
         self.app.jinja_env.undefined = jinja2.StrictUndefined
         self.app.config.from_object("flask_appbuilder.tests.config_api")
         self.app.config["RATELIMIT_ENABLED"] = True
+        self.app.config["AUTH_RATE_LIMITED"] = True
         self.app.config["AUTH_RATE_LIMIT"] = "2 per 5 second"
         logging.basicConfig(level=logging.ERROR)
 


### PR DESCRIPTION
### Description

Disable auth rate limiting by default, will break dependencies unit tests and integration tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
