### PR TITLE
feat(Filters): Add support for IN and NOT IN filter operators

### DIFF
--- a/flask_appbuilder/models/filters.py
+++ b/flask_appbuilder/models/filters.py
@@ -295,7 +295,7 @@ class Filters(object):
 
     def apply_all(self, query):
         for flt, values in zip(self.filters, self.values):
-            if isinstance(values, list):
+            if isinstance(values, list) and flt.arg_name not in {"in", "not_in"}:
                 for value in values:
                     query = flt.apply(query, value)
             else:

--- a/flask_appbuilder/models/generic/filters.py
+++ b/flask_appbuilder/models/generic/filters.py
@@ -107,6 +107,14 @@ class GenericFilterConverter(BaseFilterConverter):
                 FilterStartsWith,
             ],
         ),
-        ("is_integer", [FilterEqual, FilterNotEqual, FilterGreater, FilterSmaller]),
+        (
+            "is_integer",
+            [
+                FilterEqual,
+                FilterNotEqual,
+                FilterGreater,
+                FilterSmaller,
+            ],
+        ),
         ("is_date", [FilterEqual, FilterNotEqual, FilterGreater, FilterSmaller]),
     )

--- a/flask_appbuilder/models/sqla/filters.py
+++ b/flask_appbuilder/models/sqla/filters.py
@@ -25,6 +25,8 @@ __all__ = [
     "FilterEqualFunction",
     "FilterGreater",
     "FilterNotEndsWith",
+    "FilterIn",
+    "FilterNotIn",
     "FilterRelationManyToManyEqual",
     "FilterRelationOneToManyEqual",
     "FilterRelationOneToManyNotEqual",
@@ -183,6 +185,30 @@ class FilterSmaller(BaseFilter):
         return query.filter(field < value)
 
 
+class FilterIn(BaseFilter):
+    name = lazy_gettext("In")
+    arg_name = "in"
+
+    def apply(self, query, value):
+        query, field = get_field_setup_query(query, self.model, self.column_name)
+        typed_values = [
+            set_value_to_type(self.datamodel, self.column_name, v) for v in value
+        ]
+        return query.filter(field.in_(typed_values))
+
+
+class FilterNotIn(BaseFilter):
+    name = lazy_gettext("Not In")
+    arg_name = "not_in"
+
+    def apply(self, query, value):
+        query, field = get_field_setup_query(query, self.model, self.column_name)
+        typed_values = [
+            set_value_to_type(self.datamodel, self.column_name, v) for v in value
+        ]
+        return query.filter(~field.in_(typed_values))
+
+
 class FilterRelationOneToManyEqual(FilterRelation):
     name = lazy_gettext("Relation")
     arg_name = "rel_o_m"
@@ -319,6 +345,8 @@ class SQLAFilterConverter(BaseFilterConverter):
                 FilterNotEndsWith,
                 FilterNotContains,
                 FilterNotEqual,
+                FilterIn,
+                FilterNotIn,
             ],
         ),
         (
@@ -345,11 +373,43 @@ class SQLAFilterConverter(BaseFilterConverter):
                 FilterNotEndsWith,
                 FilterNotContains,
                 FilterNotEqual,
+                FilterIn,
+                FilterNotIn,
             ],
         ),
-        ("is_integer", [FilterEqual, FilterGreater, FilterSmaller, FilterNotEqual]),
-        ("is_float", [FilterEqual, FilterGreater, FilterSmaller, FilterNotEqual]),
-        ("is_numeric", [FilterEqual, FilterGreater, FilterSmaller, FilterNotEqual]),
+        (
+            "is_integer",
+            [
+                FilterEqual,
+                FilterGreater,
+                FilterSmaller,
+                FilterNotEqual,
+                FilterIn,
+                FilterNotIn,
+            ],
+        ),
+        (
+            "is_float",
+            [
+                FilterEqual,
+                FilterGreater,
+                FilterSmaller,
+                FilterNotEqual,
+                FilterIn,
+                FilterNotIn,
+            ],
+        ),
+        (
+            "is_numeric",
+            [
+                FilterEqual,
+                FilterGreater,
+                FilterSmaller,
+                FilterNotEqual,
+                FilterIn,
+                FilterNotIn,
+            ],
+        ),
         ("is_date", [FilterEqual, FilterGreater, FilterSmaller, FilterNotEqual]),
         ("is_boolean", [FilterEqual, FilterNotEqual]),
         ("is_datetime", [FilterEqual, FilterGreater, FilterSmaller, FilterNotEqual]),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1593,6 +1593,88 @@ class APITestCase(FABTestCase):
             self.assertEqual(data[API_RESULT_RES_KEY][0], expected_result)
             self.assertEqual(rv.status_code, 200)
 
+    def test_get_list_filter_in_operator(self):
+        """
+        REST API: Test 'in' filter on field_integer
+        """
+        client = self.app.test_client()
+        token = self.login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
+
+        with model1_data(self.appbuilder.session, 5) as models:
+            field_integers = [models[0].field_integer, models[1].field_integer]
+            expected_results = [
+                {
+                    "field_date": model.field_date.isoformat()
+                    if model.field_date
+                    else None,
+                    "field_float": float(model.field_float),
+                    "field_integer": model.field_integer,
+                    "field_string": model.field_string,
+                }
+                for model in models[:2]
+            ]
+
+            arguments = {
+                API_FILTERS_RIS_KEY: [
+                    {"col": "field_integer", "opr": "in", "value": field_integers}
+                ],
+                "order_column": "field_integer",
+                "order_direction": "asc",
+            }
+
+            uri = f"api/v1/model1api/?q={prison.dumps(arguments)}"
+            rv = self.auth_client_get(client, token, uri)
+            data = json.loads(rv.data.decode("utf-8"))
+
+            self.assertEqual(rv.status_code, 200)
+            actual_results = data[API_RESULT_RES_KEY]
+            self.assertEqual(len(actual_results), len(expected_results))
+            for result in expected_results:
+                self.assertIn(result, actual_results)
+
+    def test_get_list_filter_not_in_operator(self):
+        """
+        REST API: Test 'not in' filter on field_integer
+        """
+        client = self.app.test_client()
+        token = self.login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
+
+        with model1_data(self.appbuilder.session, 5) as models:
+            excluded_field_integers = [models[0].field_integer, models[1].field_integer]
+            expected_results = [
+                {
+                    "field_date": model.field_date.isoformat()
+                    if model.field_date
+                    else None,
+                    "field_float": float(model.field_float),
+                    "field_integer": model.field_integer,
+                    "field_string": model.field_string,
+                }
+                for model in models[2:]
+            ]
+
+            arguments = {
+                API_FILTERS_RIS_KEY: [
+                    {
+                        "col": "field_integer",
+                        "opr": "not_in",
+                        "value": excluded_field_integers,
+                    }
+                ],
+                "order_column": "field_integer",
+                "order_direction": "asc",
+            }
+
+            uri = f"api/v1/model1api/?q={prison.dumps(arguments)}"
+            rv = self.auth_client_get(client, token, uri)
+            data = json.loads(rv.data.decode("utf-8"))
+
+            self.assertEqual(rv.status_code, 200)
+            actual_results = data[API_RESULT_RES_KEY]
+            self.assertEqual(len(actual_results), len(expected_results))
+            for result in expected_results:
+                self.assertIn(result, actual_results)
+
     def test_get_list_invalid_filters(self):
         """
         REST Api: Test get list filter params
@@ -1993,12 +2075,16 @@ class APITestCase(FABTestCase):
                 {"name": "Greater than", "operator": "gt"},
                 {"name": "Smaller than", "operator": "lt"},
                 {"name": "Not Equal to", "operator": "neq"},
+                {"name": "In", "operator": "in"},
+                {"name": "Not In", "operator": "not_in"},
             ],
             "field_integer": [
                 {"name": "Equal to", "operator": "eq"},
                 {"name": "Greater than", "operator": "gt"},
                 {"name": "Smaller than", "operator": "lt"},
                 {"name": "Not Equal to", "operator": "neq"},
+                {"name": "In", "operator": "in"},
+                {"name": "Not In", "operator": "not_in"},
             ],
             "field_string": [
                 {"name": "Starts with", "operator": "sw"},
@@ -2009,6 +2095,8 @@ class APITestCase(FABTestCase):
                 {"name": "Not Ends with", "operator": "new"},
                 {"name": "Not Contains", "operator": "nct"},
                 {"name": "Not Equal to", "operator": "neq"},
+                {"name": "In", "operator": "in"},
+                {"name": "Not In", "operator": "not_in"},
             ],
         }
         self.assertEqual(data["filters"], expected_filters)


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description
<!--- Describe the change below, including rationale and design decisions -->

This PR introduces support for the `IN` and `NOT IN` operators in filters. These operators enhance query flexibility by allowing filtering based on membership in a list of values. 

This is particularly useful for multi-select filters or scenarios requiring the exclusion of multiple values.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [x] Introduces new feature
- [ ] Removes existing feature
