### PR TITLE
chore: remove marshmallow_enum

### DIFF
--- a/flask_appbuilder/api/convert.py
+++ b/flask_appbuilder/api/convert.py
@@ -132,7 +132,9 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
         enum_class = datamodel.list_columns[column.data].info.get(
             "enum_class", datamodel.list_columns[column.data].type
         )
-        field = fields.Enum(enum_class, by_value=not enum_dump_by_name, required=required)
+        field = fields.Enum(
+            enum_class, by_value=not enum_dump_by_name, required=required
+        )
         field.unique = datamodel.is_unique(column.data)
         return field
 

--- a/flask_appbuilder/api/convert.py
+++ b/flask_appbuilder/api/convert.py
@@ -4,7 +4,6 @@ from flask_appbuilder.models.sqla import Model
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from marshmallow import fields
 from marshmallow.fields import Field
-from marshmallow_enum import EnumField
 from marshmallow_sqlalchemy import field_for
 from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
 
@@ -133,11 +132,7 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
         enum_class = datamodel.list_columns[column.data].info.get(
             "enum_class", datamodel.list_columns[column.data].type
         )
-        if enum_dump_by_name:
-            enum_dump_by = EnumField.NAME
-        else:
-            enum_dump_by = EnumField.VALUE
-        field = EnumField(enum_class, dump_by=enum_dump_by, required=required)
+        field = fields.Enum(enum_class, by_value=not enum_dump_by_name, required=required)
         field.unique = datamodel.is_unique(column.data)
         return field
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,13 +63,11 @@ markupsafe==2.1.1
     # via
     #   jinja2
     #   wtforms
-marshmallow==3.15.0
+marshmallow==3.19.0
     # via
     #   Flask-AppBuilder (setup.py)
     #   marshmallow-enum
     #   marshmallow-sqlalchemy
-marshmallow-enum==1.5.1
-    # via Flask-AppBuilder (setup.py)
 marshmallow-sqlalchemy==0.26.1
     # via Flask-AppBuilder (setup.py)
 ordered-set==4.1.0

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
         "Flask-JWT-Extended>=4.0.0, <5.0.0",
         "jsonschema>=3, <5",
         "marshmallow>=3, <4",
-        "marshmallow-enum>=1.5.1, <2",
         "marshmallow-sqlalchemy>=0.22.0, <0.27.0",
         "python-dateutil>=2.3, <3",
         "prison>=0.2.1, <1.0.0",


### PR DESCRIPTION
### Description
In releae 3.18.0 marshmallow [added native Enum](https://github.com/marshmallow-code/marshmallow/blob/dev/CHANGELOG.rst#3180-2022-09-15) support. The package "[marshmallow_enum](https://github.com/justanr/marshmallow_enum)" is archived.
This PR uses marshmallow `Enum` field instead of marshmallow_enum `EnumField` and removes the dependency.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
