### PR TITLE
fix: anchor OAuth email whitelist regex to end of string

### DIFF
--- a/flask_appbuilder/security/views.py
+++ b/flask_appbuilder/security/views.py
@@ -737,7 +737,9 @@ class AuthOAuthView(AuthView):
                 whitelist = self.appbuilder.sm.oauth_whitelists[provider]
                 allow = False
                 for email in whitelist:
-                    if "email" in userinfo and re.search(email, userinfo["email"]):
+                    if "email" in userinfo and re.search(
+                        email + "$", userinfo["email"]
+                    ):
                         allow = True
                         break
                 if not allow:

--- a/tests/test_mvc_oauth.py
+++ b/tests/test_mvc_oauth.py
@@ -129,6 +129,57 @@ class MVCOAuthTestCase(FABTestCase):
         response = client.get(f"/oauth-authorized/google?state={state}")
         self.assertEqual(response.location, "/")
 
+    def test_oauth_whitelist_match(self):
+        """
+        OAuth: Test that email whitelist allows matching emails
+        """
+        self.appbuilder.sm.oauth_remotes = {"google": OAuthRemoteMock()}
+        self.appbuilder.sm.oauth_whitelists = {"google": ["@fab\\.org"]}
+
+        raw_state = {}
+        state = jwt.encode(raw_state, "random_state", algorithm="HS256")
+
+        with self.app.test_client() as client:
+            with client.session_transaction() as session_:
+                session_["oauth_state"] = "random_state"
+            client.get(f"/oauth-authorized/google?state={state}")
+            # user1@fab.org should match @fab\.org
+            self.assertEqual(current_user.email, "user1@fab.org")
+
+    def test_oauth_whitelist_rejects_domain_suffix(self):
+        """
+        OAuth: Test that email whitelist rejects emails where the
+        whitelisted domain is only a prefix of the actual domain
+        """
+
+        class EvilEmailUserInfoMock:
+            def json(self):
+                return {
+                    "id": "2",
+                    "given_name": "evil",
+                    "family_name": "user",
+                    "email": "user@fab.org.evil.com",
+                }
+
+        class EvilOAuthRemoteMock(OAuthRemoteMock):
+            def get(self, item):
+                if item == "userinfo":
+                    return EvilEmailUserInfoMock()
+
+        self.appbuilder.sm.oauth_remotes = {"google": EvilOAuthRemoteMock()}
+        self.appbuilder.sm.oauth_whitelists = {"google": ["@fab\\.org"]}
+
+        raw_state = {}
+        state = jwt.encode(raw_state, "random_state", algorithm="HS256")
+
+        with self.app.test_client() as client:
+            with client.session_transaction() as session_:
+                session_["oauth_state"] = "random_state"
+            response = client.get(f"/oauth-authorized/google?state={state}")
+            # user@fab.org.evil.com should NOT match @fab\.org
+            self.assertFalse(current_user.is_authenticated)
+            self.assertEqual(response.location, "/login/")
+
     def test_oauth_next_login_param(self):
         """
         OAuth: Test next quoted next_url param


### PR DESCRIPTION
## Summary
- Add a `$` end-of-string anchor to OAuth email whitelist regex patterns
- Existing whitelist patterns like `@company.com` continue to work as before
- Prevents domain suffix matches (e.g. `@company.com.evil.com` no longer matches `@company.com`)

## Test plan
- [ ] New test `test_oauth_whitelist_match` — verifies `@fab\.org` matches `user1@fab.org`
- [ ] New test `test_oauth_whitelist_rejects_domain_suffix` — verifies `@fab\.org` does NOT match `user@fab.org.evil.com`
- [ ] Existing OAuth tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)