### PR TITLE
fix: performance issues on user and roles list

### DIFF
--- a/flask_appbuilder/security/sqla/models.py
+++ b/flask_appbuilder/security/sqla/models.py
@@ -61,7 +61,10 @@ class Role(Model):
     id = Column(Integer, Sequence("ab_role_id_seq"), primary_key=True)
     name = Column(String(64), unique=True, nullable=False)
     permissions = relationship(
-        "PermissionView", secondary=assoc_permissionview_role, backref="role"
+        "PermissionView",
+        secondary=assoc_permissionview_role,
+        backref="role",
+        lazy="dynamic",
     )
 
     def __repr__(self):
@@ -73,9 +76,9 @@ class PermissionView(Model):
     __table_args__ = (UniqueConstraint("permission_id", "view_menu_id"),)
     id = Column(Integer, Sequence("ab_permission_view_id_seq"), primary_key=True)
     permission_id = Column(Integer, ForeignKey("ab_permission.id"))
-    permission = relationship("Permission")
+    permission = relationship("Permission", lazy="joined")
     view_menu_id = Column(Integer, ForeignKey("ab_view_menu.id"))
-    view_menu = relationship("ViewMenu")
+    view_menu = relationship("ViewMenu", lazy="joined")
 
     def __repr__(self):
         return str(self.permission).replace("_", " ") + " on " + str(self.view_menu)

--- a/flask_appbuilder/security/sqla/models.py
+++ b/flask_appbuilder/security/sqla/models.py
@@ -64,7 +64,6 @@ class Role(Model):
         "PermissionView",
         secondary=assoc_permissionview_role,
         backref="role",
-        lazy="dynamic",
     )
 
     def __repr__(self):

--- a/flask_appbuilder/security/views.py
+++ b/flask_appbuilder/security/views.py
@@ -224,8 +224,19 @@ class UserModelView(ModelView):
             {"fields": ["first_name", "last_name", "email"], "expanded": True},
         ),
     ]
-
-    search_exclude_columns = ["password"]
+    search_columns = [
+        "first_name",
+        "last_name",
+        "username",
+        "email",
+        "active",
+        "roles",
+        "created_on",
+        "changed_on",
+        "last_login",
+        "login_count",
+        "fail_login_count",
+    ]
 
     add_columns = ["first_name", "last_name", "username", "active", "email", "roles"]
     edit_columns = ["first_name", "last_name", "username", "active", "email", "roles"]

--- a/tests/test_mvc.py
+++ b/tests/test_mvc.py
@@ -109,7 +109,11 @@ class ListFilterTestCase(BaseMVCTestCase):
         class Model1View(ModelView):
             datamodel = SQLAInterface(Model1)
 
+        class Model2View(ModelView):
+            datamodel = SQLAInterface(Model2)
+
         self.appbuilder.add_view(Model1View, "Model1", category="Model1")
+        self.appbuilder.add_view(Model2View, "Model2", category="Model2")
 
     def test_list_filter_starts_with(self):
         """
@@ -181,8 +185,7 @@ class ListFilterTestCase(BaseMVCTestCase):
         with self.app.test_client() as c:
             self.browser_login(c, USERNAME_ADMIN, PASSWORD_ADMIN)
 
-            # Roles doesn't exists
-            rv = c.get("/users/list/?_flt_0_created_by=aaaa", follow_redirects=True)
+            rv = c.get("/model2view/list/?_flt_0_group=aaaa", follow_redirects=True)
             self.assertEqual(rv.status_code, 200)
             if self.db.session.bind.dialect.name != "mysql":
                 data = rv.data.decode("utf-8")
@@ -196,7 +199,7 @@ class ListFilterTestCase(BaseMVCTestCase):
             self.browser_login(c, USERNAME_ADMIN, PASSWORD_ADMIN)
 
             # Roles doesn't exists
-            rv = c.get("/users/list/?_flt_1_created_by=aaaa", follow_redirects=True)
+            rv = c.get("/model2view/list/?_flt_1_group=aaaa", follow_redirects=True)
             self.assertEqual(rv.status_code, 200)
             if self.db.session.bind.dialect.name != "mysql":
                 data = rv.data.decode("utf-8")


### PR DESCRIPTION
### Description

Fixes: #2073

adds lazy joined to permission view model (fixes N+1 issue) and removes `created_by` and `changed_by` from the user list search options so we don't load all users twice on page load.  

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
