### PR TITLE
fix: azure keep using upn if exists

### DIFF
--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -627,7 +627,9 @@ class BaseSecurityManager(AbstractSecurityManager):
             log.debug("User info from Azure: %s", me)
             # https://learn.microsoft.com/en-us/azure/active-directory/develop/id-token-claims-reference#payload-claims
             return {
-                "email": me["email"],
+                # To keep backward compatibility with previous versions
+                # of FAB, we use upn if available, otherwise we use email
+                "email": me["upn"] if "upn" in me else me["email"],
                 "first_name": me.get("given_name", ""),
                 "last_name": me.get("family_name", ""),
                 "username": me["oid"],

--- a/tests/security/test_auth_oauth.py
+++ b/tests/security/test_auth_oauth.py
@@ -480,6 +480,42 @@ class OAuthRegistrationRoleTestCase(unittest.TestCase):
         with self.assertRaises(OAuthProviderUnknown):
             self.appbuilder.sm.oauth_user_info("unknown", {})
 
+    def test_oauth_user_info_azure_email_upn(self):
+        self.appbuilder = AppBuilder(self.app, self.db.session)
+        claims = {
+            "aud": "test-aud",
+            "iss": "https://sts.windows.net/test/",
+            "iat": 7282182129,
+            "nbf": 7282182129,
+            "exp": 1000000000,
+            "amr": ["pwd"],
+            "email": "test@gmail.com",
+            "upn": "test@upn.com",
+            "family_name": "user",
+            "given_name": "test",
+            "idp": "live.com",
+            "name": "Test user",
+            "oid": "b1a54a40-8dfa-4a6d-a2b8-f90b84d4b1df",
+            "unique_name": "live.com#test@gmail.com",
+            "ver": "1.0",
+        }
+
+        # Create an unsigned JWT
+        unsigned_jwt = jwt.encode(claims, key=None, algorithm="none")
+        user_info = self.appbuilder.sm.get_oauth_user_info(
+            "azure", {"access_token": "", "id_token": unsigned_jwt}
+        )
+        self.assertEqual(
+            user_info,
+            {
+                "email": "test@upn.com",
+                "first_name": "test",
+                "last_name": "user",
+                "role_keys": [],
+                "username": "b1a54a40-8dfa-4a6d-a2b8-f90b84d4b1df",
+            },
+        )
+
     def test_oauth_user_info_azure(self):
         self.appbuilder = AppBuilder(self.app, self.db.session)
         claims = {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -961,7 +961,7 @@ class APITestCase(FABTestCase):
         client = self.app.test_client()
         token = self.login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
         with model1_data(self.appbuilder.session, 1):
-            model_id = MODEL1_DATA_SIZE + 1
+            model_id = self.appbuilder.session.query(func.max(Model1.id)).scalar()
             rv = self.auth_client_get(client, token, f"api/v1/model1api/{model_id}")
             self.assertEqual(rv.status_code, 404)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -725,9 +725,7 @@ class APITestCase(FABTestCase):
         self.assertEqual(rv.status_code, 400)
         data = json.loads(rv.data.decode("utf-8"))
         self.assertEqual(data, {"message": "Not a valid rison/json argument"})
-        uri = "api/v1/model1api/1?{}={}".format(
-            API_URI_RIS_KEY, "(columns!(not_valid))"
-        )
+        uri = "api/v1/model1api/1?{}={}".format(API_URI_RIS_KEY, "(columns!(not_valid))")
         rv = self.auth_client_get(client, token, uri)
         self.assertEqual(rv.status_code, 400)
         data = json.loads(rv.data.decode("utf-8"))
@@ -855,9 +853,7 @@ class APITestCase(FABTestCase):
             },
         )
         # test descriptions
-        self.assertEqual(
-            data["description_columns"], self.model1api.description_columns
-        )
+        self.assertEqual(data["description_columns"], self.model1api.description_columns)
         # test labels
         self.assertEqual(
             data[API_LABEL_COLUMNS_RES_KEY],
@@ -961,7 +957,7 @@ class APITestCase(FABTestCase):
         client = self.app.test_client()
         token = self.login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
         with model1_data(self.appbuilder.session, 1):
-            model_id = self.appbuilder.session.query(func.max(Model1.id)).scalar()
+            model_id = self.appbuilder.session.query(func.max(Model1.id)).scalar() + 1
             rv = self.auth_client_get(client, token, f"api/v1/model1api/{model_id}")
             self.assertEqual(rv.status_code, 404)
 
@@ -1186,9 +1182,7 @@ class APITestCase(FABTestCase):
                 {"field_string": child.field_string, "id": child.id}
                 for child in models[0].children
             ]
-            self.assertEqual(
-                data[API_RESULT_RES_KEY][0]["children"], expected_rel_field
-            )
+            self.assertEqual(data[API_RESULT_RES_KEY][0]["children"], expected_rel_field)
 
     def test_get_list_dotted_om_field(self):
         """
@@ -1650,9 +1644,7 @@ class APITestCase(FABTestCase):
             self.assertEqual(data["count"], 2)
 
         parent_ = (
-            session.query(ModelMMParent)
-            .filter_by(field_string="test_tmp")
-            .one_or_none()
+            session.query(ModelMMParent).filter_by(field_string="test_tmp").one_or_none()
         )
         child_ = (
             session.query(ModelMMChild)
@@ -2447,9 +2439,7 @@ class APITestCase(FABTestCase):
             rv = self.auth_client_put(client, token, uri, item)
             self.assertEqual(rv.status_code, 422)
             data = json.loads(rv.data.decode("utf-8"))
-            self.assertEqual(
-                data["message"]["field_integer"][0], "Not a valid integer."
-            )
+            self.assertEqual(data["message"]["field_integer"][0], "Not a valid integer.")
 
             item = dict(field_string=11, field_integer=11, field_float=11.0)
             rv = self.auth_client_put(client, token, uri, item)
@@ -2504,9 +2494,7 @@ class APITestCase(FABTestCase):
             data = json.loads(rv.data.decode("utf-8"))
             self.assertEqual(rv.status_code, 201)
             self.assertEqual(data[API_RESULT_RES_KEY], item)
-            model = (
-                self.db.session.query(Model1).filter_by(field_string="test4").first()
-            )
+            model = self.db.session.query(Model1).filter_by(field_string="test4").first()
             self.assertEqual(model.field_string, "test4")
             self.assertEqual(model.field_integer, 4)
             self.assertEqual(model.field_float, 4.0)
@@ -2717,9 +2705,7 @@ class APITestCase(FABTestCase):
             rv = self.auth_client_get(client, token, uri)
             data = json.loads(rv.data.decode("utf-8"))
             self.assertEqual(rv.status_code, 200)
-            self.assertEqual(
-                data["result"], [{"enum1": "e1", "enum2": 2, "enum3": "e3"}]
-            )
+            self.assertEqual(data["result"], [{"enum1": "e1", "enum2": 2, "enum3": "e3"}])
             self.assertEqual(data["count"], 1)
 
     def test_get_item_with_enums(self):
@@ -3013,9 +2999,7 @@ class APITestCase(FABTestCase):
         role = self.appbuilder.sm.add_role("Test")
         pvm = self.appbuilder.sm.find_permission_view_menu("can_access", "api")
         self.appbuilder.sm.add_permission_role(role, pvm)
-        self.appbuilder.sm.add_user(
-            "test", "test", "user", "test@fab.org", role, "test"
-        )
+        self.appbuilder.sm.add_user("test", "test", "user", "test@fab.org", role, "test")
 
         client = self.app.test_client()
         token = self.login(client, "test", "test")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -725,7 +725,9 @@ class APITestCase(FABTestCase):
         self.assertEqual(rv.status_code, 400)
         data = json.loads(rv.data.decode("utf-8"))
         self.assertEqual(data, {"message": "Not a valid rison/json argument"})
-        uri = "api/v1/model1api/1?{}={}".format(API_URI_RIS_KEY, "(columns!(not_valid))")
+        uri = "api/v1/model1api/1?{}={}".format(
+            API_URI_RIS_KEY, "(columns!(not_valid))"
+        )
         rv = self.auth_client_get(client, token, uri)
         self.assertEqual(rv.status_code, 400)
         data = json.loads(rv.data.decode("utf-8"))
@@ -853,7 +855,9 @@ class APITestCase(FABTestCase):
             },
         )
         # test descriptions
-        self.assertEqual(data["description_columns"], self.model1api.description_columns)
+        self.assertEqual(
+            data["description_columns"], self.model1api.description_columns
+        )
         # test labels
         self.assertEqual(
             data[API_LABEL_COLUMNS_RES_KEY],
@@ -1182,7 +1186,9 @@ class APITestCase(FABTestCase):
                 {"field_string": child.field_string, "id": child.id}
                 for child in models[0].children
             ]
-            self.assertEqual(data[API_RESULT_RES_KEY][0]["children"], expected_rel_field)
+            self.assertEqual(
+                data[API_RESULT_RES_KEY][0]["children"], expected_rel_field
+            )
 
     def test_get_list_dotted_om_field(self):
         """
@@ -1644,7 +1650,9 @@ class APITestCase(FABTestCase):
             self.assertEqual(data["count"], 2)
 
         parent_ = (
-            session.query(ModelMMParent).filter_by(field_string="test_tmp").one_or_none()
+            session.query(ModelMMParent)
+            .filter_by(field_string="test_tmp")
+            .one_or_none()
         )
         child_ = (
             session.query(ModelMMChild)
@@ -2439,7 +2447,9 @@ class APITestCase(FABTestCase):
             rv = self.auth_client_put(client, token, uri, item)
             self.assertEqual(rv.status_code, 422)
             data = json.loads(rv.data.decode("utf-8"))
-            self.assertEqual(data["message"]["field_integer"][0], "Not a valid integer.")
+            self.assertEqual(
+                data["message"]["field_integer"][0], "Not a valid integer."
+            )
 
             item = dict(field_string=11, field_integer=11, field_float=11.0)
             rv = self.auth_client_put(client, token, uri, item)
@@ -2494,7 +2504,9 @@ class APITestCase(FABTestCase):
             data = json.loads(rv.data.decode("utf-8"))
             self.assertEqual(rv.status_code, 201)
             self.assertEqual(data[API_RESULT_RES_KEY], item)
-            model = self.db.session.query(Model1).filter_by(field_string="test4").first()
+            model = (
+                self.db.session.query(Model1).filter_by(field_string="test4").first()
+            )
             self.assertEqual(model.field_string, "test4")
             self.assertEqual(model.field_integer, 4)
             self.assertEqual(model.field_float, 4.0)
@@ -2705,7 +2717,9 @@ class APITestCase(FABTestCase):
             rv = self.auth_client_get(client, token, uri)
             data = json.loads(rv.data.decode("utf-8"))
             self.assertEqual(rv.status_code, 200)
-            self.assertEqual(data["result"], [{"enum1": "e1", "enum2": 2, "enum3": "e3"}])
+            self.assertEqual(
+                data["result"], [{"enum1": "e1", "enum2": 2, "enum3": "e3"}]
+            )
             self.assertEqual(data["count"], 1)
 
     def test_get_item_with_enums(self):
@@ -2999,7 +3013,9 @@ class APITestCase(FABTestCase):
         role = self.appbuilder.sm.add_role("Test")
         pvm = self.appbuilder.sm.find_permission_view_menu("can_access", "api")
         self.appbuilder.sm.add_permission_role(role, pvm)
-        self.appbuilder.sm.add_user("test", "test", "user", "test@fab.org", role, "test")
+        self.appbuilder.sm.add_user(
+            "test", "test", "user", "test@fab.org", role, "test"
+        )
 
         client = self.app.test_client()
         token = self.login(client, "test", "test")


### PR DESCRIPTION
### Description

Keep backward compatibility with Azure, caused by this breaking change: #2121

although `id_token` does not include an `upn` field, it can optionally be included.

 https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference
 
On this change we use `upn` if it exists else use `email`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
