### PR TITLE
fix: Allow case-insensitive emails in find_user

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -23,7 +23,7 @@ Use config.py to configure the following parameters. By default it will use SQLL
     - Description: Set to True to enable user self-registration
     - Mandatory: No
 - AUTH_USERNAME_CI
-    - Description: Make auth login CI of not defaults to true
+    - Description: Make auth login username or email case-insensitive. If not provided defaults to true
     - Mandatory: No
 - AUTH_USER_REGISTRATION_ROLE
     - Description: Set role name, to be assigned when a user registers himself. This role must already exist. Mandatory when using user registration

--- a/flask_appbuilder/security/sqla/manager.py
+++ b/flask_appbuilder/security/sqla/manager.py
@@ -368,7 +368,7 @@ class SecurityManager(BaseSecurityManager):
                 else:
                     return (
                         self.session.query(self.user_model)
-                        .filter(self.user_model.username == username)
+                        .filter_by(username=username)
                         .one_or_none()
                     )
             except MultipleResultsFound:
@@ -376,11 +376,20 @@ class SecurityManager(BaseSecurityManager):
                 return None
         elif email:
             try:
-                return (
-                    self.session.query(self.user_model)
-                    .filter_by(email=email)
-                    .one_or_none()
-                )
+                if self.auth_username_ci:
+                    return (
+                        self.session.query(self.user_model)
+                        .filter(
+                            func.lower(self.user_model.email) == func.lower(email)
+                        )
+                        .one_or_none()
+                    )
+                else:
+                    return (
+                        self.session.query(self.user_model)
+                        .filter_by(email=email)
+                        .one_or_none()
+                    )
             except MultipleResultsFound:
                 log.error("Multiple results found for user with email %s", email)
                 return None

--- a/flask_appbuilder/security/sqla/manager.py
+++ b/flask_appbuilder/security/sqla/manager.py
@@ -379,9 +379,7 @@ class SecurityManager(BaseSecurityManager):
                 if self.auth_username_ci:
                     return (
                         self.session.query(self.user_model)
-                        .filter(
-                            func.lower(self.user_model.email) == func.lower(email)
-                        )
+                        .filter(func.lower(self.user_model.email) == func.lower(email))
                         .one_or_none()
                     )
                 else:


### PR DESCRIPTION
<!--- Thank you for contributing to Flask-Appbuilder. -->
<!--- This repo uses a PR lint bot (https://github.com/apps/prlint), make sure to prefix your PR title with one of: -->
<!--- build|chore|ci|docs|feat|fix|perf|refactor|style|test|other -->

### Description
Causes `find_user` to respect the auth_username_ci setting when searching by email. These queries are now more closely aligned. I was on the fence about creating a new setting, but this is the only place this setting is used, so it doesn't seem like a problem to re-use.

Also improves the description of this setting.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: https://github.com/dpgaspar/Flask-AppBuilder/issues/2463
- [ ] Is CRUD MVC related.
- [x] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
