### PR TITLE
refactor: enhance _get_list_widget and _list methods to accept additional kwargs

### DIFF
--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -1066,7 +1066,7 @@ class BaseCRUDView(BaseModelView):
         page=None,
         page_size=None,
         widgets=None,
-        **args,
+        **kwargs,
     ):
         """get joined base filter and current active filter for query"""
         widgets = widgets or {}
@@ -1100,6 +1100,7 @@ class BaseCRUDView(BaseModelView):
             actions=actions,
             filters=filters,
             modelview_name=self.__class__.__name__,
+            **kwargs,
         )
         return widgets
 
@@ -1162,7 +1163,7 @@ class BaseCRUDView(BaseModelView):
     -----------------------------------------------------
     """
 
-    def _list(self):
+    def _list(self, **kwargs):
         """
         list function logic, override to implement different logic
         returns list and search widget
@@ -1182,6 +1183,7 @@ class BaseCRUDView(BaseModelView):
             order_direction=order_direction,
             page=page,
             page_size=page_size,
+            **kwargs,
         )
         form = self.search_form.refresh()
         self.update_redirect()

--- a/flask_appbuilder/views.py
+++ b/flask_appbuilder/views.py
@@ -831,9 +831,9 @@ class CompactCRUDMixin(BaseCRUDView):
         k = cls.__name__ + "__" + k
         session.pop(k)
 
-    def _get_list_widget(self, **args):
+    def _get_list_widget(self, **kwargs):
         """get joined base filter and current active filter for query"""
-        widgets = super(CompactCRUDMixin, self)._get_list_widget(**args)
+        widgets = super(CompactCRUDMixin, self)._get_list_widget(**kwargs)
         session_form_widget = self.get_key("session_form_widget", None)
 
         form_widget = None


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description
This refactor improves the `_get_list_widget` and `_list` methods by adding support for additional keyword arguments (**kwargs). The main changes include:

- Modified `_get_list_widget` to accept and pass **kwargs to `self.list_widget`, allowing more flexibility in handling dynamic arguments.
- Updated `_list` to accept **kwargs and pass them to `_get_list_widget`, enabling the method to adapt to various contexts where additional parameters may be required.
- These changes enhance extensibility and make the codebase more adaptable to future enhancements without needing to modify the method signatures repeatedly.

### Example Usage

```python
# Now you can pass additional options like 'custom_setting' directly
widgets = self._list(custom_setting="example")
```

<!--- Describe the change below, including rationale and design decisions -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
