### PR TITLE
fix(filters): prevent shared Filters instance in concurrent requests

### DIFF
--- a/flask_appbuilder/api/__init__.py
+++ b/flask_appbuilder/api/__init__.py
@@ -1973,9 +1973,12 @@ class ModelRestApi(BaseModelApi):
         return order_column, order_direction
 
     def _handle_filters_args(self, rison_args: Dict[str, Any]) -> Filters:
-        self._filters.clear_filters()
-        self._filters.rest_add_filters(rison_args.get(API_FILTERS_RIS_KEY, []))
-        return self._filters.get_joined_filters(self._base_filters)
+        # self._filters.clear_filters()
+        filters = self.datamodel.get_filters(
+            search_columns=self.search_columns, search_filters=self.search_filters
+        )
+        filters.rest_add_filters(rison_args.get(API_FILTERS_RIS_KEY, []))
+        return filters.get_joined_filters(self._base_filters)
 
     def _description_columns_json(
         self, cols: Optional[List[str]] = None


### PR DESCRIPTION
### Description

This PR fixes a concurrency-related bug in Flask App Builder’s default API filter handling.
[About issue](https://github.com/dpgaspar/Flask-AppBuilder/issues/2366)

#### 🐞 Bug Summary

In the default implementation of the FAB API model, `Filters` instances are often stored as class-level instance variables (e.g., `self._filters`). Under concurrent request processing—especially in async or multi-threaded environments—this leads to **shared mutable state** across requests. As a result:

* `self._filters` is mutated simultaneously by different request handlers;
* Filters from one request may "bleed into" another, returning incorrect or mixed query results;
* No explicit error is raised, making the bug hard to detect;
* Disabling cache does not resolve the issue.

#### 🔧 Fix Summary

To eliminate shared state pollution between concurrent requests:

* The `_handle_filters_args` method is now refactored to instantiate a **new `Filters` object per request**;
* This ensures **isolated request-scoped filter logic**, avoiding unsafe reuse of `self._filters`;
* The original `self._filters` (if any) is preserved for non-query metadata logic like `merge_search_filters()`.

#### 💡 Design Notes

* We avoided using `.clear_filters()` on the shared instance because it does not guarantee thread safety;
* We chose per-request instantiation rather than object pooling for simplicity and correctness;
* This change prepares FAB for safer use in async-capable Flask environments or threaded WSGI servers.

---

### ADDITIONAL INFORMATION

* [x] Is CRUD MVC related.
* [ ] Is Auth, RBAC security related.
* [ ] Changes the security db schema.
* [ ] Introduces new feature
* [ ] Removes existing feature

