### PR TITLE
fix: setup pkg filename

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def desc():
 
 
 setup(
-    name="Flask-AppBuilder",
+    name="flask-appbuilder",
     version=version,
     url="https://github.com/dpgaspar/flask-appbuilder/",
     license="BSD",


### PR DESCRIPTION
### Description

Pypi will not allow non normalized pkg names anymore

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
