### PR TITLE
fix: make deletion in quicktemplates example work again

### DIFF
--- a/examples/quicktemplates/app/templates/mybase.html
+++ b/examples/quicktemplates/app/templates/mybase.html
@@ -8,6 +8,8 @@
 {% endblock %}
 
 {% block body %}
+    {% include 'appbuilder/general/confirm.html' %}
+    {% include 'appbuilder/general/alert.html' %}
     {% set languages = appbuilder.languages %}
     {% set menu = appbuilder.menu %}
 


### PR DESCRIPTION
### Description

if those `include`s are not added, deletion of records is not working in this example

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
