### PR TITLE
fix: next url validation

### DIFF
--- a/flask_appbuilder/utils/base.py
+++ b/flask_appbuilder/utils/base.py
@@ -1,3 +1,4 @@
+from fnmatch import fnmatch
 import logging
 from typing import Any, Callable
 import unicodedata
@@ -27,10 +28,16 @@ def is_safe_redirect_url(url: str) -> bool:
     if not url_info.scheme and url_info.netloc:
         scheme = "http"
     valid_schemes = ["http", "https"]
-    host_url = urlparse(request.host_url)
-    return (not url_info.netloc or url_info.netloc == host_url.netloc) and (
-        not scheme or scheme in valid_schemes
+
+    safe_hosts = current_app.config.get("SAFE_REDIRECT_HOSTS", [])
+    if not safe_hosts:
+        safe_hosts = [urlparse(request.host_url).netloc]
+
+    is_host_allowed = not url_info.netloc or any(
+        fnmatch(url_info.netloc, pattern) for pattern in safe_hosts
     )
+
+    return is_host_allowed and (not scheme or scheme in valid_schemes)
 
 
 def get_safe_redirect(url):

--- a/tests/base.py
+++ b/tests/base.py
@@ -75,6 +75,7 @@ class FABTestCase(unittest.TestCase):
         password: str,
         next_url: Optional[str] = None,
         follow_redirects: bool = True,
+        headers: Optional[dict] = None,
     ) -> Response:
         login_url = "/login/"
         if next_url:
@@ -83,6 +84,7 @@ class FABTestCase(unittest.TestCase):
             login_url,
             data=dict(username=username, password=password),
             follow_redirects=follow_redirects,
+            headers=headers or {},
         )
 
     def assert_response(


### PR DESCRIPTION
### Description

fixes next url validation add a new config key `SAFE_REDIRECT_HOSTS` (:list[str]) that when set will validate next url against these.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
