### PR TITLE
fix: Import RequestLimit from public namespace

### DIFF
--- a/flask_appbuilder/security/decorators.py
+++ b/flask_appbuilder/security/decorators.py
@@ -20,7 +20,7 @@ from flask_appbuilder.const import (
 )
 from flask_appbuilder.utils.limit import Limit
 from flask_jwt_extended import verify_jwt_in_request
-from flask_limiter.wrappers import RequestLimit
+from flask_limiter import RequestLimit
 from flask_login import current_user
 from typing_extensions import ParamSpec
 

--- a/flask_appbuilder/utils/limit.py
+++ b/flask_appbuilder/utils/limit.py
@@ -2,7 +2,7 @@ import dataclasses
 from typing import Callable, Optional, Tuple, Union
 
 from flask import Response
-from flask_limiter.wrappers import RequestLimit
+from flask_limiter import RequestLimit
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
### Description

The import of `RequestLimit` from `flask-limiter` was using the `flask_limiter.wrappers` namespace which was not intended to be part of the public API. As of version `3.13` `RequestLimit` was moved, but still available from the root `flask_limiter` namespace.

### ADDITIONAL INFORMATION
Related Issue: https://github.com/alisaifee/flask-limiter/issues/479

(If possible, it would probably benefit users of `Flask-AppBuilder` if this fix was backported)