### PR TITLE
fix: marshmallow enum by value keep compatibility

### DIFF
--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -1485,18 +1485,22 @@ Enum Fields
 ``ModelRestApi`` offers support for **Enum** fields, you have to declare them
 on a specific way::
 
-    class GenderEnum(enum.Enum):
-        male = 'Male'
-        female = 'Female'
+    class BookType(enum.Enum):
+        HARDCOVER = 1
+        PAPERBACK = 2
+        EBOOK = 3
 
 
-    class Contact(Model):
+    class Book(Model):
         id = Column(Integer, primary_key=True)
-        name = Column(String(150), unique=True, nullable=False)
-        address = Column(String(564))
-        birthday = Column(Date, nullable=True)
-        personal_phone = Column(String(20))
-        personal_celphone = Column(String(20))
-        contact_group_id = Column(Integer, ForeignKey('contact_group.id'), nullable=False)
-        contact_group = relationship("ContactGroup")
-        gender = Column(Enum(GenderEnum), nullable=False)
+        title = Column(String(150), unique=True, nullable=False)
+        type = Column(Enum(BookType), nullable=False)
+
+Default marshmallow behaviour for enums is to return the value of the enum, in this case an integer.
+If you want to return the string representation of the enum you can set this behaviour at the Model definition::
+
+    class Book(Model):
+        id = Column(Integer, primary_key=True)
+        title = Column(String(150), unique=True, nullable=False)
+        type = Column(Enum(BookType), nullable=False, info={"marshmallow_enum": {"by_value": False}})
+

--- a/examples/crud_rest_api/app/models.py
+++ b/examples/crud_rest_api/app/models.py
@@ -17,8 +17,8 @@ class ContactGroup(Model):
 
 
 class Gender(enum.Enum):
-    Female = "Female"
-    Male = "Male"
+    Female = 1
+    Male = 2
 
 
 class Contact(Model):
@@ -30,7 +30,7 @@ class Contact(Model):
     personal_celphone = Column(String(20))
     contact_group_id = Column(Integer, ForeignKey("contact_group.id"), nullable=False)
     contact_group = relationship("ContactGroup")
-    gender = Column(Enum(Gender))
+    gender = Column(Enum(Gender), info={"marshmallow_by_value": False})
 
     def __repr__(self):
         return self.name

--- a/flask_appbuilder/api/convert.py
+++ b/flask_appbuilder/api/convert.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Type, TypedDict, Union
+from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 from flask_appbuilder.models.sqla import Model
 from flask_appbuilder.models.sqla.interface import SQLAInterface
@@ -6,10 +6,6 @@ from marshmallow import fields, Schema
 from marshmallow.fields import Field
 from marshmallow_sqlalchemy import field_for
 from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
-
-
-class MarshmallowFieldOptions(TypedDict):
-    marshmallow_by_value: Union[bool, Field]
 
 
 class TreeNode:
@@ -149,7 +145,7 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
         required = not datamodel.is_nullable(column.name)
         sqla_column = datamodel.list_columns[column.name]
         # get SQLAlchemy column user info, we use it to get the marshmallow enum options
-        column_info: MarshmallowFieldOptions = sqla_column.info
+        column_info = sqla_column.info
         # TODO: Default should be False, but keeping this to True to keep compatibility
         # Turn this to False in the next major release
         by_value = column_info.get("marshmallow_by_value", True)

--- a/flask_appbuilder/api/convert.py
+++ b/flask_appbuilder/api/convert.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Type
 
 from flask_appbuilder.models.sqla import Model
 from flask_appbuilder.models.sqla.interface import SQLAInterface

--- a/flask_appbuilder/tests/sqla/models.py
+++ b/flask_appbuilder/tests/sqla/models.py
@@ -105,7 +105,7 @@ class ModelWithProperty(Model):
 
 
 class TmpEnum(enum.Enum):
-    e1 = "a"
+    e1 = 1
     e2 = 2
     e3 = 3
 
@@ -114,6 +114,7 @@ class ModelWithEnums(Model):
     id = Column(Integer, primary_key=True)
     enum1 = Column(Enum("e1", "e2", "e3", "e4", name="enum1"))
     enum2 = Column(Enum(TmpEnum))
+    enum3 = Column(Enum(TmpEnum), info={"marshmallow_by_value": False})
 
 
 assoc_parent_child = Table(
@@ -281,6 +282,7 @@ def insert_data(session, count):
     model = ModelWithEnums()
     model.enum1 = "e1"
     model.enum2 = TmpEnum.e2
+    model.enum3 = TmpEnum.e3.name
     session.add(model)
     session.commit()
 

--- a/flask_appbuilder/tests/test_api.py
+++ b/flask_appbuilder/tests/test_api.py
@@ -2639,7 +2639,7 @@ class APITestCase(FABTestCase):
         rv = self.auth_client_get(client, token, uri)
         data = json.loads(rv.data.decode("utf-8"))
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(data["result"], [{"enum1": "e1", "enum2": "e2"}])
+        self.assertEqual(data["result"], [{"enum1": "e1", "enum2": 2, "enum3": "e3"}])
         self.assertEqual(data["count"], 1)
 
     def test_get_item_with_enums(self):
@@ -2658,7 +2658,7 @@ class APITestCase(FABTestCase):
         rv = self.auth_client_get(client, token, uri)
         data = json.loads(rv.data.decode("utf-8"))
         self.assertEqual(rv.status_code, 200)
-        self.assertEqual(data["result"], {"enum1": "e1", "enum2": "e2"})
+        self.assertEqual(data["result"], {"enum1": "e1", "enum2": 2, "enum3": "e3"})
 
     def test_model_with_enum_oas(self):
         """
@@ -2677,7 +2677,8 @@ class APITestCase(FABTestCase):
                     "maxLength": 2,
                     "nullable": True,
                 },
-                "enum2": {"enum": ["e1", "e2", "e3"], "type": "string"},
+                "enum2": {"enum": [1, 2, 3]},
+                "enum3": {"enum": ["e1", "e2", "e3"], "type": "string"},
             },
             "type": "object",
         }
@@ -2695,7 +2696,7 @@ class APITestCase(FABTestCase):
         """
         client = self.app.test_client()
         token = self.login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
-        item = dict(enum1="e1", enum2="e1")
+        item = dict(enum1="e1", enum2=1)
         uri = "api/v1/modelwithenumsapi/"
         rv = self.auth_client_post(client, token, uri, item)
         data = json.loads(rv.data.decode("utf-8"))
@@ -2721,7 +2722,7 @@ class APITestCase(FABTestCase):
         rv = self.auth_client_post(client, token, uri, item)
         data = json.loads(rv.data.decode("utf-8"))
         self.assertEqual(rv.status_code, 422)
-        self.assertEqual(data, {"message": {"enum2": ["Must be one of: e1, e2, e3."]}})
+        self.assertEqual(data, {"message": {"enum2": ["Must be one of: 1, 2, 3."]}})
 
     def test_create_item_with_enum_inline_validation(self):
         """

--- a/flask_appbuilder/tests/test_mvc.py
+++ b/flask_appbuilder/tests/test_mvc.py
@@ -571,7 +571,9 @@ class MVCTestCase(BaseMVCTestCase):
 
         def get_model1_by_name(datamodel, name):
             model = (
-                datamodel.session.query(Model1).filter_by(field_string=name).one_or_none()
+                datamodel.session.query(Model1)
+                .filter_by(field_string=name)
+                .one_or_none()
             )
             return model
 
@@ -944,7 +946,9 @@ class MVCTestCase(BaseMVCTestCase):
         )
 
         self.assertEqual(rv.status_code, 200)
-        model = self.appbuilder.get_session.query(Model3).filter_by(pk1="1").one_or_none()
+        model = (
+            self.appbuilder.get_session.query(Model3).filter_by(pk1="1").one_or_none()
+        )
         self.assertEqual(model.pk1, 1)
         self.assertEqual(model.pk2, datetime.datetime(2017, 1, 1))
         self.assertEqual(model.field_string, "foo2")
@@ -1100,7 +1104,10 @@ class MVCTestCase(BaseMVCTestCase):
         client = self.app.test_client()
         self.browser_login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
         model_id = (
-            self.db.session.query(Model1).filter_by(field_string="test0").one_or_none().id
+            self.db.session.query(Model1)
+            .filter_by(field_string="test0")
+            .one_or_none()
+            .id
         )
         rv = client.post(
             f"/model1viewwithredirects/edit/{model_id}",
@@ -1498,7 +1505,9 @@ class MVCTestCase(BaseMVCTestCase):
             follow_redirects=True,
         )
         self.assertEqual(rv.status_code, 200)
-        model1 = self.db.session.query(Model1).filter_by(field_string="zzz").one_or_none()
+        model1 = (
+            self.db.session.query(Model1).filter_by(field_string="zzz").one_or_none()
+        )
         self.assertIsNotNone(model1)
 
         # Revert data changes

--- a/flask_appbuilder/tests/test_mvc.py
+++ b/flask_appbuilder/tests/test_mvc.py
@@ -571,9 +571,7 @@ class MVCTestCase(BaseMVCTestCase):
 
         def get_model1_by_name(datamodel, name):
             model = (
-                datamodel.session.query(Model1)
-                .filter_by(field_string=name)
-                .one_or_none()
+                datamodel.session.query(Model1).filter_by(field_string=name).one_or_none()
             )
             return model
 
@@ -946,9 +944,7 @@ class MVCTestCase(BaseMVCTestCase):
         )
 
         self.assertEqual(rv.status_code, 200)
-        model = (
-            self.appbuilder.get_session.query(Model3).filter_by(pk1="1").one_or_none()
-        )
+        model = self.appbuilder.get_session.query(Model3).filter_by(pk1="1").one_or_none()
         self.assertEqual(model.pk1, 1)
         self.assertEqual(model.pk2, datetime.datetime(2017, 1, 1))
         self.assertEqual(model.field_string, "foo2")
@@ -1013,7 +1009,7 @@ class MVCTestCase(BaseMVCTestCase):
         client = self.app.test_client()
         self.browser_login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
 
-        data = {"enum1": "e3", "enum2": "e3"}
+        data = {"enum1": "e3", "enum2": "e3", "enum3": "e3"}
         rv = client.post("/modelwithenumsview/add", data=data, follow_redirects=True)
         self.assertEqual(rv.status_code, 200)
 
@@ -1104,10 +1100,7 @@ class MVCTestCase(BaseMVCTestCase):
         client = self.app.test_client()
         self.browser_login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
         model_id = (
-            self.db.session.query(Model1)
-            .filter_by(field_string="test0")
-            .one_or_none()
-            .id
+            self.db.session.query(Model1).filter_by(field_string="test0").one_or_none().id
         )
         rv = client.post(
             f"/model1viewwithredirects/edit/{model_id}",
@@ -1505,9 +1498,7 @@ class MVCTestCase(BaseMVCTestCase):
             follow_redirects=True,
         )
         self.assertEqual(rv.status_code, 200)
-        model1 = (
-            self.db.session.query(Model1).filter_by(field_string="zzz").one_or_none()
-        )
+        model1 = self.db.session.query(Model1).filter_by(field_string="zzz").one_or_none()
         self.assertIsNotNone(model1)
 
         # Revert data changes

--- a/flask_appbuilder/tests/test_mvc.py
+++ b/flask_appbuilder/tests/test_mvc.py
@@ -1041,7 +1041,7 @@ class MVCTestCase(BaseMVCTestCase):
         client = self.app.test_client()
         self.browser_login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
 
-        data = {"enum1": "e3", "enum2": "e3"}
+        data = {"enum1": "e3", "enum2": "e3", "enum3": "e3"}
         pk = 1
         rv = client.post(
             f"/modelwithenumsview/edit/{pk}", data=data, follow_redirects=True


### PR DESCRIPTION
### Description

Using default marshmallow Enum by value option is a breaking change for FAB. This PR changes the Enum `by_value` default to True.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
