### PR TITLE
style(login): capitalize OAuth provider

### DIFF
--- a/flask_appbuilder/templates/appbuilder/general/security/login_oauth.html
+++ b/flask_appbuilder/templates/appbuilder/general/security/login_oauth.html
@@ -17,7 +17,7 @@
                         class="btn btn-primary btn-block"
                         type="submit"
                     >
-                        {{_('Sign In with ')}}{{ provider.name }}
+                        {{_('Sign in with ')}}{{ provider.name | capitalize}}
                         <i id="{{provider.name}}" class="provider-select fa {{provider.icon}} fa-1x"></i>
                     </a>
                     {% endfor %}


### PR DESCRIPTION
### Description

Fixes #2320.

Tested - note capitalization of "in" (lower) and Azure, etc. (upper):

![image](https://github.com/user-attachments/assets/8ff08c05-cfde-4b0d-9567-6e367d791d43)
 
Compare with screenshot in #2320.

### ADDITIONAL INFORMATION
- [ ] Has associated issue: #2320
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
