### PR TITLE
feat: Add option to open links in different targets

### DIFF
--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -113,6 +113,8 @@ By default menu is constructed based on your classes and in a reversed navbar. L
                             category="Others", category_label=lazy_gettext('Other'), category_label='fa-envelope')
             # Add a link
             appbuilder.add_link("google", href="www.google.com", icon = "fa-google-plus")
+            # Add a link that opens in a new tab
+            appbuilder.add_link("Flask documentation", href="flask-appbuilder.readthedocs.io", icon="fa-book", target="_blank")
 		
 	- Add separators::
 

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -114,7 +114,7 @@ By default menu is constructed based on your classes and in a reversed navbar. L
             # Add a link
             appbuilder.add_link("google", href="www.google.com", icon = "fa-google-plus")
             # Add a link that opens in a new tab
-            appbuilder.add_link("Flask documentation", href="flask-appbuilder.readthedocs.io", icon="fa-book", target="_blank")
+            appbuilder.add_link("Flask documentation", href="https://flask-appbuilder.readthedocs.io", icon="fa-book", target="_blank")
 		
 	- Add separators::
 

--- a/examples/quickexternalurl/run.py
+++ b/examples/quickexternalurl/run.py
@@ -1,0 +1,18 @@
+import os
+
+from flask import Flask
+from flask_appbuilder import AppBuilder, SQLA
+
+app = Flask(__name__)
+
+basedir = os.path.abspath(os.path.dirname(__file__))
+app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///" + os.path.join(basedir, "app.db")
+app.config["CSRF_ENABLED"] = True
+app.config["SECRET_KEY"] = "thisismyscretkey"
+
+db = SQLA(app)
+appbuilder = AppBuilder(app, db.session)
+
+appbuilder.add_link("Flask documentation", href="https://flask-appbuilder.readthedocs.io", icon="fa-book", target="_blank")
+
+app.run(host="0.0.0.0", port=8080, debug=True)

--- a/flask_appbuilder/base.py
+++ b/flask_appbuilder/base.py
@@ -472,6 +472,7 @@ class AppBuilder:
         category_label: str = "",
         baseview: Optional["AbstractViewApi"] = None,
         cond: Optional[Callable[..., bool]] = None,
+        target: str = "_self",
     ) -> None:
         """
         Add your own links to menu using this method
@@ -501,6 +502,11 @@ class AppBuilder:
             then this link will be a part of the menu. Otherwise, it
             will not be included in the menu items. Defaults to
             :code:`None`, meaning the item will always be present.
+        :param target:
+            Target for the HTML <a> tag. This allows for links to
+            open in a new page or tab and even in seperate iframes.
+            Options are: :code:`_blank`, :code:`_self`, :code:`_parent`,
+            :code:`_top` or a custom iframe. Defaults to :code:`_self`
         """
         if self.menu is None:
             return
@@ -514,6 +520,7 @@ class AppBuilder:
             category_label=category_label,
             baseview=baseview,
             cond=cond,
+            target=target,
         )
         if self.app:
             self._add_permissions_menu(name)

--- a/flask_appbuilder/menu.py
+++ b/flask_appbuilder/menu.py
@@ -10,7 +10,7 @@ from .security.decorators import permission_name, protect
 
 class MenuItem(object):
     def __init__(
-        self, name, href="", icon="", label="", childs=None, baseview=None, cond=None
+        self, name, href="", icon="", label="", childs=None, baseview=None, cond=None, target="_self"
     ):
         self.name = name
         self.href = href
@@ -19,9 +19,14 @@ class MenuItem(object):
         self.childs = childs or []
         self.baseview = baseview
         self.cond = cond
+        self.target = target
 
     def should_render(self) -> bool:
         return bool(self.cond()) if self.cond is not None else True
+
+    def get_target(self) -> str:
+        """Returns the target for a HTML <a> tag. Defaults to _self"""
+        return self.target
 
     def get_url(self):
         if not self.href:
@@ -94,6 +99,7 @@ class Menu(object):
                         "icon": item.icon,
                         "label": __(str(item.label)),
                         "url": item.get_url(),
+                        "target": item.get_target(),
                     }
                 )
         return ret_list
@@ -135,6 +141,7 @@ class Menu(object):
         category_label="",
         baseview=None,
         cond=None,
+        target="_self",
     ):
         label = label or name
         category_label = category_label or category
@@ -147,6 +154,7 @@ class Menu(object):
                     label=label,
                     baseview=baseview,
                     cond=cond,
+                    target=target,
                 )
             )
         else:
@@ -159,6 +167,7 @@ class Menu(object):
                     label=label,
                     baseview=baseview,
                     cond=cond,
+                    target=target,
                 )
                 menu_item.childs.append(new_menu_item)
             else:
@@ -172,6 +181,7 @@ class Menu(object):
                     label=label,
                     baseview=baseview,
                     cond=cond,
+                    target=target,
                 )
                 self.find(category).childs.append(new_menu_item)
 

--- a/flask_appbuilder/templates/appbuilder/navbar_menu.html
+++ b/flask_appbuilder/templates/appbuilder/navbar_menu.html
@@ -1,5 +1,5 @@
 {% macro menu_item(item) %}
-    <a tabindex="-1" href="{{item.get_url()}}">
+    <a tabindex="-1" href="{{item.get_url()}}" target="{{item.get_target()}}">
        {% if item.icon %}
         <i class="fa fa-fw {{item.icon}}"></i>&nbsp;
     {% endif %}


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

This will allow for links to be opened in different HTML targets meaning users can follow navigation links without leaving the current page they are on. This can be usefull if you want to guide them to external tools.

So far I have limited it to the `add_link()` function, but this can easily be expended to `add_view()` aswell

This was requested by @gugupy 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #2229 
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [x] Introduces new feature
- [ ] Removes existing feature
