### PR TITLE
feat: allow GeneralModelConverter to be overridden

### DIFF
--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -581,6 +581,9 @@ class BaseModelView(BaseView):
     search_widget = SearchWidget
     """ Search widget you can override with your own """
 
+    model_converter = GeneralModelConverter
+    """ Use this property to set a custom model converter """
+
     _base_filters = None
     """ Internal base Filter from class Filters will always filter view """
     _filters = None
@@ -630,7 +633,7 @@ class BaseModelView(BaseView):
         self._filters = self.datamodel.get_filters(self.search_columns)
 
     def _init_forms(self):
-        conv = GeneralModelConverter(self.datamodel)
+        conv = self.model_converter(self.datamodel)
         if not self.search_form:
             self.search_form = conv.create_form(
                 self.label_columns,
@@ -883,7 +886,7 @@ class BaseCRUDView(BaseModelView):
         Init forms for Add and Edit
         """
         super(BaseCRUDView, self)._init_forms()
-        conv = GeneralModelConverter(self.datamodel)
+        conv = self.model_converter(self.datamodel)
         if not self.add_form:
             self.add_form = conv.create_form(
                 self.label_columns,


### PR DESCRIPTION

<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

It may be useful to override GeneralModelConverter to implement a different logic for automatic form creation.  
Currently this class is used directly in the code, which makes this impossible. 
The current PR add a class variable to BaseModelView which defines the model converter class to be used (default GeneralModelConverter) 

<!--- Describe the change below, including rationale and design decisions -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [x] Introduces new feature
- [ ] Removes existing feature
