### PR TITLE
feat: isolate populate_obj in a separate method so that it can be easily overriden

### DIFF
--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -1222,7 +1222,7 @@ class BaseCRUDView(BaseModelView):
                 item = self.datamodel.obj()
 
                 try:
-                    form.populate_obj(item)
+                    self.populate_item_from_form(form, item, True)
                     self.pre_add(item)
                 except Exception as e:
                     flash(str(e), "danger")
@@ -1266,7 +1266,7 @@ class BaseCRUDView(BaseModelView):
                 self.process_form(form, False)
 
                 try:
-                    form.populate_obj(item)
+                    self.populate_item_from_form(form, item, False)
                     self.pre_update(item)
                 except Exception as e:
                     flash(str(e), "danger")
@@ -1379,6 +1379,13 @@ class BaseCRUDView(BaseModelView):
         return not (
             request.method == "GET" and self.appbuilder.app.extensions.get("csrf")
         )
+
+    def populate_item_from_form(self, form, item, is_created):
+        """
+        Populate the properties of the item to be created or updated based 
+        on the content of the form.
+        """
+        form.populate_obj(item)
 
     def prefill_form(self, form, pk):
         """


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

Similar to [update_model](https://flask-admin.readthedocs.io/en/latest/_modules/flask_admin/model/base/#BaseModelView.update_model) on Flask-Admin, isolating the call to `form.update_obj` to a separate method allows the step to be easily overridden. Currently, the methods exposed can access either the form (`process_form`, for example) or the item (`pre_add`, `pre_update`, for example), but not both. Depending on the behavior to be implemented, access to both can be really useful. 

<!--- Describe the change below, including rationale and design decisions -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [x] Introduces new feature
- [ ] Removes existing feature
