### PR TITLE
fix: broken link to config.py template

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -343,7 +343,7 @@ Next you only have to import them to the Flask app object, like this
     app = Flask(__name__)
     app.config.from_object('config')
 
-Take a look at the skeleton `config.py <https://github.com/dpgaspar/Flask-AppBuilder-Skeleton/blob/master/config.py>`_
+Take a look at the skeleton `config.py <https://github.com/dpgaspar/Flask-AppBuilder-Skeleton/blob/master/config.py.tpl>`_
 
 
 .. _jmespath-examples:


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

<!--- Describe the change below, including rationale and design decisions -->
File config.py in Flask-AppBuilder-Skeleton has been renamed to [config.py.tpl](https://github.com/dpgaspar/Flask-AppBuilder-Skeleton/blob/master/config.py.tpl) and link to it in docs is broken now.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [X] Has associated issue: #2057 
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
