### PR TITLE
added comma - from apispec[yaml]>=1.1.1<2 to apispec[yaml]>=1.1.1,<2…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     install_requires=[
         'colorama>=0.3.9,<1',
         'click>=6.7,<8',
-        'apispec[yaml]>=1.1.1<2',
+        'apispec[yaml]>=1.1.1,<2',
         'Flask>=0.12,<2',
         'Flask-Babel>=0.11.1,<1',
         'Flask-Login>=0.3,<0.5',


### PR DESCRIPTION
… in setup.py file


<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

setup.py file have a missing comma in the install_requires var with 'apispec[yaml]>=1.1.1<2',. This line has been modified to 'apispec[yaml]>=1.1.1,<2'. Airflow older version puckle/docker-airflow 10.6 have a dependency from flask-appbuilder which installs as a subprocess from 1.13.1 version. So, this is required to be fixed as the dependency is failing the setup.


