### PR TITLE
feat: OAuth - redirect direct to provider if just one provider exists

### DIFF
--- a/flask_appbuilder/security/views.py
+++ b/flask_appbuilder/security/views.py
@@ -633,12 +633,16 @@ class AuthOAuthView(AuthView):
             return redirect(self.appbuilder.get_url_for_index)
 
         if provider is None:
-            return self.render_template(
-                self.login_template,
-                providers=self.appbuilder.sm.oauth_providers,
-                title=self.title,
-                appbuilder=self.appbuilder,
-            )
+            providers = self.appbuilder.sm.oauth_providers
+            if len(providers) == 1:
+                provider = providers[0]["name"]
+            else:
+                return self.render_template(
+                    self.login_template,
+                    providers=providers,
+                    title=self.title,
+                    appbuilder=self.appbuilder,
+                )
 
         log.debug("Going to call authorize for: %s", provider)
         random_state = generate_random_string()


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description
If just one provider exists, users can go to the provider auth page directly without selection.

The fix from PR #1618 (sqla-filters-fix) was merged into 3.1.1 but was not included in releases >=3.4.0. This commit re-applies the changes to ensure the fix is present in current and future versions.

<!--- Describe the change below, including rationale and design decisions -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [x] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
