### PR TITLE
chore: Translate "Sign In with " string into a handful of additional languages (de, es, fr, nl, pt, pt_BR)

### DIFF
--- a/flask_appbuilder/translations/de/LC_MESSAGES/messages.po
+++ b/flask_appbuilder/translations/de/LC_MESSAGES/messages.po
@@ -720,6 +720,10 @@ msgstr "Wenn Sie noch kein Nutzer sind, registrieren Sie sich bitte"
 msgid "Register"
 msgstr "Registrieren"
 
+#: flask_appbuilder/templates/appbuilder/general/security/login_oauth.html:30
+msgid "Sign In with "
+msgstr "Anmelden mit "
+
 #: flask_appbuilder/templates/appbuilder/general/security/login_oauth.html:44
 msgid "Please choose one of the following providers:"
 msgstr "Bitte wählen Sie eine der folgenden Anbieter:"

--- a/flask_appbuilder/translations/es/LC_MESSAGES/messages.po
+++ b/flask_appbuilder/translations/es/LC_MESSAGES/messages.po
@@ -628,6 +628,10 @@ msgstr "Si no eres usuario, regístrate"
 msgid "Register"
 msgstr "Registrar"
 
+#: flask_appbuilder/templates/appbuilder/general/security/login_oauth.html:30
+msgid "Sign In with "
+msgstr "Iniciar sesión con "
+
 #: flask_appbuilder/templates/appbuilder/general/security/login_oauth.html:44
 msgid "Please choose one of the following providers:"
 msgstr "Por favor, elija uno de los proveedores siguientes:"

--- a/flask_appbuilder/translations/fr/LC_MESSAGES/messages.po
+++ b/flask_appbuilder/translations/fr/LC_MESSAGES/messages.po
@@ -625,6 +625,10 @@ msgstr "Si vous n'êtes pas inscrit, inscrivez-vous"
 msgid "Register"
 msgstr "S'inscrire"
 
+#: flask_appbuilder/templates/appbuilder/general/security/login_oauth.html:30
+msgid "Sign In with "
+msgstr "Connectez-vous avec "
+
 #: flask_appbuilder/templates/appbuilder/general/security/login_oauth.html:44
 msgid "Please choose one of the following providers:"
 msgstr "S'il vous plaît, choisissez un des fournisseurs:"

--- a/flask_appbuilder/translations/nl/LC_MESSAGES/messages.po
+++ b/flask_appbuilder/translations/nl/LC_MESSAGES/messages.po
@@ -621,6 +621,10 @@ msgstr "Registreer als u nog geen gebruiker bent"
 msgid "Register"
 msgstr "Registreren"
 
+#: flask_appbuilder/templates/appbuilder/general/security/login_oauth.html:30
+msgid "Sign In with "
+msgstr "Aanmelden met "
+
 #: flask_appbuilder/templates/appbuilder/general/security/login_oauth.html:44
 msgid "Please choose one of the following providers:"
 msgstr "Kies een van de volgende providers:"

--- a/flask_appbuilder/translations/pt/LC_MESSAGES/messages.po
+++ b/flask_appbuilder/translations/pt/LC_MESSAGES/messages.po
@@ -622,6 +622,10 @@ msgstr "Se ainda não for um utilizador, por favor registre-se"
 msgid "Register"
 msgstr "Registrar"
 
+#: flask_appbuilder/templates/appbuilder/general/security/login_oauth.html:30
+msgid "Sign In with "
+msgstr "Faça login com "
+
 #: flask_appbuilder/templates/appbuilder/general/security/login_oauth.html:44
 msgid "Please choose one of the following providers:"
 msgstr "Por favor, Escolha um dos seguintes:"

--- a/flask_appbuilder/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/flask_appbuilder/translations/pt_BR/LC_MESSAGES/messages.po
@@ -620,6 +620,10 @@ msgstr "Se ainda não for um usuário, por favor registre-se"
 msgid "Register"
 msgstr "Registro"
 
+#: flask_appbuilder/templates/appbuilder/general/security/login_oauth.html:30
+msgid "Sign In with "
+msgstr "Faça login com "
+
 #: flask_appbuilder/templates/appbuilder/general/security/login_oauth.html:44
 msgid "Please choose one of the following providers:"
 msgstr "Por favor, escolha um dos seguintes:"


### PR DESCRIPTION
### Description

This PR translates [this "Sign In with " string](https://github.com/dpgaspar/Flask-AppBuilder/blob/bbf2adb1312ac1f994ef04e5d5e581d1447cb732/flask_appbuilder/templates/appbuilder/general/security/login_oauth.html#L20) for signing in with oauth into a handful of languages: Dutch, German, Spanish, Portuguese, and French. I did not have the language skills to do more than that.

I saw that this string was [translated into Slovenian and followed directly after translations for a "Register" string](https://github.com/dpgaspar/Flask-AppBuilder/blob/bbf2adb1312ac1f994ef04e5d5e581d1447cb732/flask_appbuilder/translations/sl/LC_MESSAGES/messages.po#L659-L666), so I followed suit and placed my translations after "Register" for each language.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
