### PR TITLE
fix: select2-ajax-widget

### DIFF
--- a/examples/related_fields/app/views.py
+++ b/examples/related_fields/app/views.py
@@ -111,7 +111,7 @@ class ContactModelView(ModelView):
             col_name="contact_sub_group",
             widget=Select2SlaveAJAXWidget(
                 master_id="contact_group",
-                endpoint="/contactmodelview/api/column/add/contact_sub_group?_flt_0_contact_group_id={{ID}}",
+                endpoint="/contactmodelview/api/column/add/contact_sub_group?_flt_0_contact_group={{ID}}",
             ),
         ),
         "contact_group2": AJAXSelectField(
@@ -130,7 +130,7 @@ class ContactModelView(ModelView):
             col_name="contact_sub_group2",
             widget=Select2SlaveAJAXWidget(
                 master_id="contact_group2",
-                endpoint="/contactmodelview/api/column/add/contact_sub_group2?_flt_0_contact_group2_id={{ID}}",
+                endpoint="/contactmodelview/api/column/add/contact_sub_group2?_flt_0_contact_group2={{ID}}",
             ),
         ),
     }

--- a/flask_appbuilder/static/appbuilder/js/ab.js
+++ b/flask_appbuilder/static/appbuilder/js/ab.js
@@ -6,6 +6,7 @@ function loadSelectDataSlave(elem) {
         var elem = $(this);
         var master_id = elem.attr('master_id');
         var master_val = $('#' + master_id).val();
+​
         if (master_val) {
             var endpoint = elem.attr('endpoint');
             endpoint = endpoint.replace("{{ID}}", master_val);
@@ -16,10 +17,13 @@ function loadSelectDataSlave(elem) {
         else {
             elem.select2({data: {id: "",text: ""}, placeholder: "Select", allowClear: true});
         }
+​
         $('#' + master_id).on("change", function(e) {
+            var change_master_id = elem.attr('master_id');
+            var change_master_val = $('#' + master_id).val();
             var endpoint = elem.attr('endpoint');
-            if (e.val) {
-                endpoint = endpoint.replace("{{ID}}", e.val);
+            if (change_master_val) {
+                endpoint = endpoint.replace("{{ID}}", change_master_val);
                 $.get( endpoint, function( data ) {
                     elem.select2({data: data, placeholder: "Select", allowClear: true});
                 });


### PR DESCRIPTION

### Description

We discovered bug at releated_fields example. Select2SlaveAJAXWidget was not populated correctly to slave dropdown when master dropdown has changed. We discovered that related bug causes from `e.val` is undefined. I fixed the function `loadSelectDataSlave`, also my colleague (@ozanonurtek) fixed the example endpoint. 

### ADDITIONAL INFORMATION
- [x] New discovered bug

