### PR TITLE
fix: always add a unique col to ordering

### DIFF
--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -199,10 +199,17 @@ class SQLAInterface(BaseInterface):
                 column_leaf = get_column_leaf(order_column)
                 _alias = self.get_alias_mapping(root_relation, aliases_mapping)
                 _order_column = getattr(_alias, column_leaf)
+            # get the primary key so we can add a tie breaker of the order
+            # when the order column is not unique it can cause issues with pagination
+            pk = self.get_pk()
             if order_direction == "asc":
                 query = query.order_by(asc(_order_column))
+                if pk:
+                    query = query.order_by(asc(pk))
             else:
                 query = query.order_by(desc(_order_column))
+                if pk:
+                    query = query.order_by(desc(pk))
         return query
 
     def apply_pagination(

--- a/flask_appbuilder/models/sqla/interface.py
+++ b/flask_appbuilder/models/sqla/interface.py
@@ -202,14 +202,12 @@ class SQLAInterface(BaseInterface):
             # get the primary key so we can add a tie breaker of the order
             # when the order column is not unique it can cause issues with pagination
             pk = self.get_pk()
-            if order_direction == "asc":
-                query = query.order_by(asc(_order_column))
-                if pk:
-                    query = query.order_by(asc(pk))
-            else:
-                query = query.order_by(desc(_order_column))
-                if pk:
-                    query = query.order_by(desc(pk))
+            direction = asc if order_direction == "asc" else desc
+            order_by_columns = [direction(_order_column)]
+            if pk:
+                order_by_columns.append(direction(pk))
+            query = query.order_by(*order_by_columns)
+
         return query
 
     def apply_pagination(


### PR DESCRIPTION
### Description

Add an order by tie breaker on order by, this is specially important when paginations is used and order by is done on non unique columns

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
