### PR TITLE
fix: respect scale for SQL type NUMERIC

### DIFF
--- a/flask_appbuilder/forms.py
+++ b/flask_appbuilder/forms.py
@@ -48,19 +48,79 @@ class FieldConverter(object):
     """
 
     conversion_table = (
-        ("is_image", ImageUploadField, BS3ImageUploadFieldWidget),
-        ("is_file", FileUploadField, BS3FileUploadFieldWidget),
-        ("is_gridfs_file", MongoFileField, BS3FileUploadFieldWidget),
-        ("is_gridfs_image", MongoImageField, BS3ImageUploadFieldWidget),
-        ("is_text", TextAreaField, BS3TextAreaFieldWidget),
-        ("is_binary", TextAreaField, BS3TextAreaFieldWidget),
-        ("is_string", StringField, BS3TextFieldWidget),
-        ("is_integer", IntegerField, BS3TextFieldWidget),
-        ("is_numeric", DecimalField, BS3TextFieldWidget),
-        ("is_float", FloatField, BS3TextFieldWidget),
-        ("is_boolean", BooleanField, None),
-        ("is_date", DateField, DatePickerWidget),
-        ("is_datetime", DateTimeField, DateTimePickerWidget),
+        # sqlalchemy.types.Enum inherits from String, therefore `is_enum` must be
+        # checked before checking for `is_string`:
+        ("is_enum", lambda conv, col_type : EnumField(conv.label,
+            enums=col_type.enums,
+            description=conv.description,
+            validators=conv.validators,
+            widget=BS3ImageUploadFieldWidget(),
+            default=conv.default)),
+        ("is_image", lambda conv, _ : ImageUploadField(conv.label,
+            description=conv.description,
+            validators=conv.validators,
+            widget=BS3ImageUploadFieldWidget(),
+            default=conv.default)),
+        ("is_file", lambda conv, _ : FileUploadField(conv.label,
+            description=conv.description,
+            validators=conv.validators,
+            widget=BS3FileUploadFieldWidget(),
+            default=conv.default)),
+        ("is_gridfs_file", lambda conv, _ : MongoFileField(conv.label,
+            description=conv.description,
+            validators=conv.validators,
+            widget=BS3FileUploadFieldWidget(),
+            default=conv.default)),
+        ("is_gridfs_image", lambda conv, _ : MongoImageField(conv.label,
+            description=conv.description,
+            validators=conv.validators,
+            widget=BS3ImageUploadFieldWidget(),
+            default=conv.default)),
+        ("is_text", lambda conv, _ : TextAreaField(conv.label,
+            description=conv.description,
+            validators=conv.validators,
+            widget=BS3TextAreaFieldWidget(),
+            default=conv.default)),
+        ("is_binary", lambda conv, _ : TextAreaField(conv.label,
+            description=conv.description,
+            validators=conv.validators,
+            widget=BS3TextAreaFieldWidget(),
+            default=conv.default)),
+        ("is_string", lambda conv, _ : StringField(conv.label,
+            description=conv.description,
+            validators=conv.validators,
+            widget=BS3TextFieldWidget(),
+            default=conv.default)),
+        ("is_integer", lambda conv, _ : IntegerField(conv.label,
+            description=conv.description,
+            validators=conv.validators,
+            widget=BS3TextFieldWidget(),
+            default=conv.default)),
+        ("is_float", lambda conv, _ : FloatField(conv.label,
+            description=conv.description,
+            validators=conv.validators,
+            widget=BS3TextFieldWidget(),
+            default=conv.default)),
+        ("is_numeric", lambda conv, col_type : DecimalField(conv.label,
+            places=col_type.scale,
+            description=conv.description,
+            validators=conv.validators,
+            widget=BS3TextFieldWidget(),
+            default=conv.default)),
+        ("is_boolean", lambda conv, _ : BooleanField(conv.label,
+            description=conv.description,
+            validators=conv.validators,
+            default=conv.default)),
+        ("is_date", lambda conv, _ : DateField(conv.label,
+            description=conv.description,
+            validators=conv.validators,
+            widget=DatePickerWidget(),
+            default=conv.default)),
+        ("is_datetime", lambda conv, _ : DateTimeField(conv.label,
+            description=conv.description,
+            validators=conv.validators,
+            widget=DateTimePickerWidget(),
+            default=conv.default)),
     )
 
     def __init__(
@@ -74,36 +134,10 @@ class FieldConverter(object):
         self.default = default
 
     def convert(self):
-        # sqlalchemy.types.Enum inherits from String, therefore `is_enum` must be
-        # checked before checking for `is_string`:
-        if getattr(self.datamodel, "is_enum")(self.colname):
-            col_type = self.datamodel.list_columns[self.colname].type
-            return EnumField(
-                enum_class=col_type.enum_class,
-                enums=col_type.enums,
-                label=self.label,
-                description=self.description,
-                validators=self.validators,
-                widget=Select2Widget(),
-                default=self.default,
-            )
-        for type_marker, field, widget in self.conversion_table:
+        for type_marker, field in self.conversion_table:
             if getattr(self.datamodel, type_marker)(self.colname):
-                if widget:
-                    return field(
-                        self.label,
-                        description=self.description,
-                        validators=self.validators,
-                        widget=widget(),
-                        default=self.default,
-                    )
-                else:
-                    return field(
-                        self.label,
-                        description=self.description,
-                        validators=self.validators,
-                        default=self.default,
-                    )
+                col_type = self.datamodel.list_columns[self.colname].type
+                return field(self, col_type)
         log.error("Column %s Type not supported", self.colname)
 
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,0 +1,113 @@
+import unittest
+
+from sqlalchemy import (
+    Column,
+    Boolean,
+    Date,
+    DateTime,
+    Enum,
+    Float,
+    Integer,
+    Numeric,
+    String,
+    Text,
+)
+
+from flask_appbuilder.fields import EnumField
+from wtforms import (
+    BooleanField,
+    DateField,
+    DateTimeField,
+    DecimalField,
+    FloatField,
+    IntegerField,
+    StringField,
+    TextAreaField,
+)
+
+from flask_appbuilder.models.sqla.interface import SQLAInterface
+from flask_appbuilder.forms import GeneralModelConverter
+from flask_appbuilder import Model
+
+from flask import Flask
+
+
+class FieldsModel(Model):
+    id = Column(Integer, primary_key=True)
+    field_boolean = Column(Boolean())
+    field_date = Column(Date())
+    field_datetime = Column(DateTime())
+    field_enum = Column(Enum())
+    field_float = Column(Float())
+    field_integer = Column(Integer())
+    field_numeric_scale0 = Column(Numeric())
+    field_numeric_scale2 = Column(Numeric(scale=2))
+    field_numeric_scale4 = Column(Numeric(scale=4))
+    field_string = Column(String(256))
+    field_text = Column(Text)
+
+
+class FlaskTestCase(unittest.TestCase):
+
+    def test_model_without_context(self):
+        datamodel = SQLAInterface(FieldsModel)
+        conv = GeneralModelConverter(datamodel)
+        columns = [
+            "field_boolean",
+            "field_date",
+            "field_datetime",
+            "field_enum",
+            "field_float",
+            "field_integer",
+            "field_numeric_scale0",
+            "field_numeric_scale2",
+            "field_numeric_scale4",
+            "field_string",
+            "field_text",
+        ]
+        form = conv.create_form(None, columns)
+        self.assertTrue(form.field_boolean.field_class is BooleanField)
+        self.assertTrue(form.field_date.field_class is DateField)
+        self.assertTrue(form.field_datetime.field_class is DateTimeField)
+        self.assertTrue(form.field_enum.field_class is EnumField)
+        self.assertTrue(form.field_float.field_class is FloatField)
+        self.assertTrue(form.field_integer.field_class is IntegerField)
+        self.assertTrue(form.field_numeric_scale0.field_class is DecimalField and not form.field_numeric_scale0.kwargs["places"])
+        self.assertTrue(form.field_numeric_scale2.field_class is DecimalField and form.field_numeric_scale2.kwargs["places"] == 2)
+        self.assertTrue(form.field_numeric_scale4.field_class is DecimalField and form.field_numeric_scale4.kwargs["places"] == 4)
+        self.assertTrue(form.field_string.field_class is StringField)
+        self.assertTrue(form.field_text.field_class is TextAreaField)
+
+    def test_model_with_context(self):
+        datamodel = SQLAInterface(FieldsModel)
+        conv = GeneralModelConverter(datamodel)
+        columns = [
+            "field_boolean",
+            "field_date",
+            "field_datetime",
+            "field_enum",
+            "field_float",
+            "field_integer",
+            "field_numeric_scale0",
+            "field_numeric_scale2",
+            "field_numeric_scale4",
+            "field_string",
+            "field_text",
+        ]
+        app = Flask(__name__)
+        app.config["CSRF_ENABLED"] = True
+        app.config["SECRET_KEY"] = "thisismysecretkey"
+        with app.test_request_context():
+            # with app.app_context():
+            form = conv.create_form(None, columns)()
+            self.assertTrue(isinstance(form.field_boolean, BooleanField))
+            self.assertTrue(isinstance(form.field_date, DateField))
+            self.assertTrue(isinstance(form.field_datetime, DateTimeField))
+            self.assertTrue(isinstance(form.field_enum, EnumField))
+            self.assertTrue(isinstance(form.field_float, FloatField))
+            self.assertTrue(isinstance(form.field_integer, IntegerField))
+            self.assertTrue(isinstance(form.field_numeric_scale0, DecimalField) and not form.field_numeric_scale0.places)
+            self.assertTrue(isinstance(form.field_numeric_scale2, DecimalField) and form.field_numeric_scale2.places == 2)
+            self.assertTrue(isinstance(form.field_numeric_scale4, DecimalField) and form.field_numeric_scale4.places == 4)
+            self.assertTrue(isinstance(form.field_string, StringField))
+            self.assertTrue(isinstance(form.field_text, TextAreaField))


### PR DESCRIPTION
### Description

When testing with different SQL numeric types like NUMERIC, NUMERIC(14, 2), NUMERIC(14, 4) we noticed that the views always show two decimal places. This fix respects the SQL schema.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
