### PR TITLE
chore: Increase upper bound for Flask-Limiter dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.10", "3.13"]
     env:
       SQLALCHEMY_DATABASE_URI:
         postgresql+psycopg2://pguser:pguserpassword@127.0.0.1:15432/app
@@ -141,7 +141,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.10", "3.13"]
     env:
       SQLALCHEMY_DATABASE_URI: |
         mysql+mysqldb://mysqluser:mysqluserpassword@127.0.0.1:13306/app?charset=utf8mb4&binary_prefix=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.14"]
     env:
       SQLALCHEMY_DATABASE_URI:
         postgresql+psycopg2://pguser:pguserpassword@127.0.0.1:15432/app
@@ -141,7 +141,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.14"]
     env:
       SQLALCHEMY_DATABASE_URI: |
         mysql+mysqldb://mysqluser:mysqluserpassword@127.0.0.1:13306/app?charset=utf8mb4&binary_prefix=true

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -39,7 +39,7 @@ flask-babel==4.0.0
     # via flask-appbuilder
 flask-jwt-extended==4.5.3
     # via flask-appbuilder
-flask-limiter==4.2.2
+flask-limiter==4.1.1
     # via flask-appbuilder
 flask-login==0.6.3
     # via flask-appbuilder

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -63,7 +63,7 @@ jsonschema==4.19.1
     # via flask-appbuilder
 jsonschema-specifications==2023.7.1
     # via jsonschema
-limits==3.6.0
+limits==5.8.0
     # via flask-limiter
 markdown-it-py==3.0.0
     # via rich

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -39,7 +39,7 @@ flask-babel==4.0.0
     # via flask-appbuilder
 flask-jwt-extended==4.5.3
     # via flask-appbuilder
-flask-limiter==3.7.0
+flask-limiter==4.2.2
     # via flask-appbuilder
 flask-login==0.6.3
     # via flask-appbuilder

--- a/requirements/base_legacy.txt
+++ b/requirements/base_legacy.txt
@@ -65,7 +65,7 @@ jsonschema==4.19.1
     # via flask-appbuilder
 jsonschema-specifications==2023.7.1
     # via jsonschema
-limits==3.6.0
+limits==5.8.0
     # via flask-limiter
 markdown-it-py==3.0.0
     # via rich

--- a/requirements/base_legacy.txt
+++ b/requirements/base_legacy.txt
@@ -39,7 +39,7 @@ flask-babel==3.1.0
     # via flask-appbuilder
 flask-jwt-extended==4.5.3
     # via flask-appbuilder
-flask-limiter==3.7.0
+flask-limiter==4.1.1
     # via flask-appbuilder
 flask-login==0.6.3
     # via flask-appbuilder

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -73,7 +73,7 @@ flask-jwt-extended==4.5.3
     # via
     #   -r requirements/base.txt
     #   flask-appbuilder
-flask-limiter==3.7.0
+flask-limiter==4.1.1
     # via
     #   -r requirements/base.txt
     #   flask-appbuilder

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -125,7 +125,7 @@ jsonschema-specifications==2023.7.1
     # via
     #   -r requirements/base.txt
     #   jsonschema
-limits==3.6.0
+limits==5.8.0
     # via
     #   -r requirements/base.txt
     #   flask-limiter

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "email_validator>=1.0.5",
         "Flask>=2, <4",
         "Flask-Babel>=3, <5",
-        "Flask-Limiter>3,<4",
+        "Flask-Limiter>3,<5",
         "Flask-Login>=0.3, <0.7",
         "Flask-SQLAlchemy>=2.4.0, <4",
         "Flask-WTF>=0.14.2, <2",


### PR DESCRIPTION
### Description

This PR increases the upper bound of the Flask-Limiter dependency. This allows using Flask-AppBuilder with newer version of said package, and newer versions of its dependencies. This PR came about because I indirectly needed a newer version of `rich`.

I had to bump the minimum required version of Python to 3.10 for this PR to pass. 3.9 is EOL anyway so I assume it's ok.

Fixes https://github.com/dpgaspar/Flask-AppBuilder/issues/2397

### ADDITIONAL INFORMATION
- [x] Has associated issue.
- [ ] Is CRUD MVC related.
- [ ] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature
- [ ] Removes existing feature
