### PR TITLE
feat(security): Support POST OAuth callback endpoint

### DIFF
--- a/flask_appbuilder/baseviews.py
+++ b/flask_appbuilder/baseviews.py
@@ -119,6 +119,11 @@ class BaseView(AbstractViewApi):
     route_base = None
     """ Override this if you want to define your own relative url """
 
+    csrf_exempt = False
+    """
+    If using flask-wtf CSRFProtect exempt the View from check
+    """
+
     template_folder = "templates"
     """ The template folder relative location """
     static_folder = "static"
@@ -299,6 +304,13 @@ class BaseView(AbstractViewApi):
                 static_folder=static_folder,
             )
         self._register_urls()
+
+        # Exempt from CSRF if the view opts in
+        if getattr(self, "csrf_exempt", False):
+            csrf = current_app.extensions.get("csrf")
+            if csrf:
+                csrf.exempt(self.blueprint)
+
         return self.blueprint
 
     def _register_urls(self):

--- a/flask_appbuilder/security/views.py
+++ b/flask_appbuilder/security/views.py
@@ -660,6 +660,8 @@ class AuthLDAPView(AuthView):
 
 
 class AuthOAuthView(AuthView):
+    # csrf_exempt is needed for the POST /oauth-authorized/<provider> endpoint
+    csrf_exempt = True
     login_template = "appbuilder/general/security/login_oauth.html"
 
     @expose("/login/")
@@ -706,7 +708,8 @@ class AuthOAuthView(AuthView):
             flash(as_unicode(self.invalid_login_message), "warning")
             return redirect(self.appbuilder.get_url_for_index)
 
-    @expose("/oauth-authorized/<provider>")
+    # Microsoft Entra ID supports response_mode=fom_post which uses a POST callback.
+    @expose("/oauth-authorized/<provider>", methods=("GET", "POST"))
     def oauth_authorized(self, provider: str) -> WerkzeugResponse:
         log.debug("Authorized init")
         if provider not in self.appbuilder.sm.oauth_remotes:
@@ -752,8 +755,12 @@ class AuthOAuthView(AuthView):
             return redirect(self.appbuilder.get_url_for_login)
         else:
             try:
+                if request.method == "GET":
+                    state_from_request = request.args["state"]
+                else:
+                    state_from_request = request.form["state"]
                 state = jwt.decode(
-                    request.args["state"], session["oauth_state"], algorithms=["HS256"]
+                    state_from_request, session["oauth_state"], algorithms=["HS256"]
                 )
             except (jwt.InvalidTokenError, KeyError):
                 flash(as_unicode("Invalid state signature"), "warning")

--- a/tests/config_oauth.py
+++ b/tests/config_oauth.py
@@ -26,7 +26,24 @@ OAUTH_PROVIDERS = [
             "access_token_url": "https://accounts.google.com/o/oauth2/token",
             "authorize_url": "https://accounts.google.com/o/oauth2/auth",
         },
-    }
+    },
+    {  # For Azure response_mode=form_post POST callback endpoint test
+        "name": "azure",
+        "icon": "fa-windows",
+        "token_key": "access_token",
+        "remote_app": {
+            "client_id": "CLIENT_ID",
+            "client_secret": "CLIENT_SECRET",
+            "api_base_url": "https://login.microsoftonline.com/D/oauth2/v2.0",
+            "client_kwargs": {
+                "scope": "email profile",
+                "response_mode": "form_post",
+            },
+            "request_token_url": None,
+            "access_token_url": "https://login.microsoftonline.com/D/oauth2/v2.0/token",
+            "authorize_url": "https://login.microsoftonline.com/D/oauth2/v2.0/authorize",
+        },
+    },
 ]
 
 # Will allow user self registration

--- a/tests/test_mvc_oauth.py
+++ b/tests/test_mvc_oauth.py
@@ -69,6 +69,29 @@ class MVCOAuthTestCase(FABTestCase):
             self.assertEqual(current_user.email, "user1@fab.org")
             self.assertEqual(response.location, "/")
 
+    def test_oauth_login_azure_post_response(self):
+        """
+        OAuth: Test login with Microsoft Entra ID with response_mode=form_post and the
+        callback from Microsoft is via a POST request.
+        """
+        self.appbuilder.sm.oauth_remotes = {"azure": OAuthRemoteMock()}
+
+        raw_state = {}
+        state = jwt.encode(raw_state, "random_state", algorithm="HS256")
+
+        @self.appbuilder.sm.oauth_user_info_getter
+        def user_info_getter(sm, provider, response):
+            return {"email": "user1@fab.org"}
+
+        with self.app.test_client() as client:
+            with client.session_transaction() as session_:
+                session_["oauth_state"] = "random_state"
+            # With response_mode=form_post, state is sent in the POST body
+            response = client.post("/oauth-authorized/azure", data={"state": state})
+            self.assertLess(response.status_code, 400)
+            self.assertEqual(current_user.email, "user1@fab.org")
+            self.assertEqual(response.location, "/")
+
     def test_oauth_login_invalid_state(self):
         """
         OAuth: Test login invalid state


### PR DESCRIPTION
### Description

This PR adds an HTTP `POST` method for the `/oauth-authorized/<provider>` callback endpoint.

Microsoft Azure supports `response_mode=fom_post` which uses a HTTP POST callback. This is more secure than GET with the state code in the URL itself.

See https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#request-an-authorization-code

**NOTE:** When the POST endpoint is used with Flask-WTF for CSRF protection, this OAuth2 callback endpoint must be exempted from CSRF or the Flask session cookie will not be available, and the callback endpoint won't be able to find the corresponding session to complete the authentication flow.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Is CRUD MVC related.
- [x] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [x] Introduces new feature
- [ ] Removes existing feature
