### PR TITLE
fix: enforce API login provider validation when AUTH_TYPE has no API provider

### DIFF
--- a/flask_appbuilder/security/schemas.py
+++ b/flask_appbuilder/security/schemas.py
@@ -22,7 +22,7 @@ def validate_password(value: Union[bytes, bytearray, str]) -> None:
 def validate_provider(value: Union[bytes, bytearray, str]) -> None:
     if not current_app.appbuilder.sm.api_login_allow_multiple_providers:
         provider_name = current_app.appbuilder.sm.auth_type_provider_name
-        if provider_name and provider_name != value:
+        if provider_name is None or provider_name != value:
             raise ValidationError("Alternative authentication provider is not allowed")
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -30,6 +30,8 @@ from flask_appbuilder.const import (
     API_SHOW_COLUMNS_RIS_KEY,
     API_SHOW_TITLE_RIS_KEY,
     API_URI_RIS_KEY,
+    AUTH_OAUTH,
+    AUTH_REMOTE_USER,
 )
 from flask_appbuilder.hooks import before_request
 from flask_appbuilder.models.sqla.filters import FilterGreater, FilterSmaller
@@ -647,6 +649,75 @@ class APITestCase(FABTestCase):
                 }
             },
         )
+
+    def test_auth_login_provider_db_rejected_when_oauth(self):
+        """
+        REST Api: Test that provider=db is rejected when AUTH_TYPE=AUTH_OAUTH
+        and AUTH_API_LOGIN_ALLOW_MULTIPLE_PROVIDERS=False
+        """
+        self.app.config["AUTH_TYPE"] = AUTH_OAUTH
+        self.app.config["AUTH_API_LOGIN_ALLOW_MULTIPLE_PROVIDERS"] = False
+        try:
+            client = self.app.test_client()
+            rv = client.post(
+                "api/v1/security/login",
+                json={
+                    "username": USERNAME_ADMIN,
+                    "password": PASSWORD_ADMIN,
+                    "provider": "db",
+                },
+            )
+            self.assertEqual(rv.status_code, 400)
+            response = json.loads(rv.data.decode("utf-8"))
+            self.assertIn("provider", response["message"])
+        finally:
+            self.app.config["AUTH_TYPE"] = 1  # AUTH_DB
+
+    def test_auth_login_provider_db_rejected_when_remote_user(self):
+        """
+        REST Api: Test that provider=db is rejected when AUTH_TYPE=AUTH_REMOTE_USER
+        and AUTH_API_LOGIN_ALLOW_MULTIPLE_PROVIDERS=False
+        """
+        self.app.config["AUTH_TYPE"] = AUTH_REMOTE_USER
+        self.app.config["AUTH_API_LOGIN_ALLOW_MULTIPLE_PROVIDERS"] = False
+        try:
+            client = self.app.test_client()
+            rv = client.post(
+                "api/v1/security/login",
+                json={
+                    "username": USERNAME_ADMIN,
+                    "password": PASSWORD_ADMIN,
+                    "provider": "db",
+                },
+            )
+            self.assertEqual(rv.status_code, 400)
+            response = json.loads(rv.data.decode("utf-8"))
+            self.assertIn("provider", response["message"])
+        finally:
+            self.app.config["AUTH_TYPE"] = 1  # AUTH_DB
+
+    def test_auth_login_provider_db_allowed_when_oauth_multiple_providers(self):
+        """
+        REST Api: Test that provider=db is allowed when AUTH_TYPE=AUTH_OAUTH
+        but AUTH_API_LOGIN_ALLOW_MULTIPLE_PROVIDERS=True
+        """
+        self.app.config["AUTH_TYPE"] = AUTH_OAUTH
+        self.app.config["AUTH_API_LOGIN_ALLOW_MULTIPLE_PROVIDERS"] = True
+        try:
+            client = self.app.test_client()
+            rv = client.post(
+                "api/v1/security/login",
+                json={
+                    "username": USERNAME_ADMIN,
+                    "password": PASSWORD_ADMIN,
+                    "provider": "db",
+                },
+            )
+            # Should succeed authentication (not blocked by provider validation)
+            self.assertEqual(rv.status_code, 200)
+        finally:
+            self.app.config["AUTH_TYPE"] = 1  # AUTH_DB
+            self.app.config["AUTH_API_LOGIN_ALLOW_MULTIPLE_PROVIDERS"] = False
 
     def test_auth_login_bad(self):
         """


### PR DESCRIPTION
## Summary
- Fix `validate_provider` to reject API login requests when the configured `AUTH_TYPE` does not map to an API login provider (e.g. OAuth, SAML, Remote User) and `AUTH_API_LOGIN_ALLOW_MULTIPLE_PROVIDERS` is `False`
- Previously, the validation was skipped when `auth_type_provider_name` returned `None`, now it correctly rejects the request
- Added tests covering the new behavior for OAuth, Remote User, and the `AUTH_API_LOGIN_ALLOW_MULTIPLE_PROVIDERS=True` escape hatch

## Test plan
- [x] Existing `test_auth_login` tests pass (no regression for AUTH_DB)
- [x] `test_auth_login_invalid_provider` still works correctly
- [x] New test: `provider=db` rejected when `AUTH_TYPE=AUTH_OAUTH`
- [x] New test: `provider=db` rejected when `AUTH_TYPE=AUTH_REMOTE_USER`
- [x] New test: `provider=db` allowed when `AUTH_API_LOGIN_ALLOW_MULTIPLE_PROVIDERS=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)