### PR TITLE
fix: conf_password also must required field

### DIFF
--- a/flask_appbuilder/security/forms.py
+++ b/flask_appbuilder/security/forms.py
@@ -60,7 +60,10 @@ class ResetPasswordForm(DynamicForm):
     conf_password = PasswordField(
         lazy_gettext("Confirm Password"),
         description=lazy_gettext("Please rewrite the password to confirm"),
-        validators=[EqualTo("password", message=lazy_gettext("Passwords must match"))],
+        validators=[
+            DataRequired(),
+            EqualTo("password", message=lazy_gettext("Passwords must match")),
+        ],
         widget=BS3PasswordFieldWidget(),
     )
 
@@ -98,7 +101,10 @@ class RegisterUserDBForm(DynamicForm):
     conf_password = PasswordField(
         lazy_gettext("Confirm Password"),
         description=lazy_gettext("Please rewrite the password to confirm"),
-        validators=[EqualTo("password", message=lazy_gettext("Passwords must match"))],
+        validators=[
+            DataRequired(),
+            EqualTo("password", message=lazy_gettext("Passwords must match")),
+        ],
         widget=BS3PasswordFieldWidget(),
     )
     recaptcha = RecaptchaField()


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

<!--- Describe the change below, including rationale and design decisions -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature

In ResetPasswordForm and RegisterUserDBForm field `conf_password` accept empty password. 

`EqualTo` only validated on submit.

So adding `DataRequired()` validator to `conf_password` field.