### PR TITLE
chore: bump cryptography to 42.0.4

### DIFF
--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -12,7 +12,7 @@ cffi==1.16.0
     # via cryptography
 charset-normalizer==2.0.12
     # via requests
-cryptography==42.0.2
+cryptography==42.0.4
     # via authlib
 cython==0.29.17
     # via -r requirements/extra.in


### PR DESCRIPTION
### Description

chore: bump cryptography to 42.0.4

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
