### PR TITLE
fix: using base_filters with FilterEqualFunction not working for relation fields

### DIFF
--- a/examples/extendsecurity/testdata.py
+++ b/examples/extendsecurity/testdata.py
@@ -2,8 +2,8 @@ from datetime import datetime
 import logging
 import random
 
-from .app import appbuilder, db, create_app
-from .app.models import ContactGroup, Gender, Contact, Company
+from app import appbuilder, db, create_app
+from app.models import ContactGroup, Gender, Contact, Company
 
 
 log = logging.getLogger(__name__)

--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -345,7 +345,9 @@ class SQLAInterface(BaseInterface):
                     _filters.append((flt.column_name, flt.__class__, value))
                 elif self.is_relation_many_to_one(
                     get_column_root_relation(flt.column_name)
-                ) or self.is_relation_one_to_one(get_column_root_relation(flt.column_name)):
+                ) or self.is_relation_one_to_one(
+                    get_column_root_relation(flt.column_name)
+                ):
                     _filters.append((flt.column_name, flt.__class__, value))
             inner_filters.add_filter_list(_filters)
         return inner_filters

--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -344,8 +344,8 @@ class SQLAInterface(BaseInterface):
                 if not is_column_dotted(flt.column_name):
                     _filters.append((flt.column_name, flt.__class__, value))
                 elif self.is_relation_many_to_one(
-                    flt.column_name
-                ) or self.is_relation_one_to_one(flt.column_name):
+                    get_column_root_relation(flt.column_name)
+                ) or self.is_relation_one_to_one(get_column_root_relation(flt.column_name)):
                     _filters.append((flt.column_name, flt.__class__, value))
             inner_filters.add_filter_list(_filters)
         return inner_filters

--- a/flask_appbuilder/tests/test_mvc.py
+++ b/flask_appbuilder/tests/test_mvc.py
@@ -744,7 +744,7 @@ class MVCTestCase(BaseMVCTestCase):
         """
         Test views creation and registration
         """
-        self.assertEqual(len(self.appbuilder.baseviews), 37)
+        self.assertEqual(len(self.appbuilder.baseviews), 38)
 
     def test_back(self):
         """

--- a/flask_appbuilder/tests/test_mvc.py
+++ b/flask_appbuilder/tests/test_mvc.py
@@ -19,7 +19,11 @@ from flask_appbuilder.models.generic import PSModel
 from flask_appbuilder.models.generic import PSSession
 from flask_appbuilder.models.generic.interface import GenericInterface
 from flask_appbuilder.models.group import aggregate_avg, aggregate_count, aggregate_sum
-from flask_appbuilder.models.sqla.filters import FilterEqual, FilterStartsWith, FilterEqualFunction
+from flask_appbuilder.models.sqla.filters import (
+    FilterEqual,
+    FilterStartsWith,
+    FilterEqualFunction,
+)
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.views import CompactCRUDMixin, MasterDetailView, ModelView
 from flask_wtf import CSRFProtect
@@ -567,14 +571,24 @@ class MVCTestCase(BaseMVCTestCase):
             base_filters = [["field_integer", FilterEqual, 0]]
 
         def get_model1_by_name(datamodel, name):
-            model = datamodel.session.query(Model1) \
-            .filter_by(field_string=name) \
-            .one_or_none()
+            model = (
+                datamodel.session.query(Model1)
+                .filter_by(field_string=name)
+                .one_or_none()
+            )
             return model
-        
+
         class Model2FilterEqualFunctionView(ModelView):
             datamodel = SQLAInterface(Model2)
-            base_filters = [["group", FilterEqualFunction, lambda: get_model1_by_name(Model2FilterEqualFunctionView.datamodel,"test1")]]
+            base_filters = [
+                [
+                    "group",
+                    FilterEqualFunction,
+                    lambda: get_model1_by_name(
+                        Model2FilterEqualFunctionView.datamodel, "test1"
+                    ),
+                ]
+            ]
             list_columns = ["group"]
             search_columns = ["field_integer"]
 
@@ -681,7 +695,9 @@ class MVCTestCase(BaseMVCTestCase):
             Model1Filtered2View, "Model1Filtered2", category="Model1"
         )
         self.appbuilder.add_view(
-            Model2FilterEqualFunctionView, "Model2FilterEqualFunction", category="Model2"
+            Model2FilterEqualFunctionView,
+            "Model2FilterEqualFunction",
+            category="Model2",
         )
         self.appbuilder.add_view(
             Model1FormattedView, "Model1FormattedView", category="Model1FormattedView"
@@ -1330,7 +1346,7 @@ class MVCTestCase(BaseMVCTestCase):
         """
         client = self.app.test_client()
         self.browser_login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
-        
+
         # Base filter string starts with
         rv = client.get("/model2filterequalfunctionview/list/")
         self.assertEqual(rv.status_code, 200)
@@ -1338,8 +1354,7 @@ class MVCTestCase(BaseMVCTestCase):
         self.assertIn("test1", data)
         self.assertNotIn("test0", data)
         self.assertNotIn("test2", data)
-        
-        
+
     def test_model_list_method_field(self):
         """
         Tests a model's field has a method

--- a/flask_appbuilder/tests/test_mvc.py
+++ b/flask_appbuilder/tests/test_mvc.py
@@ -19,7 +19,7 @@ from flask_appbuilder.models.generic import PSModel
 from flask_appbuilder.models.generic import PSSession
 from flask_appbuilder.models.generic.interface import GenericInterface
 from flask_appbuilder.models.group import aggregate_avg, aggregate_count, aggregate_sum
-from flask_appbuilder.models.sqla.filters import FilterEqual, FilterStartsWith
+from flask_appbuilder.models.sqla.filters import FilterEqual, FilterStartsWith, FilterEqualFunction
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.views import CompactCRUDMixin, MasterDetailView, ModelView
 from flask_wtf import CSRFProtect
@@ -566,6 +566,18 @@ class MVCTestCase(BaseMVCTestCase):
             datamodel = SQLAInterface(Model1)
             base_filters = [["field_integer", FilterEqual, 0]]
 
+        def get_model1_by_name(datamodel, name):
+            model = datamodel.session.query(Model1) \
+            .filter_by(field_string=name) \
+            .one_or_none()
+            return model
+        
+        class Model2FilterEqualFunctionView(ModelView):
+            datamodel = SQLAInterface(Model2)
+            base_filters = [["group", FilterEqualFunction, lambda: get_model1_by_name(Model2FilterEqualFunctionView.datamodel,"test1")]]
+            list_columns = ["group"]
+            search_columns = ["field_integer"]
+
         class Model2ChartView(ChartView):
             datamodel = SQLAInterface(Model2)
             chart_title = "Test Model1 Chart"
@@ -667,6 +679,9 @@ class MVCTestCase(BaseMVCTestCase):
         )
         self.appbuilder.add_view(
             Model1Filtered2View, "Model1Filtered2", category="Model1"
+        )
+        self.appbuilder.add_view(
+            Model2FilterEqualFunctionView, "Model2FilterEqualFunction", category="Model2"
         )
         self.appbuilder.add_view(
             Model1FormattedView, "Model1FormattedView", category="Model1FormattedView"
@@ -1309,6 +1324,22 @@ class MVCTestCase(BaseMVCTestCase):
         self.assertIn("test0", data)
         self.assertNotIn("test1", data)
 
+    def test_filterequalfunction_with_relation(self):
+        """
+        Test FilterEqualFunction
+        """
+        client = self.app.test_client()
+        self.browser_login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
+        
+        # Base filter string starts with
+        rv = client.get("/model2filterequalfunctionview/list/")
+        self.assertEqual(rv.status_code, 200)
+        data = rv.data.decode("utf-8")
+        self.assertIn("test1", data)
+        self.assertNotIn("test0", data)
+        self.assertNotIn("test2", data)
+        
+        
     def test_model_list_method_field(self):
         """
         Tests a model's field has a method

--- a/flask_appbuilder/tests/test_mvc.py
+++ b/flask_appbuilder/tests/test_mvc.py
@@ -21,8 +21,8 @@ from flask_appbuilder.models.generic.interface import GenericInterface
 from flask_appbuilder.models.group import aggregate_avg, aggregate_count, aggregate_sum
 from flask_appbuilder.models.sqla.filters import (
     FilterEqual,
-    FilterStartsWith,
     FilterEqualFunction,
+    FilterStartsWith,
 )
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_appbuilder.views import CompactCRUDMixin, MasterDetailView, ModelView


### PR DESCRIPTION
Description:
### issue #1745

<!--- Describe the change below, including rationale and design decisions -->

ADDITIONAL INFORMATION

Has associated issue:
- [x] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature