### PR TITLE
fix: Inlcude FKs when creating marshmallow-sqlalchemy schemas

### DIFF
--- a/flask_appbuilder/api/convert.py
+++ b/flask_appbuilder/api/convert.py
@@ -75,6 +75,7 @@ class BaseModel2SchemaConverter(object):
         columns: List[str],
         model: Optional[Type[Model]] = None,
         nested: bool = True,
+        include_fk: bool = True,
         parent_schema_name: Optional[str] = None,
     ) -> SQLAlchemyAutoSchema:
         pass

--- a/flask_appbuilder/api/convert.py
+++ b/flask_appbuilder/api/convert.py
@@ -123,6 +123,7 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
                 class Meta:
                     model = _model
                     fields = columns
+                    include_fk = True
                     load_instance = True
                     sqla_session = current_app.appbuilder.session
                     # The parent_schema_name is useful to humanize nested schema names
@@ -134,6 +135,7 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
         class MetaSchema(SQLAlchemyAutoSchema, class_mixin):  # type: ignore
             class Meta:
                 model = _model
+                include_fk = True
                 load_instance = True
                 sqla_session = current_app.appbuilder.session
                 # The parent_schema_name is useful to humanize nested schema names

--- a/flask_appbuilder/api/convert.py
+++ b/flask_appbuilder/api/convert.py
@@ -105,6 +105,7 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
         columns: List[str],
         model: Optional[Type[Model]],
         class_mixin: Type[Schema],
+        include_fk: bool = False,
         parent_schema_name: Optional[str] = None,
     ) -> Type[SQLAlchemyAutoSchema]:
         """
@@ -113,17 +114,19 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
         :param columns: a list of columns to mix
         :param model: Model
         :param class_mixin: a marshamallow Schema to mix
+        :param include_fk: Include foreign keys
         :return: ModelSchema
         """
         _model = model
         _parent_schema_name = parent_schema_name
+        _include_fk = include_fk
         if columns:
 
             class MetaSchema(SQLAlchemyAutoSchema, class_mixin):  # type: ignore
                 class Meta:
                     model = _model
                     fields = columns
-                    include_fk = True
+                    include_fk = _include_fk
                     load_instance = True
                     sqla_session = current_app.appbuilder.session
                     # The parent_schema_name is useful to humanize nested schema names
@@ -135,7 +138,7 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
         class MetaSchema(SQLAlchemyAutoSchema, class_mixin):  # type: ignore
             class Meta:
                 model = _model
-                include_fk = True
+                include_fk = _include_fk
                 load_instance = True
                 sqla_session = current_app.appbuilder.session
                 # The parent_schema_name is useful to humanize nested schema names
@@ -173,7 +176,11 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
             nested_model = datamodel.get_related_model(column.name)
             lst = [item.name for item in column.children]
             nested_schema = self.convert(
-                lst, nested_model, nested=False, parent_schema_name=parent_schema_name
+                lst,
+                nested_model,
+                nested=False,
+                include_fk=False,
+                parent_schema_name=parent_schema_name,
             )
             if datamodel.is_relation_many_to_one(column.name):
                 many = False
@@ -244,6 +251,7 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
         columns: List[str],
         model: Optional[Type[Model]] = None,
         nested: bool = True,
+        include_fk: bool = True,
         parent_schema_name: Optional[str] = None,
     ) -> SQLAlchemyAutoSchema:
         """
@@ -253,6 +261,7 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
         :param columns: List with columns to include, if empty converts all on model
         :param model: Override Model to convert
         :param nested: Generate relation with nested schemas
+        :param include_fk: Include foreign keys
         :return: ModelSchema object
         """
         super(Model2SchemaConverter, self).convert(
@@ -278,5 +287,9 @@ class Model2SchemaConverter(BaseModel2SchemaConverter):
         for k, v in ma_sqla_fields_override.items():
             setattr(SchemaMixin, k, v)
         return self._meta_schema_factory(
-            _columns, _model, SchemaMixin, parent_schema_name=parent_schema_name
+            _columns,
+            _model,
+            SchemaMixin,
+            include_fk=include_fk,
+            parent_schema_name=parent_schema_name,
         )()


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

Fixes https://github.com/dpgaspar/Flask-AppBuilder/issues/2361 and https://github.com/dpgaspar/Flask-AppBuilder/issues/2425

In marshmallow-sqlalchemy 1.x, the `SQLAlchemyAutoSchema` class defaults `include_fk` to False. When FAB generates the schemas for security models like `PermissionView`, it explicitly requests foreign key columns (like `permission_id` and `view_menu_id`). However, because `include_fk` is False, the `SQLAlchemyAutoSchemaMeta` metaclass filters these fields out before the schema is initialized. Marshmallow 4 then throws a KeyError (due to [this](https://github.com/marshmallow-code/marshmallow/commit/747c198bc13317e45dae00f160122b79858b3811#diff-bd65dcffe6f5090b10ab332e088e00a9dbce332d1b35d4be4d494c135b55182eR959) change) because it expects all fields listed in `Meta.fields` to be present in the schema.

In order to preserve existing API behavior, `include_fk` is set to False when generating nested schemas for relationship fields.
