### PR TITLE
fix: Warn when Azure OAuth JWT signature verification is disabled

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -324,8 +324,8 @@ Specify a list of OAUTH_PROVIDERS in **config.py** that you want to allow for yo
                 "client_kwargs": {
                     "scope": "User.read name preferred_username email profile upn",
                     "resource": "AZURE_APPLICATION_ID",
-                    # Optionally enforce signature JWT verification
-                    "verify_signature": False
+                    # Recommended: verify Azure JWT signature
+                    "verify_signature": True
                 },
                 "request_token_url": None,
                 "access_token_url": "https://login.microsoftonline.com/AZURE_TENANT_ID/oauth2/token",

--- a/flask_appbuilder/security/manager.py
+++ b/flask_appbuilder/security/manager.py
@@ -781,6 +781,12 @@ class BaseSecurityManager(AbstractSecurityManager):
             claims.validate()
             return claims
 
+        log.warning(
+            "Azure OAuth JWT signature verification is disabled. "
+            "Set 'verify_signature': True in your Azure OAuth provider's "
+            "client_kwargs to enable it. A future major release will change "
+            "the default to True."
+        )
         return jwt.decode(id_token, options={"verify_signature": False})
 
     def _get_authentik_jwks(self, jwks_url) -> dict:

--- a/tests/security/test_auth_oauth.py
+++ b/tests/security/test_auth_oauth.py
@@ -608,6 +608,33 @@ class OAuthRegistrationRoleTestCase(unittest.TestCase):
                 },
             )
 
+    def test_oauth_user_info_azure_no_verify_signature_warning(self):
+        with self.app.app_context():
+            SQLA = get_sqla_class()
+            db = SQLA(self.app)
+            self.appbuilder = AppBuilder(self.app, db.session)
+            claims = {
+                "aud": "test-aud",
+                "iss": "https://sts.windows.net/test/",
+                "iat": 7282182129,
+                "nbf": 7282182129,
+                "exp": 1000000000,
+                "email": "test@gmail.com",
+                "family_name": "user",
+                "given_name": "test",
+                "oid": "b1a54a40-8dfa-4a6d-a2b8-f90b84d4b1df",
+            }
+            unsigned_jwt = jwt.encode(claims, key=None, algorithm="none")
+            with self.assertLogs(
+                "flask_appbuilder.security.manager", level="WARNING"
+            ) as cm:
+                self.appbuilder.sm.get_oauth_user_info(
+                    "azure", {"access_token": "", "id_token": unsigned_jwt}
+                )
+            self.assertTrue(
+                any("signature verification is disabled" in msg for msg in cm.output)
+            )
+
     def test_oauth_user_info_azure_with_jwt_validation(self):
         self.app.config["OAUTH_PROVIDERS"] = [
             {


### PR DESCRIPTION
## Summary
- Log a warning when `verify_signature` is not enabled for Azure OAuth JWT validation
- Update docs to recommend `verify_signature: True` instead of `False`
- Add test for the warning log message

## Test plan
- [ ] New test `test_oauth_user_info_azure_no_verify_signature_warning` passes
- [ ] Existing Azure OAuth tests still pass
- [ ] No behavioral change — only adds a log warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)