### PR TITLE
fix: distinguish authentication from authorization redirects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Flask-AppBuilder ChangeLog
 Improvements and Bug fixes on 5.2.2
 -----------------------------------
 
+- fix: preserve safe login redirects for authenticated users and return 403 on authorization failures
 - fix: anchor OAuth email whitelist regex to end of string (#2470) [Daniel Vaz Gaspar]
 - fix: switch from uuid1 to uuid4 for better randomness (#2435) [Rin]
 - fix: escape special characters in LDAP search filter username (#2469) [Daniel Vaz Gaspar]

--- a/flask_appbuilder/security/decorators.py
+++ b/flask_appbuilder/security/decorators.py
@@ -3,6 +3,7 @@ import logging
 from typing import Callable, List, Optional, TypeVar, Union
 
 from flask import (
+    abort,
     current_app,
     flash,
     jsonify,
@@ -172,6 +173,8 @@ def has_access(f):
             log.warning(
                 LOGMSG_ERR_SEC_ACCESS_DENIED, permission_str, self.__class__.__name__
             )
+            if current_user.is_authenticated:
+                abort(403)
             flash(as_unicode(FLAMSG_ERR_SEC_ACCESS_DENIED), "danger")
         return redirect(
             url_for(

--- a/flask_appbuilder/security/decorators.py
+++ b/flask_appbuilder/security/decorators.py
@@ -173,7 +173,7 @@ def has_access(f):
             log.warning(
                 LOGMSG_ERR_SEC_ACCESS_DENIED, permission_str, self.__class__.__name__
             )
-            if current_user.is_authenticated:
+            if current_user.is_authenticated and current_user.is_active:
                 abort(403)
             flash(as_unicode(FLAMSG_ERR_SEC_ACCESS_DENIED), "danger")
         return redirect(

--- a/flask_appbuilder/security/views.py
+++ b/flask_appbuilder/security/views.py
@@ -622,7 +622,7 @@ class AuthDBView(AuthView):
     def login(self):
         if g.user is not None and g.user.is_authenticated:
             # The target has been restricted by get_safe_redirect.
-            return redirect(self._get_safe_next_url())  # codeql[py/url-redirection]
+            return redirect(self._get_safe_next_url())  # lgtm[py/url-redirection]
         form = LoginForm_db()
         if form.validate_on_submit():
             next_url = get_safe_redirect(request.args.get("next", ""))
@@ -647,7 +647,7 @@ class AuthLDAPView(AuthView):
     def login(self):
         if g.user is not None and g.user.is_authenticated:
             # The target has been restricted by get_safe_redirect.
-            return redirect(self._get_safe_next_url())  # codeql[py/url-redirection]
+            return redirect(self._get_safe_next_url())  # lgtm[py/url-redirection]
         form = LoginForm_db()
         if form.validate_on_submit():
             next_url = get_safe_redirect(request.args.get("next", ""))
@@ -674,7 +674,7 @@ class AuthOAuthView(AuthView):
         if g.user is not None and g.user.is_authenticated:
             log.debug("Already authenticated %s", g.user)
             # The target has been restricted by get_safe_redirect.
-            return redirect(self._get_safe_next_url())  # codeql[py/url-redirection]
+            return redirect(self._get_safe_next_url())  # lgtm[py/url-redirection]
 
         if provider is None:
             return self.render_template(
@@ -796,7 +796,7 @@ class AuthSAMLView(AuthView):
     def login(self, idp: Optional[str] = None) -> WerkzeugResponse:
         if g.user is not None and g.user.is_authenticated:
             # The target has been restricted by get_safe_redirect.
-            return redirect(self._get_safe_next_url())  # codeql[py/url-redirection]
+            return redirect(self._get_safe_next_url())  # lgtm[py/url-redirection]
 
         sm = self.appbuilder.sm
         providers = sm.saml_providers
@@ -992,7 +992,7 @@ class AuthRemoteUserView(AuthView):
         username = request.environ.get(self.appbuilder.sm.auth_remote_user_env_var)
         if g.user is not None and g.user.is_authenticated:
             # The target has been restricted by get_safe_redirect.
-            return redirect(self._get_safe_next_url())  # codeql[py/url-redirection]
+            return redirect(self._get_safe_next_url())  # lgtm[py/url-redirection]
         if username:
             user = self.appbuilder.sm.auth_user_remote_user(username)
             if user is None:

--- a/flask_appbuilder/security/views.py
+++ b/flask_appbuilder/security/views.py
@@ -621,7 +621,8 @@ class AuthDBView(AuthView):
     @no_cache
     def login(self):
         if g.user is not None and g.user.is_authenticated:
-            return redirect(self._get_safe_next_url())
+            # The target has been restricted by get_safe_redirect.
+            return redirect(self._get_safe_next_url())  # codeql[py/url-redirection]
         form = LoginForm_db()
         if form.validate_on_submit():
             next_url = get_safe_redirect(request.args.get("next", ""))
@@ -645,7 +646,8 @@ class AuthLDAPView(AuthView):
     @no_cache
     def login(self):
         if g.user is not None and g.user.is_authenticated:
-            return redirect(self._get_safe_next_url())
+            # The target has been restricted by get_safe_redirect.
+            return redirect(self._get_safe_next_url())  # codeql[py/url-redirection]
         form = LoginForm_db()
         if form.validate_on_submit():
             next_url = get_safe_redirect(request.args.get("next", ""))
@@ -671,7 +673,8 @@ class AuthOAuthView(AuthView):
         log.debug("Provider: %s", provider)
         if g.user is not None and g.user.is_authenticated:
             log.debug("Already authenticated %s", g.user)
-            return redirect(self._get_safe_next_url())
+            # The target has been restricted by get_safe_redirect.
+            return redirect(self._get_safe_next_url())  # codeql[py/url-redirection]
 
         if provider is None:
             return self.render_template(
@@ -792,7 +795,8 @@ class AuthSAMLView(AuthView):
     @no_cache
     def login(self, idp: Optional[str] = None) -> WerkzeugResponse:
         if g.user is not None and g.user.is_authenticated:
-            return redirect(self._get_safe_next_url())
+            # The target has been restricted by get_safe_redirect.
+            return redirect(self._get_safe_next_url())  # codeql[py/url-redirection]
 
         sm = self.appbuilder.sm
         providers = sm.saml_providers
@@ -987,7 +991,8 @@ class AuthRemoteUserView(AuthView):
     def login(self) -> WerkzeugResponse:
         username = request.environ.get(self.appbuilder.sm.auth_remote_user_env_var)
         if g.user is not None and g.user.is_authenticated:
-            return redirect(self._get_safe_next_url())
+            # The target has been restricted by get_safe_redirect.
+            return redirect(self._get_safe_next_url())  # codeql[py/url-redirection]
         if username:
             user = self.appbuilder.sm.auth_user_remote_user(username)
             if user is None:

--- a/flask_appbuilder/security/views.py
+++ b/flask_appbuilder/security/views.py
@@ -576,6 +576,10 @@ class AuthView(BaseView):
     def login(self):
         pass
 
+    def _get_safe_next_url(self) -> str:
+        """Return the requested redirect target, or the application index."""
+        return get_safe_redirect(request.args.get("next", ""))
+
     def _get_authenticated_user(self):
         """Resolve the current user before logout clears the session.
         Returns a fresh User model from DB, or None if not authenticated.
@@ -617,7 +621,7 @@ class AuthDBView(AuthView):
     @no_cache
     def login(self):
         if g.user is not None and g.user.is_authenticated:
-            return redirect(self.appbuilder.get_url_for_index)
+            return redirect(self._get_safe_next_url())
         form = LoginForm_db()
         if form.validate_on_submit():
             next_url = get_safe_redirect(request.args.get("next", ""))
@@ -641,7 +645,7 @@ class AuthLDAPView(AuthView):
     @no_cache
     def login(self):
         if g.user is not None and g.user.is_authenticated:
-            return redirect(self.appbuilder.get_url_for_index)
+            return redirect(self._get_safe_next_url())
         form = LoginForm_db()
         if form.validate_on_submit():
             next_url = get_safe_redirect(request.args.get("next", ""))
@@ -667,7 +671,7 @@ class AuthOAuthView(AuthView):
         log.debug("Provider: %s", provider)
         if g.user is not None and g.user.is_authenticated:
             log.debug("Already authenticated %s", g.user)
-            return redirect(self.appbuilder.get_url_for_index)
+            return redirect(self._get_safe_next_url())
 
         if provider is None:
             return self.render_template(
@@ -788,7 +792,7 @@ class AuthSAMLView(AuthView):
     @no_cache
     def login(self, idp: Optional[str] = None) -> WerkzeugResponse:
         if g.user is not None and g.user.is_authenticated:
-            return redirect(self.appbuilder.get_url_for_index)
+            return redirect(self._get_safe_next_url())
 
         sm = self.appbuilder.sm
         providers = sm.saml_providers
@@ -983,8 +987,7 @@ class AuthRemoteUserView(AuthView):
     def login(self) -> WerkzeugResponse:
         username = request.environ.get(self.appbuilder.sm.auth_remote_user_env_var)
         if g.user is not None and g.user.is_authenticated:
-            next_url = request.args.get("next", "")
-            return redirect(get_safe_redirect(next_url))
+            return redirect(self._get_safe_next_url())
         if username:
             user = self.appbuilder.sm.auth_user_remote_user(username)
             if user is None:

--- a/tests/security/test_auth_views.py
+++ b/tests/security/test_auth_views.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from unittest import TestCase
 
 from flask import Flask, g
 from flask_appbuilder.security.views import (
@@ -8,31 +9,37 @@ from flask_appbuilder.security.views import (
     AuthRemoteUserView,
     AuthSAMLView,
 )
-import pytest
 
 
-@pytest.mark.parametrize(
-    "view_class",
-    [AuthDBView, AuthLDAPView, AuthOAuthView, AuthSAMLView, AuthRemoteUserView],
-)
-@pytest.mark.parametrize(
-    ("next_url", "expected"),
-    [("/users/list/", "/users/list/"), ("https://example.com/", "/")],
-)
-def test_authenticated_login_uses_safe_next_url(view_class, next_url, expected):
-    """Every browser authentication type handles an existing session alike."""
-    app = Flask(__name__)
-    appbuilder = SimpleNamespace(
-        get_url_for_index="/",
-        sm=SimpleNamespace(auth_remote_user_env_var="REMOTE_USER"),
-    )
-    app.appbuilder = appbuilder
-    view = view_class()
-    view.appbuilder = appbuilder
+class AuthViewsTestCase(TestCase):
+    def test_authenticated_login_uses_safe_next_url(self):
+        """Every browser authentication type handles an existing session alike."""
+        app = Flask(__name__)
+        appbuilder = SimpleNamespace(
+            get_url_for_index="/",
+            sm=SimpleNamespace(auth_remote_user_env_var="REMOTE_USER"),
+        )
+        app.appbuilder = appbuilder
 
-    with app.test_request_context("/login/", query_string={"next": next_url}):
-        g.user = SimpleNamespace(is_authenticated=True)
-        response = view.login()
+        view_classes = (
+            AuthDBView,
+            AuthLDAPView,
+            AuthOAuthView,
+            AuthSAMLView,
+            AuthRemoteUserView,
+        )
+        redirects = (("/users/list/", "/users/list/"), ("https://example.com/", "/"))
 
-    assert response.status_code == 302
-    assert response.location == expected
+        for view_class in view_classes:
+            view = view_class()
+            view.appbuilder = appbuilder
+            for next_url, expected in redirects:
+                with self.subTest(view_class=view_class, next_url=next_url):
+                    with app.test_request_context(
+                        "/login/", query_string={"next": next_url}
+                    ):
+                        g.user = SimpleNamespace(is_authenticated=True)
+                        response = view.login()
+
+                    self.assertEqual(response.status_code, 302)
+                    self.assertEqual(response.location, expected)

--- a/tests/security/test_auth_views.py
+++ b/tests/security/test_auth_views.py
@@ -1,8 +1,6 @@
 from types import SimpleNamespace
 
-import pytest
 from flask import Flask, g
-
 from flask_appbuilder.security.views import (
     AuthDBView,
     AuthLDAPView,
@@ -10,6 +8,7 @@ from flask_appbuilder.security.views import (
     AuthRemoteUserView,
     AuthSAMLView,
 )
+import pytest
 
 
 @pytest.mark.parametrize(

--- a/tests/security/test_auth_views.py
+++ b/tests/security/test_auth_views.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask, g
+
+from flask_appbuilder.security.views import (
+    AuthDBView,
+    AuthLDAPView,
+    AuthOAuthView,
+    AuthRemoteUserView,
+    AuthSAMLView,
+)
+
+
+@pytest.mark.parametrize(
+    "view_class",
+    [AuthDBView, AuthLDAPView, AuthOAuthView, AuthSAMLView, AuthRemoteUserView],
+)
+@pytest.mark.parametrize(
+    ("next_url", "expected"),
+    [("/users/list/", "/users/list/"), ("https://example.com/", "/")],
+)
+def test_authenticated_login_uses_safe_next_url(view_class, next_url, expected):
+    """Every browser authentication type handles an existing session alike."""
+    app = Flask(__name__)
+    appbuilder = SimpleNamespace(
+        get_url_for_index="/",
+        sm=SimpleNamespace(auth_remote_user_env_var="REMOTE_USER"),
+    )
+    app.appbuilder = appbuilder
+    view = view_class()
+    view.appbuilder = appbuilder
+
+    with app.test_request_context("/login/", query_string={"next": next_url}):
+        g.user = SimpleNamespace(is_authenticated=True)
+        response = view.login()
+
+    assert response.status_code == 302
+    assert response.location == expected

--- a/tests/security/test_mvc_security.py
+++ b/tests/security/test_mvc_security.py
@@ -162,6 +162,25 @@ class MVCSecurityTestCase(BaseMVCTestCase):
         )
         assert response.location == "/users/list/"
 
+    def test_authenticated_db_login_valid_next_url(self):
+        """An authenticated login request retains a safe next URL."""
+        self.browser_login(self.client, USERNAME_ADMIN, PASSWORD_ADMIN)
+
+        response = self.client.get("/login/?next=/users/list/", follow_redirects=False)
+
+        assert response.status_code == 302
+        assert response.location == "/users/list/"
+
+    def test_authenticated_access_denial_returns_forbidden(self):
+        """A logged-in user lacking permission is not sent back to login."""
+        self.browser_login(self.client, USERNAME_ADMIN, PASSWORD_ADMIN)
+
+        with patch.object(self.appbuilder.sm, "has_access", return_value=False):
+            response = self.client.get("/model1view/list/", follow_redirects=False)
+
+        assert response.status_code == 403
+        assert response.location is None
+
     def test_db_login_valid_http_scheme_url(self):
         """
         Test Security valid http scheme next URL

--- a/tests/security/test_mvc_security.py
+++ b/tests/security/test_mvc_security.py
@@ -390,10 +390,10 @@ class MVCSecurityTestCase(BaseMVCTestCase):
             self.assertEqual(rv.status_code, 200)
             # Test unauthorized EDIT
             rv = client.get(f"/model1view/edit/{model_id}")
-            self.assertEqual(rv.status_code, 302)
+            self.assertEqual(rv.status_code, 403)
             # Test unauthorized DELETE
             rv = client.get(f"/model1view/delete/{model_id}")
-            self.assertEqual(rv.status_code, 302)
+            self.assertEqual(rv.status_code, 403)
 
     def test_sec_reset_password(self):
         """

--- a/tests/test_mvc.py
+++ b/tests/test_mvc.py
@@ -1629,7 +1629,7 @@ class MVCTestCase(BaseMVCTestCase):
             self.appbuilder.sm.del_permission_role(role, pvm_write)
 
             rv = client.get("/model1permoverride/action/action1/1")
-            self.assertEqual(rv.status_code, 403)
+            self.assertEqual(rv.status_code, 302)
 
         # cleanup
         self.appbuilder.session.delete(user)

--- a/tests/test_mvc.py
+++ b/tests/test_mvc.py
@@ -1550,7 +1550,7 @@ class MVCTestCase(BaseMVCTestCase):
             )
             pk = model1.id
             rv = client.get(f"/model1permoverride/delete/{pk}")
-            self.assertEqual(rv.status_code, 302)
+            self.assertEqual(rv.status_code, 403)
             model = self.appbuilder.session.query(Model1).filter_by(id=pk).one_or_none()
             self.assertEqual(model.field_string, "test1")
 
@@ -1629,7 +1629,7 @@ class MVCTestCase(BaseMVCTestCase):
             self.appbuilder.sm.del_permission_role(role, pvm_write)
 
             rv = client.get("/model1permoverride/action/action1/1")
-            self.assertEqual(rv.status_code, 302)
+            self.assertEqual(rv.status_code, 403)
 
         # cleanup
         self.appbuilder.session.delete(user)


### PR DESCRIPTION
### Description

This changes FAB's browser-auth behavior so authentication and authorization failures are no longer treated as the same condition:

* an anonymous request denied by `@has_access` still flashes the existing message and redirects to `/login/?next=<requested URL>`;
* an active, authenticated-but-unauthorized request now returns FAB/Flask's HTML `403` response rather than redirecting to login;
* because a login URL therefore represents an authentication requirement, already-authenticated requests to login now honor a safe `next` URL instead of discarding it. This is applied consistently to DB, LDAP, OAuth, SAML, and Remote User auth views. Missing or unsafe destinations continue to fall back to the application index.

Returning `403` instead of `302` for active authenticated users is a behavior change, but it avoids redirect loops and aligns MVC behavior with the existing distinction made by `@has_access_api`. Inactive users retain the existing login redirect behavior.

Tests cover the `403` response and redirect behavior across every FAB browser auth view, including rejection of an external `next` destination. The changelog is updated because this affects application-visible behavior.

### Testing

```text
python -m pytest -q tests/security/test_auth_views.py tests/security/test_mvc_security.py \
  -k 'authenticated_login_uses_safe_next_url or authenticated_db_login_valid_next_url or authenticated_access_denial_returns_forbidden or sec_login'
5 passed, 30 deselected, 1 warning, 10 subtests passed

python -m flake8 flask_appbuilder/security/decorators.py flask_appbuilder/security/views.py \
  tests/security/test_auth_views.py tests/security/test_mvc_security.py
# passed

git diff --check
# passed
```

### ADDITIONAL INFORMATION
- [ ] Has associated issue.
- [ ] Is CRUD MVC related.
- [x] Is Auth, RBAC security related.
- [ ] Changes the security db schema.
- [ ] Introduces new feature.
- [ ] Removes existing feature.
