### PR TITLE
feat: Make password hashing parameters configurable

### DIFF
--- a/bin/hash_db_password.py
+++ b/bin/hash_db_password.py
@@ -38,7 +38,11 @@ except Exception as e:
 
 for user in users:
     log.info("Hashing password for {0}".format(user.username))
-    user.password = generate_password_hash(user.password)
+    user.password = generate_password_hash(
+        password=user.password,
+        method=app.config.get('FAB_PASSWORD_HASH_METHOD', 'scrypt'),
+        salt_length=app.config.get('FAB_PASSWORD_HASH_SALT_LENGTH', 16),
+    )
     try:
         db.session.merge(user)
         db.session.commit()

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -325,6 +325,16 @@ Use config.py to configure the following parameters. By default it will use SQLL
 |                                        | validation for AUTH database users.        |   No      |
 |                                        | Default is False.                          |           |
 +----------------------------------------+--------------------------------------------+-----------+
+| FAB_PASSWORD_HASH_METHOD               | Sets the password hashing method. For the  |           |
+|                                        | supported parameters see                   |           |
+|                                        | `generate_password_hash`_.                 |   No      |
+|                                        | Default: ``'scrypt'``.                     |           |
++----------------------------------------+--------------------------------------------+-----------+
+| FAB_PASSWORD_HASH_SALT_LENGTH          | Sets the password hashing salt length.     |   No      |
+|                                        | Default: ``16``.                           |           |
++----------------------------------------+--------------------------------------------+-----------+
+
+.. _generate_password_hash: https://werkzeug.palletsprojects.com/en/stable/utils/#werkzeug.security.generate_password_hash
 
 Note
 ----

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -952,8 +952,12 @@ class BaseSecurityManager(AbstractSecurityManager):
         user = self.get_user_by_id(userid)
         user.password = generate_password_hash(
             password=password,
-            method=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_METHOD', 'scrypt'),
-            salt_length=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_SALT_LENGTH', 16),
+            method=self.appbuilder.get_app.config.get(
+                "FAB_PASSWORD_HASH_METHOD", "scrypt"
+            ),
+            salt_length=self.appbuilder.get_app.config.get(
+                "FAB_PASSWORD_HASH_SALT_LENGTH", 16
+            ),
         )
         self.update_user(user)
 

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -950,7 +950,11 @@ class BaseSecurityManager(AbstractSecurityManager):
             The clear text password to reset and save hashed on the db
         """
         user = self.get_user_by_id(userid)
-        user.password = generate_password_hash(password)
+        user.password = generate_password_hash(
+            password=password,
+            method=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_METHOD', 'scrypt'),
+            salt_length=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_SALT_LENGTH', 16),
+        )
         self.update_user(user)
 
     def update_user_auth_stat(self, user, success=True):

--- a/flask_appbuilder/security/mongoengine/manager.py
+++ b/flask_appbuilder/security/mongoengine/manager.py
@@ -94,7 +94,11 @@ class SecurityManager(BaseSecurityManager):
             if hashed_password:
                 register_user.password = hashed_password
             else:
-                register_user.password = generate_password_hash(password)
+                register_user.password = generate_password_hash(
+                    password=password,
+                    method=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_METHOD', 'scrypt'),
+                    salt_length=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_SALT_LENGTH', 16),
+                )
             register_user.registration_hash = str(uuid.uuid1())
             register_user.save()
             return register_user
@@ -141,7 +145,11 @@ class SecurityManager(BaseSecurityManager):
             if hashed_password:
                 user.password = hashed_password
             else:
-                user.password = generate_password_hash(password)
+                user.password = generate_password_hash(
+                    password=password,
+                    method=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_METHOD', 'scrypt'),
+                    salt_length=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_SALT_LENGTH', 16),
+                )
             user.save()
             log.info(c.LOGMSG_INF_SEC_ADD_USER, username)
             return user

--- a/flask_appbuilder/security/mongoengine/manager.py
+++ b/flask_appbuilder/security/mongoengine/manager.py
@@ -96,8 +96,12 @@ class SecurityManager(BaseSecurityManager):
             else:
                 register_user.password = generate_password_hash(
                     password=password,
-                    method=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_METHOD', 'scrypt'),
-                    salt_length=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_SALT_LENGTH', 16),
+                    method=self.appbuilder.get_app.config.get(
+                        "FAB_PASSWORD_HASH_METHOD", "scrypt"
+                    ),
+                    salt_length=self.appbuilder.get_app.config.get(
+                        "FAB_PASSWORD_HASH_SALT_LENGTH", 16
+                    ),
                 )
             register_user.registration_hash = str(uuid.uuid1())
             register_user.save()
@@ -147,8 +151,12 @@ class SecurityManager(BaseSecurityManager):
             else:
                 user.password = generate_password_hash(
                     password=password,
-                    method=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_METHOD', 'scrypt'),
-                    salt_length=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_SALT_LENGTH', 16),
+                    method=self.appbuilder.get_app.config.get(
+                        "FAB_PASSWORD_HASH_METHOD", "scrypt"
+                    ),
+                    salt_length=self.appbuilder.get_app.config.get(
+                        "FAB_PASSWORD_HASH_SALT_LENGTH", 16
+                    ),
                 )
             user.save()
             log.info(c.LOGMSG_INF_SEC_ADD_USER, username)

--- a/flask_appbuilder/security/sqla/apis/user/api.py
+++ b/flask_appbuilder/security/sqla/apis/user/api.py
@@ -71,15 +71,23 @@ class UserApi(ModelRestApi):
         if item.password:
             item.password = generate_password_hash(
                 password=item.password,
-                method=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_METHOD', 'scrypt'),
-                salt_length=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_SALT_LENGTH', 16),
+                method=self.appbuilder.get_app.config.get(
+                    "FAB_PASSWORD_HASH_METHOD", "scrypt"
+                ),
+                salt_length=self.appbuilder.get_app.config.get(
+                    "FAB_PASSWORD_HASH_SALT_LENGTH", 16
+                ),
             )
 
     def pre_add(self, item):
         item.password = generate_password_hash(
             password=item.password,
-            method=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_METHOD', 'scrypt'),
-            salt_length=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_SALT_LENGTH', 16),
+            method=self.appbuilder.get_app.config.get(
+                "FAB_PASSWORD_HASH_METHOD", "scrypt"
+            ),
+            salt_length=self.appbuilder.get_app.config.get(
+                "FAB_PASSWORD_HASH_SALT_LENGTH", 16
+            ),
         )
 
     @expose("/", methods=["POST"])

--- a/flask_appbuilder/security/sqla/apis/user/api.py
+++ b/flask_appbuilder/security/sqla/apis/user/api.py
@@ -69,10 +69,18 @@ class UserApi(ModelRestApi):
         item.changed_on = datetime.now()
         item.changed_by_fk = g.user.id
         if item.password:
-            item.password = generate_password_hash(item.password)
+            item.password = generate_password_hash(
+                password=item.password,
+                method=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_METHOD', 'scrypt'),
+                salt_length=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_SALT_LENGTH', 16),
+            )
 
     def pre_add(self, item):
-        item.password = generate_password_hash(item.password)
+        item.password = generate_password_hash(
+            password=item.password,
+            method=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_METHOD', 'scrypt'),
+            salt_length=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_SALT_LENGTH', 16),
+        )
 
     @expose("/", methods=["POST"])
     @protect()

--- a/flask_appbuilder/security/sqla/manager.py
+++ b/flask_appbuilder/security/sqla/manager.py
@@ -141,7 +141,11 @@ class SecurityManager(BaseSecurityManager):
         if hashed_password:
             register_user.password = hashed_password
         else:
-            register_user.password = generate_password_hash(password)
+            register_user.password = generate_password_hash(
+                password=password,
+                method=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_METHOD', 'scrypt'),
+                salt_length=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_SALT_LENGTH', 16),
+            )
         register_user.registration_hash = str(uuid.uuid1())
         try:
             self.get_session.add(register_user)
@@ -234,7 +238,11 @@ class SecurityManager(BaseSecurityManager):
             if hashed_password:
                 user.password = hashed_password
             else:
-                user.password = generate_password_hash(password)
+                user.password = generate_password_hash(
+                    password=password,
+                    method=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_METHOD', 'scrypt'),
+                    salt_length=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_SALT_LENGTH', 16),
+                )
             self.get_session.add(user)
             self.get_session.commit()
             log.info(c.LOGMSG_INF_SEC_ADD_USER, username)

--- a/flask_appbuilder/security/sqla/manager.py
+++ b/flask_appbuilder/security/sqla/manager.py
@@ -143,8 +143,12 @@ class SecurityManager(BaseSecurityManager):
         else:
             register_user.password = generate_password_hash(
                 password=password,
-                method=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_METHOD', 'scrypt'),
-                salt_length=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_SALT_LENGTH', 16),
+                method=self.appbuilder.get_app.config.get(
+                    "FAB_PASSWORD_HASH_METHOD", "scrypt"
+                ),
+                salt_length=self.appbuilder.get_app.config.get(
+                    "FAB_PASSWORD_HASH_SALT_LENGTH", 16
+                ),
             )
         register_user.registration_hash = str(uuid.uuid1())
         try:
@@ -240,8 +244,12 @@ class SecurityManager(BaseSecurityManager):
             else:
                 user.password = generate_password_hash(
                     password=password,
-                    method=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_METHOD', 'scrypt'),
-                    salt_length=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_SALT_LENGTH', 16),
+                    method=self.appbuilder.get_app.config.get(
+                        "FAB_PASSWORD_HASH_METHOD", "scrypt"
+                    ),
+                    salt_length=self.appbuilder.get_app.config.get(
+                        "FAB_PASSWORD_HASH_SALT_LENGTH", 16
+                    ),
                 )
             self.get_session.add(user)
             self.get_session.commit()

--- a/flask_appbuilder/security/views.py
+++ b/flask_appbuilder/security/views.py
@@ -448,8 +448,12 @@ class UserDBModelView(UserModelView):
     def pre_add(self, item: Any) -> None:
         item.password = generate_password_hash(
             password=item.password,
-            method=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_METHOD', 'scrypt'),
-            salt_length=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_SALT_LENGTH', 16),
+            method=self.appbuilder.get_app.config.get(
+                "FAB_PASSWORD_HASH_METHOD", "scrypt"
+            ),
+            salt_length=self.appbuilder.get_app.config.get(
+                "FAB_PASSWORD_HASH_SALT_LENGTH", 16
+            ),
         )
 
 

--- a/flask_appbuilder/security/views.py
+++ b/flask_appbuilder/security/views.py
@@ -446,7 +446,11 @@ class UserDBModelView(UserModelView):
         item.changed_by_fk = g.user.id
 
     def pre_add(self, item: Any) -> None:
-        item.password = generate_password_hash(item.password)
+        item.password = generate_password_hash(
+            password=item.password,
+            method=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_METHOD', 'scrypt'),
+            salt_length=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_SALT_LENGTH', 16),
+        )
 
 
 class UserStatsChartView(DirectByChartView):

--- a/tests/test_security_api.py
+++ b/tests/test_security_api.py
@@ -53,8 +53,12 @@ class UserAPITestCase(FABTestCase):
         user.roles = roles
         user.password = generate_password_hash(
             password=password,
-            method=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_METHOD', 'scrypt'),
-            salt_length=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_SALT_LENGTH', 16),
+            method=self.appbuilder.get_app.config.get(
+                "FAB_PASSWORD_HASH_METHOD", "scrypt"
+            ),
+            salt_length=self.appbuilder.get_app.config.get(
+                "FAB_PASSWORD_HASH_SALT_LENGTH", 16
+            ),
         )
         self.session.commit()
         return user

--- a/tests/test_security_api.py
+++ b/tests/test_security_api.py
@@ -51,7 +51,11 @@ class UserAPITestCase(FABTestCase):
         user.username = username
         user.email = email
         user.roles = roles
-        user.password = generate_password_hash(password)
+        user.password = generate_password_hash(
+            password=password,
+            method=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_METHOD', 'scrypt'),
+            salt_length=self.appbuilder.get_app.config.get('FAB_PASSWORD_HASH_SALT_LENGTH', 16),
+        )
         self.session.commit()
         return user
 


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description

<!--- Describe the change below, including rationale and design decisions -->

This is a continuation of PR #2234.

It should be noted that apart from the compliance reasons mentioned in the original PR, this change 
is also necessary for compatibility with Python <=3.9 on macOS where `hashlib.scrypt` is not available.

Two configuration options have been added: `FAB_PASSWORD_HASH_METHOD` and `FAB_PASSWORD_HASH_SALT_LENGTH`.

While `FAB_PASSWORD_HASH_SALT_LENGTH` is not strictly required for the reasons mentioned above,
I included it as there may be use cases where configuring both is needed.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [X] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [X] Introduces new feature
- [ ] Removes existing feature
