### PR TITLE
chore: dont add 'tests' package to wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     ),
     long_description=desc(),
     long_description_content_type="text/x-rst",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests*"]),
     package_data={"": ["LICENSE"]},
     entry_points={
         "flask.commands": ["fab=flask_appbuilder.cli:fab"],


### PR DESCRIPTION
in commit 7f194cf, the tests package got moved from within the
'flask_appbuilder' namespace into the root namespace, but the package
was not explicitely excluded from the wheel in setuptools.

As a result, all the FAB tests would get installed into the 'tests'
package namespace during an installation of the FAB 4.3.4 wheel.

Furthermore, if other wheels would also ship modules inside the 'tests'
namespace, these modules would get overidden. Package managers like
`pip` probably wouldn't even notice.

But other package managers (e.g. `dpkg` or `rpm`) will detect such
conflicts and will complain about it loudly and refuse to install
packages with conflicting files.
