### PR TITLE
fix: fix pkg name to comply with pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def desc():
 
 
 setup(
-    name="flask-appbuilder",
+    name="flask_appbuilder",
     version=version,
     url="https://github.com/dpgaspar/flask-appbuilder/",
     license="BSD",


### PR DESCRIPTION
### Description

fix:
```
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/                                                                                                                                   
         Filename 'flask-appbuilder-5.0.2rc1.tar.gz' is invalid, should be 'flask_appbuilder-5.0.2rc1.tar.gz'.
```


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
