### PR TITLE
fix: Ensure sub is a string when generating JWT tokens

### DIFF
--- a/flask_appbuilder/security/api.py
+++ b/flask_appbuilder/security/api.py
@@ -105,11 +105,11 @@ class SecurityApi(BaseApi):
         # Identity can be any data that is json serializable
         resp = dict()
         resp[API_SECURITY_ACCESS_TOKEN_KEY] = create_access_token(
-            identity=user.id, fresh=True
+            identity=str(user.id), fresh=True
         )
         if "refresh" in login_payload and login_payload["refresh"]:
             resp[API_SECURITY_REFRESH_TOKEN_KEY] = create_refresh_token(
-                identity=user.id
+                identity=str(user.id)
             )
         return self.response(200, **resp)
 


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

There has been a recent change in PyJWT and this library has become less forgiving.

Specifically, it will now fail to decode JWT tokens if the sub field is not a string, generating an error of the form `Subject must be a string`.

Whilst it would be ideal to fix this at source, there are likely to be lots of applications that rely on this code where `user.id`
already exists and is not a string. If feels like the simplest solution is to ensure user.id is cast to a string whenever used as part of JWT token generation.

<!--- Describe the change below, including rationale and design decisions -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
