### PR TITLE
fix: Remove erroring endpoint "/login/<provider>/<register>" from AuthOAut…

### DIFF
--- a/flask_appbuilder/security/views.py
+++ b/flask_appbuilder/security/views.py
@@ -604,7 +604,6 @@ class AuthOAuthView(AuthView):
 
     @expose("/login/")
     @expose("/login/<provider>")
-    @expose("/login/<provider>/<register>")
     def login(self, provider: Optional[str] = None) -> WerkzeugResponse:
         log.debug("Provider: %s", provider)
         if g.user is not None and g.user.is_authenticated:


### PR DESCRIPTION
…hView


<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description
Keyword argument `register` was removed from `AuthOAuthView.login` as part of #1707. However, the endpoint `/login/<provider>/<register>/` is still exposed, resulting in a 500 error whenever it is called:
```
TypeError: AuthOAuthView.login() got an unexpected keyword argument 'register'
```
This PR fixes this error and any calls to that endpoint will properly return a 404 instead.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
