### PR TITLE
fix(ci): move ldap to bitnami legacy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
             -e LDAP_ADMIN_PASSWORD=admin_password \
             -e LDAP_EXTRA_SCHEMAS=cosine,inetorgperson,nis,memberof \
             -p 1389:1389 \
-            bitnami/openldap:2.6.4
+            bitnamilegacy/openldap:2.6
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -121,7 +121,7 @@ jobs:
             -e LDAP_ADMIN_PASSWORD=admin_password \
             -e LDAP_EXTRA_SCHEMAS=cosine,inetorgperson,nis,memberof \
             -p 1389:1389 \
-            bitnami/openldap:2.6.4
+            bitnamilegacy/openldap:2.6
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -172,7 +172,7 @@ jobs:
             -e LDAP_ADMIN_PASSWORD=admin_password \
             -e LDAP_EXTRA_SCHEMAS=cosine,inetorgperson,nis,memberof \
             -p 1389:1389 \
-            bitnami/openldap:2.6.4
+            bitnamilegacy/openldap:2.6
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -221,7 +221,7 @@ jobs:
             -e LDAP_ADMIN_PASSWORD=admin_password \
             -e LDAP_EXTRA_SCHEMAS=cosine,inetorgperson,nis,memberof \
             -p 1389:1389 \
-            bitnami/openldap:2.6.4
+            bitnamilegacy/openldap:2.6
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - 5432:5432
   ldap:
     container_name: fab-ldap
-    image: bitnami/openldap:2.6.4
+    image: bitnamilegacy/openldap:2.6
     environment:
       LDAP_URI: ldap://openldap:1389
       LDAP_BASE: dc=example,dc=org


### PR DESCRIPTION
### Description

Move CI and docker compose to bitnami legacy for now. Image stopped working their behind a paywall

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
