### PR TITLE
fix(ci): update MSSQL Docker image to 2022-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
         mssql+pyodbc://sa:Password_123@localhost:11433/master?driver=FreeTDS
     services:
       mssql:
-        image: mcr.microsoft.com/mssql/server:2019-CU31-ubuntu-20.04
+        image: mcr.microsoft.com/mssql/server:2022-latest
         env:
           SA_PASSWORD: Password_123
           ACCEPT_EULA: Y


### PR DESCRIPTION
## Summary
- Update MSSQL Docker image from `2019-CU31-ubuntu-20.04` to `2022-latest`
- The 2019 image was removed from Microsoft's container registry, causing `test-mssql` CI jobs to fail

## Test plan
- [ ] Verify `test-mssql` CI job passes with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)