### PR TITLE
fix: MVC form action, broken reset my password

### DIFF
--- a/flask_appbuilder/templates/appbuilder/general/lib.html
+++ b/flask_appbuilder/templates/appbuilder/general/lib.html
@@ -23,7 +23,7 @@
                 <input type="hidden" id="action" name="action" />
             </form>
             <a
-                id="btn-action-{{ endpoint }}"
+                id="btn-action-{{ endpoint }}-{{ action.name }}"
                 href="#"
                 class="btn btn-sm btn-primary"
             >
@@ -32,7 +32,7 @@
             </a>
 
             <script nonce="{{ baselib.get_nonce() }}">
-                document.getElementById("btn-action-{{ endpoint }}")
+                document.getElementById("btn-action-{{ endpoint }}-{{ action.name }}")
                     .addEventListener("click", function () {
                         {% if action.confirmation %}
                             const adminAction = new AdminActions();


### PR DESCRIPTION
### Description

Fix for reported issue: #2086

On user info view, reset my password action is incorrectly redirecting the user to user info view. Caused by https://github.com/dpgaspar/Flask-AppBuilder/pull/2075, both buttons have the same id so the click action get's triggered twice on this specific case reset my password executes twice so the last one will redirect to the second action user info view.

This PR makes the action button ids unique

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
