### PR TITLE
chore(username): Expand username length

### DIFF
--- a/flask_appbuilder/security/sqla/models.py
+++ b/flask_appbuilder/security/sqla/models.py
@@ -163,7 +163,7 @@ class User(Model):
     )
     first_name: Mapped[str] = mapped_column(String(64), nullable=False)
     last_name: Mapped[str] = mapped_column(String(64), nullable=False)
-    username: Mapped[str] = mapped_column(String(64), unique=True, nullable=False)
+    username: Mapped[str] = mapped_column(String(128), unique=True, nullable=False)
     password: Mapped[Optional[str]] = mapped_column(String(256))
     active: Mapped[Optional[bool]] = mapped_column(Boolean, default=True)
     email: Mapped[str] = mapped_column(String(320), unique=True, nullable=False)
@@ -301,7 +301,7 @@ class RegisterUser(Model):
     )
     first_name: Mapped[str] = mapped_column(String(64), nullable=False)
     last_name: Mapped[str] = mapped_column(String(64), nullable=False)
-    username: Mapped[str] = mapped_column(String(64), unique=True, nullable=False)
+    username: Mapped[str] = mapped_column(String(128), unique=True, nullable=False)
     password: Mapped[Optional[str]] = mapped_column(String(256))
     email: Mapped[str] = mapped_column(String(320), unique=True, nullable=False)
     registration_date: Mapped[Optional[datetime.datetime]] = mapped_column(


### PR DESCRIPTION
### Description

64 chars is not enough to handle usernames, especially when things like SSO is used which adds up some extra chars to them. This PR is doubling the size from 64 to 128 chars.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
