### PR TITLE
fix: correct is_pk_composite return 

### DIFF
--- a/flask_appbuilder/models/base.py
+++ b/flask_appbuilder/models/base.py
@@ -247,7 +247,7 @@ class BaseInterface:
         return False
 
     def is_pk_composite(self):
-        raise False
+        return False
 
     def is_fk(self, col_name):
         return False


### PR DESCRIPTION
### Description

is_pk_composite raises False, which is not only not a BaseException, but probably just a typo

### ADDITIONAL INFORMATION
Fixes #2377
- [ ] Has associated issue:
- [x] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
