### PR TITLE
fix: Double escaping for next param in login with oauth

### DIFF
--- a/flask_appbuilder/templates/appbuilder/general/security/login_oauth.html
+++ b/flask_appbuilder/templates/appbuilder/general/security/login_oauth.html
@@ -6,7 +6,7 @@
 <script type="text/javascript">
     var baseLoginUrl = "{{appbuilder.get_url_for_login}}";
     var baseRegisterUrl = "{{appbuilder.get_url_for_login}}";
-    var next = "?next=" + encodeURIComponent("{{request.args.get('next', '')}}");
+    var next = "?next=" + "{{request.args.get('next', '') | urlencode}}";
 
     function signin(provider) {
         window.location.href = baseLoginUrl + provider + next;

--- a/flask_appbuilder/tests/test_mvc_oauth.py
+++ b/flask_appbuilder/tests/test_mvc_oauth.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote
+
 from flask_appbuilder import SQLA
 from flask_appbuilder.security.sqla.models import User
 from flask_appbuilder.tests.base import FABTestCase
@@ -123,3 +125,17 @@ class APICSRFTestCase(FABTestCase):
                 session["oauth_state"] = "random_state"
         response = client.get(f"/oauth-authorized/google?state={state}")
         self.assertEqual(response.location, "/")
+
+    def test_oauth_next_login_param(self):
+        """
+        OAuth: Test next quoted next_url param
+        """
+        self.appbuilder.sm.oauth_remotes = {"google": OAuthRemoteMock()}
+
+        next_url = "http://localhost/data?param1=1&param2=2&param3="
+        with self.app.test_client() as client:
+            # use quote function to reproduce redirect to login
+            response = client.get(
+                f"/login/?next={quote(next_url)}", follow_redirects=True
+            )
+            self.assertTrue(quote(next_url) in response.text)


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

Since next parameter shouldn't be used with `safe` Jinja filter (see https://github.com/dpgaspar/Flask-AppBuilder/pull/1978), to avoid double escaping we can use Jinja's `urlencode`. Also, it might be clearer to work with this parameter in the related libraries, no need to double unquote the url.

cc @gschuurman 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [x] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
