### PR TITLE
fix: Changed the form of field_flags to that of WTForms 3.

### DIFF
--- a/flask_appbuilder/security/forms.py
+++ b/flask_appbuilder/security/forms.py
@@ -18,7 +18,7 @@ class SelectDataRequired(DataRequired):
     select fields
     """
 
-    field_flags = ()
+    field_flags = {}
 
 
 class LoginForm_oid(DynamicForm):

--- a/flask_appbuilder/validators.py
+++ b/flask_appbuilder/validators.py
@@ -26,7 +26,7 @@ class Unique:
     a specified table field.
     """
 
-    field_flags = ("unique",)
+    field_flags = {"unique": True}
 
     def __init__(
         self, datamodel: BaseInterface, col_name: str, message: Optional[str] = None


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### This a quick change of the form of the field_flags attribute to the form specified in WTForms 3, because WTForms raises a exception whenever I go to the users list or to any form with fields that specify the `unique` flag. It's already fixed in master; I just made the changes in this branch.

<!--- Describe the change below, including rationale and design decisions -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
