### PR TITLE
fix: werkzeug version check

### DIFF
--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -1,4 +1,5 @@
 import datetime
+import importlib
 import logging
 import re
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
@@ -13,7 +14,6 @@ from flask_limiter.util import get_remote_address
 from flask_login import current_user, LoginManager
 import jwt
 from packaging.version import Version
-from pkg_resources import get_distribution
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from .api import SecurityApi
@@ -233,7 +233,7 @@ class BaseSecurityManager(AbstractSecurityManager):
         app.config.setdefault("AUTH_API_LOGIN_ALLOW_MULTIPLE_PROVIDERS", False)
 
         # Werkzeug prior to 3.0.0 does not support scrypt
-        parsed_werkzeug_version = Version(get_distribution("werkzeug").version)
+        parsed_werkzeug_version = Version(importlib.metadata.version("werkzeug"))
         if parsed_werkzeug_version < Version("3.0.0"):
             app.config.setdefault(
                 "AUTH_DB_FAKE_PASSWORD_HASH_CHECK",

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -12,6 +12,8 @@ from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_login import current_user, LoginManager
 import jwt
+from packaging.version import Version
+from pkg_resources import get_distribution
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from .api import SecurityApi
@@ -230,10 +232,8 @@ class BaseSecurityManager(AbstractSecurityManager):
         app.config.setdefault("AUTH_ROLES_SYNC_AT_LOGIN", False)
         app.config.setdefault("AUTH_API_LOGIN_ALLOW_MULTIPLE_PROVIDERS", False)
 
-        from packaging.version import Version
-        from werkzeug import __version__ as werkzeug_version
-
-        parsed_werkzeug_version = Version(werkzeug_version)
+        # Werkzeug prior to 3.0.0 does not support scrypt
+        parsed_werkzeug_version = Version(get_distribution("werkzeug").version)
         if parsed_werkzeug_version < Version("3.0.0"):
             app.config.setdefault(
                 "AUTH_DB_FAKE_PASSWORD_HASH_CHECK",


### PR DESCRIPTION
### Description

Fixes: https://github.com/dpgaspar/Flask-AppBuilder/pull/2306

on werkzeug 3.1.X the `__version__` attr does not exist anymore 

@potiuk 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
