### PR TITLE
fix: switch from uuid1 to uuid4 for better randomness

### DIFF
--- a/flask_appbuilder/filemanager.py
+++ b/flask_appbuilder/filemanager.py
@@ -224,7 +224,7 @@ class ImageManager(FileManager):
 
 
 def uuid_namegen(file_data):
-    return str(uuid.uuid1()) + "_sep_" + file_data.filename
+    return str(uuid.uuid4()) + "_sep_" + file_data.filename
 
 
 def get_file_original_name(name):

--- a/flask_appbuilder/security/sqla/manager.py
+++ b/flask_appbuilder/security/sqla/manager.py
@@ -326,7 +326,7 @@ class SecurityManager(BaseSecurityManager):
                 method=current_app.config.get("FAB_PASSWORD_HASH_METHOD", "scrypt"),
                 salt_length=current_app.config.get("FAB_PASSWORD_HASH_SALT_LENGTH", 16),
             )
-        register_user.registration_hash = str(uuid.uuid1())
+        register_user.registration_hash = str(uuid.uuid4())
         try:
             self.session.add(register_user)
             self.session.commit()


### PR DESCRIPTION
### Description

Switching from `uuid.uuid1()` to `uuid.uuid4()` for generating registration hashes and unique filenames ensures better randomness. Since UUID1 is generated using the host's MAC address and current time, it can be somewhat predictable in certain environments. Moving to UUID4 eliminates this predictability, which is a security best practice for generating sensitive tokens like account activation hashes. This change improves the overall robustness of the user registration process.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [x] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature