### PR TITLE
fix: use userinfo() with okta and don't try decoding as json

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -407,7 +407,7 @@ To customize the userinfo retrieval, you can create your own method like this::
         response: Dict[str, Any]
     ) -> Dict[str, Any]:
         if provider == "okta":
-            me = sm.oauth_remotes[provider].get("userinfo")
+            me = sm.oauth_remotes[provider].userinfo()
             return {
                 "username": "okta_" + me.data.get("sub", ""),
                 "first_name": me.data.get("given_name", ""),

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -659,8 +659,7 @@ class BaseSecurityManager(AbstractSecurityManager):
             return {"username": "openshift_" + data.get("metadata").get("name")}
         # for Okta
         if provider == "okta":
-            me = self.appbuilder.sm.oauth_remotes[provider].get("userinfo")
-            data = me.json()
+            data = self.appbuilder.sm.oauth_remotes[provider].userinfo()
             log.debug("User info from Okta: %s", data)
             if "error" not in data:
                 return {


### PR DESCRIPTION
### Description

This plainly doesn't work with Okta, and it is not so hard to get it to work with Okta... There is no custom security class, no hacks to rely on identity token, just using the metadata url, to do what it should.

Fixes #2291 

### ADDITIONAL INFORMATION

- [X] Has associated issue:
- [ ] Is CRUD MVC related.
- [X] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature

I Would love it if someone can cut a release once this merges, so that I can build a superset image based upon this.