### PR TITLE
fix: don't load inactive users with sessions

### DIFF
--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -2088,14 +2088,17 @@ class BaseSecurityManager(AbstractSecurityManager):
         raise NotImplementedError
 
     def load_user(self, pk):
-        return self.get_user_by_id(int(pk))
+        user = self.get_user_by_id(int(pk))
+        if user.is_active:
+            return user
 
     def load_user_jwt(self, _jwt_header, jwt_data):
         identity = jwt_data["sub"]
         user = self.load_user(identity)
-        # Set flask g.user to JWT user, we can't do it on before request
-        g.user = user
-        return user
+        if user.is_active:
+            # Set flask g.user to JWT user, we can't do it on before request
+            g.user = user
+            return user
 
     @staticmethod
     def before_request():

--- a/tests/base.py
+++ b/tests/base.py
@@ -14,6 +14,7 @@ from flask_appbuilder.const import (
     API_SECURITY_USERNAME_KEY,
     API_SECURITY_VERSION,
 )
+from flask_appbuilder.security.sqla.models import User
 from hiro import Timeline
 import jinja2
 from tests.const import (
@@ -130,7 +131,7 @@ class FABTestCase(unittest.TestCase):
         last_name="user",
         email="admin@fab.org",
         role_names=None,
-    ):
+    ) -> User:
         user = appbuilder.sm.find_user(username=username)
         if user:
             appbuilder.session.delete(user)

--- a/tests/security/test_mvc_security.py
+++ b/tests/security/test_mvc_security.py
@@ -93,6 +93,34 @@ class MVCSecurityTestCase(BaseMVCTestCase):
         data = rv.data.decode("utf-8")
         self.assertIn(INVALID_LOGIN_STRING, data)
 
+    def test_login_invalid_user(self):
+        """
+        Test Security Login, Logout, invalid login, invalid access
+        """
+        test_username = "testuser"
+        test_password = "password"
+        test_user = self.create_user(
+            self.appbuilder,
+            test_username,
+            test_password,
+            "Admin",
+            "user",
+            "user",
+            "testuser@fab.org",
+        )
+        # Login and list with admin
+        self.browser_login(self.client, test_username, test_password)
+        rv = self.client.get("/model1view/list/")
+        self.assertEqual(rv.status_code, 200)
+
+        # Using the same session make sure the user is not allowed to access when
+        # the user is deactivated
+        test_user.active = False
+        self.db.session.merge(test_user)
+        self.db.session.commit()
+        rv = self.client.get("/model1view/list/")
+        self.assertEqual(rv.status_code, 302)
+
     def test_db_login_no_next_url(self):
         """
         Test Security no next URL

--- a/tests/security/test_mvc_security.py
+++ b/tests/security/test_mvc_security.py
@@ -121,6 +121,9 @@ class MVCSecurityTestCase(BaseMVCTestCase):
         rv = self.client.get("/model1view/list/")
         self.assertEqual(rv.status_code, 302)
 
+        self.db.session.delete(test_user)
+        self.db.session.commit()
+
     def test_db_login_no_next_url(self):
         """
         Test Security no next URL


### PR DESCRIPTION
### Description

Make sure the when a user is made inactive any active sessions are not allowed to login

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
