### PR TITLE
feat: Support the select_columns arg on the Get Item method

### DIFF
--- a/flask_appbuilder/exceptions.py
+++ b/flask_appbuilder/exceptions.py
@@ -34,6 +34,12 @@ class InvalidOrderByColumnFABException(FABException):
     ...
 
 
+class InvalidColumnArgsFABException(FABException):
+    """Invalid combination of column arguments"""
+
+    ...
+
+
 class InterfaceQueryWithoutSession(FABException):
     """You need to setup a session on the interface to perform queries"""
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -879,7 +879,7 @@ class APITestCase(FABTestCase):
 
     def test_get_item_choose_cols(self):
         """
-        REST Api: Test get item with select columns
+        REST Api: Test get item with the columns arg
         """
         client = self.app.test_client()
         token = self.login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
@@ -888,6 +888,30 @@ class APITestCase(FABTestCase):
             uri = (
                 f"api/v1/model1api/{model_id}?"
                 f"q=({API_SELECT_COLUMNS_RIS_KEY}:!(field_integer))"
+            )
+            rv = self.auth_client_get(client, token, uri)
+            data = json.loads(rv.data.decode("utf-8"))
+            self.assertEqual(data[API_RESULT_RES_KEY], {"field_integer": 0})
+            self.assertEqual(
+                data[API_DESCRIPTION_COLUMNS_RES_KEY],
+                {"field_integer": "Field Integer"},
+            )
+            self.assertEqual(
+                data[API_LABEL_COLUMNS_RES_KEY], {"field_integer": "Field Integer"}
+            )
+            self.assertEqual(rv.status_code, 200)
+
+    def test_get_item_choose_select_cols(self):
+        """
+        REST Api: Test get item with the select_columns arg
+        """
+        client = self.app.test_client()
+        token = self.login(client, USERNAME_ADMIN, PASSWORD_ADMIN)
+        with model1_data(self.appbuilder.session, 1) as models:
+            model_id = models[0].id
+            uri = (
+                f"api/v1/model1api/{model_id}?"
+                f"q=({API_SELECT_SEL_COLUMNS_RIS_KEY}:!(field_integer))"
             )
             rv = self.auth_client_get(client, token, uri)
             data = json.loads(rv.data.decode("utf-8"))


### PR DESCRIPTION
### Description
This PR adds support for the `select_columns` argument to the `get_headless` method.

The `select_columns` argument was initially introduced with https://github.com/dpgaspar/Flask-AppBuilder/pull/2242 to the `get_list_headless` method.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [x] Introduces new feature
- [ ] Removes existing feature
